### PR TITLE
IOS-1893 Update Beta.xcconfig

### DIFF
--- a/Tangem/Configurations/Beta.xcconfig
+++ b/Tangem/Configurations/Beta.xcconfig
@@ -12,7 +12,7 @@
 ENVIRONMENT_NAME = Beta
 
 // Storage container name
-SUITE_NAME = $(PRODUCT_BUNDLE_IDENTIFIER)
+SUITE_NAME = group.$(PRODUCT_BUNDLE_IDENTIFIER)
 
 // Overriding (do NOT change key name)
 // app name


### PR DESCRIPTION
Каким то неведомым образом при использовании `UserDefaults.standard` при первом запуске там создается запись по ключам `NSLanguages` и `AppleLanguages` "предпочитаемые" языки из настроек телефона, и больше не меняются. И все последующие запуски, `Locale.current` берет локаль первый из этих языков. 

Если я создаю UserDefaults с другим suiteName, то все работает отлично.
Я не придумал ничего лучше, чем сделать так же как и в основном Tangem