### PR TITLE
IOS-1571 Don't use top padding

### DIFF
--- a/Tangem/MultiWallet/TokenList/TokenListView.swift
+++ b/Tangem/MultiWallet/TokenList/TokenListView.swift
@@ -115,7 +115,7 @@ struct TokenListView: View {
                                                    layout: .flexibleWidth,
                                                    isDisabled: viewModel.isSaveDisabled,
                                                    isLoading: viewModel.isSaving))
-                    .padding([.horizontal, .top], 16)
+                    .padding(.horizontal, 16)
                     .padding(.bottom, 8)
                     .background(LinearGradient(colors: [.white, .white, .white.opacity(0)],
                                                startPoint: .bottom,


### PR DESCRIPTION
Почему-то на iOS14 экран manage tokens анимировался при показе во второй и последующие разы, причем только если на экране есть кнопка "Save Changes". На iOS 13/15 проблемы нет. Фикс проверял на устройстве с iOS 15 и на симуляторе iOS 13.3 / 14.4.

Если отдельно добавить `.padding(.top, 16)`, то проблема не исчезнет. Также можно починить добавив `.animation(nil)`.