### PR TITLE
IOS-1941 Remove async call

### DIFF
--- a/Tangem/Common/Storage/AppStorageCompat.swift
+++ b/Tangem/Common/Storage/AppStorageCompat.swift
@@ -67,9 +67,7 @@ final class Storage<Value>: NSObject, ObservableObject {
                                change: [NSKeyValueChangeKey: Any]?,
                                context: UnsafeMutableRawPointer?) {
 
-        DispatchQueue.main.async {
-            self.value = change?[.newKey].flatMap(self.transform) ?? self.defaultValue
-        }
+        self.value = change?[.newKey].flatMap(self.transform) ?? self.defaultValue
     }
 }
 


### PR DESCRIPTION
Убрал асинхронный диспатч, который я добавлял, чтобы пофиксить краш с одновременным чтением/записью.  Этот фикс сломал принятие дисклеймера. Краш почему-то больше не воспроизводится. Видимо у меня был какой-то глюк сборки, поэтому вернул все взад