### PR TITLE
IOS-1935 Refactor AppScanTask to use ScanTask from SDK

### DIFF
--- a/Tangem/App/ViewModels/CardViewModel.swift
+++ b/Tangem/App/ViewModels/CardViewModel.swift
@@ -363,20 +363,6 @@ class CardViewModel: Identifiable, ObservableObject {
     }
 
     // MARK: - Security
-
-    func checkPin(_ completion: @escaping (Result<CheckUserCodesResponse, Error>) -> Void) {
-        tangemSdk.startSession(with: CheckUserCodesCommand(), cardId: cardInfo.card.cardId) { [weak self] (result) in
-            switch result {
-            case .success(let resp):
-                self?.cardPinSettings = CardPinSettings(isPin1Default: !resp.isAccessCodeSet, isPin2Default: !resp.isPasscodeSet)
-                self?.updateCurrentSecurityOption()
-                completion(.success(resp))
-            case .failure(let error):
-                completion(.failure(error))
-            }
-        }
-    }
-
     func changeSecurityOption(_ option: SecurityModeOption, completion: @escaping (Result<Void, Error>) -> Void) {
         switch option {
         case .accessCode:

--- a/Tangem/Common/TangemSdk/Tasks/AppScanTask.swift
+++ b/Tangem/Common/TangemSdk/Tasks/AppScanTask.swift
@@ -128,7 +128,7 @@ final class AppScanTask: CardSessionRunnable {
 
         }
 
-        runAttestation(session, completion)
+        self.runScanTask(session, completion)
     }
 
     private func readNote(_ card: Card, session: CardSession, completion: @escaping CompletionResult<AppScanTaskResponse>) {
@@ -166,7 +166,7 @@ final class AppScanTask: CardSessionRunnable {
                 }
 
                 self.noteWalletData = walletData
-                self.runAttestation(session, completion)
+                self.runScanTask(session, completion)
             case .failure(let error):
                 switch error {
                 case .fileNotFound, .insNotSupported:
@@ -190,7 +190,7 @@ final class AppScanTask: CardSessionRunnable {
                     return
                 }
 
-                self.runAttestation(session, completion)
+                self.runScanTask(session, completion)
             case .failure(let error):
                 completion(.failure(error))
             }
@@ -218,7 +218,7 @@ final class AppScanTask: CardSessionRunnable {
         CreateMultiWalletTask(curves: curves).run(in: session) { result in
             switch result {
             case .success:
-                self.runAttestation(session, completion)
+                self.runScanTask(session, completion)
             case .failure(let error):
                 completion(.failure(error))
             }
@@ -240,11 +240,11 @@ final class AppScanTask: CardSessionRunnable {
 
     private func deriveKeysIfNeeded(_ session: CardSession, _ completion: @escaping CompletionResult<AppScanTaskResponse>) {
         #if CLIP
-        self.runAttestation(session, completion)
+        self.runScanTask(session, completion)
         return
         #else
         guard session.environment.card?.settings.isHDWalletAllowed == true else {
-            self.runAttestation(session, completion)
+            self.runScanTask(session, completion)
             return
         }
 
@@ -270,7 +270,7 @@ final class AppScanTask: CardSessionRunnable {
         }
 
         if derivations.isEmpty {
-            self.runAttestation(session, completion)
+            self.runScanTask(session, completion)
             return
         }
 
@@ -279,7 +279,7 @@ final class AppScanTask: CardSessionRunnable {
                 switch result {
                 case .success(let derivedKeys):
                     self.derivedKeys = derivedKeys
-                    self.runAttestation(session, completion)
+                    self.runScanTask(session, completion)
                 case .failure(let error):
                     completion(.failure(error))
                 }
@@ -287,9 +287,9 @@ final class AppScanTask: CardSessionRunnable {
         #endif
     }
 
-    private func runAttestation(_ session: CardSession, _ completion: @escaping CompletionResult<AppScanTaskResponse>) {
-        let attestationTask = AttestationTask(mode: session.environment.config.attestationMode)
-        attestationTask.run(in: session) { result in
+    private func runScanTask(_ session: CardSession, _ completion: @escaping CompletionResult<AppScanTaskResponse>) {
+        let scanTask = ScanTask()
+        scanTask.run(in: session) { result in
             switch result {
             case .success:
                 self.complete(session, completion)


### PR DESCRIPTION
Скантаск приложения теперь будет использовать скантаск сдк, в котором есть и аттестация и чекпин для старых карт. Теперь результат сканирования будет содержать всю необходимую информацию по пинам