### PR TITLE
IOS-1607 Replaced emoji with a unicode symbol

### DIFF
--- a/Tangem/Common/Localizations/de.lproj/Localizable.strings
+++ b/Tangem/Common/Localizations/de.lproj/Localizable.strings
@@ -409,7 +409,7 @@ URL: %@";
 "warning_button_really_cool" = "Really cool!";
 "warning_failed_to_verify_card_message" = "This card might be a production sample or counterfeit";
 "warning_failed_to_verify_card_title" = "Authenticity check failed";
-"warning_important_security_info" = "Important security information ⚠️";
+"warning_important_security_info" = "Important security information \U26A0";
 "warning_low_signatures_format" = "There are only %@ signatures available on this card. You must withdraw all of your funds.";
 "warning_rate_app_message" = "How do you like Tangem?";
 "warning_rate_app_title" = "One question";

--- a/Tangem/Common/Localizations/en.lproj/Localizable.strings
+++ b/Tangem/Common/Localizations/en.lproj/Localizable.strings
@@ -409,7 +409,7 @@ URL: %@";
 "warning_button_really_cool" = "Really cool!";
 "warning_failed_to_verify_card_message" = "This card might be a production sample or counterfeit";
 "warning_failed_to_verify_card_title" = "Authenticity check failed";
-"warning_important_security_info" = "Important security information ⚠️";
+"warning_important_security_info" = "Important security information \U26A0";
 "warning_low_signatures_format" = "There are only %@ signatures available on this card. You must withdraw all of your funds.";
 "warning_rate_app_message" = "How do you like Tangem?";
 "warning_rate_app_title" = "One question";

--- a/Tangem/Common/Localizations/fr.lproj/Localizable.strings
+++ b/Tangem/Common/Localizations/fr.lproj/Localizable.strings
@@ -409,7 +409,7 @@ URL: %@";
 "warning_button_really_cool" = "Really cool!";
 "warning_failed_to_verify_card_message" = "This card might be a production sample or counterfeit";
 "warning_failed_to_verify_card_title" = "Authenticity check failed";
-"warning_important_security_info" = "Important security information ⚠️";
+"warning_important_security_info" = "Important security information \U26A0";
 "warning_low_signatures_format" = "There are only %@ signatures available on this card. You must withdraw all of your funds.";
 "warning_rate_app_message" = "How do you like Tangem?";
 "warning_rate_app_title" = "One question";

--- a/Tangem/Common/Localizations/it.lproj/Localizable.strings
+++ b/Tangem/Common/Localizations/it.lproj/Localizable.strings
@@ -409,7 +409,7 @@ URL: %@";
 "warning_button_really_cool" = "Really cool!";
 "warning_failed_to_verify_card_message" = "This card might be a production sample or counterfeit";
 "warning_failed_to_verify_card_title" = "Authenticity check failed";
-"warning_important_security_info" = "Important security information ⚠️";
+"warning_important_security_info" = "Important security information \U26A0";
 "warning_low_signatures_format" = "There are only %@ signatures available on this card. You must withdraw all of your funds.";
 "warning_rate_app_message" = "How do you like Tangem?";
 "warning_rate_app_title" = "One question";

--- a/Tangem/Common/Localizations/ru.lproj/Localizable.strings
+++ b/Tangem/Common/Localizations/ru.lproj/Localizable.strings
@@ -409,7 +409,7 @@ URL: %@";
 "warning_button_really_cool" = "Очень круто!";
 "warning_failed_to_verify_card_message" = "Эта карта может быть производственным образцом или подделкой.";
 "warning_failed_to_verify_card_title" = "Проверка подлинности не удалась";
-"warning_important_security_info" = "Важная информация о безопасности ⚠️";
+"warning_important_security_info" = "Важная информация о безопасности \U26A0";
 "warning_low_signatures_format" = "На этой карте осталось только %@ подписей. Вы должны вывести все свои средства.";
 "warning_rate_app_message" = "Как вам Tangem?";
 "warning_rate_app_title" = "Один вопрос";


### PR DESCRIPTION
В андроиде нельзя использовать эмодзи в файлах локализации. У них показывается текстовым символом `\u26A0`, сделал аналогично 
![File](https://user-images.githubusercontent.com/12209839/166908377-902028c1-41a4-42a2-841c-00408a972eb0.jpg)
.