### PR TITLE
IOS-1972 Crash selected currency

### DIFF
--- a/Tangem/App/Services/TangemApiService/CommonTangemApiService.swift
+++ b/Tangem/App/Services/TangemApiService/CommonTangemApiService.swift
@@ -78,10 +78,9 @@ extension CommonTangemApiService: TangemApiService {
             .eraseToAnyPublisher()
     }
 
-    func loadRates(for coinIds: [String]) -> AnyPublisher<[String: Decimal], Never> {
+    func loadRates(for coinIds: [String], currencyCode: String) -> AnyPublisher<[String: Decimal], Never> {
         provider
-            .requestPublisher(TangemApiTarget(type: .rates(coinIds: coinIds,
-                                                           currencyId: AppSettings.shared.selectedCurrencyCode),
+            .requestPublisher(TangemApiTarget(type: .rates(coinIds: coinIds, currencyId: currencyCode),
                                               authData: authData))
             .filterSuccessfulStatusAndRedirectCodes()
             .map(RatesResponse.self)

--- a/Tangem/App/Services/TangemApiService/TangemApiService.swift
+++ b/Tangem/App/Services/TangemApiService/TangemApiService.swift
@@ -13,7 +13,7 @@ protocol TangemApiService: AnyObject, Initializable {
     var geoIpRegionCode: String { get }
 
     func loadCoins(requestModel: CoinsListRequestModel) -> AnyPublisher<[CoinModel], Error>
-    func loadRates(for coinIds: [String]) -> AnyPublisher<[String: Decimal], Never>
+    func loadRates(for coinIds: [String], currencyCode code: String) -> AnyPublisher<[String: Decimal], Never>
     func loadCurrencies() -> AnyPublisher<[CurrenciesResponse.Currency], Error>
 
     func setAuthData(_ authData: TangemApiTarget.AuthData)


### PR DESCRIPTION
Крэш был из за того что пытались получить доступ в момент записи нового значения

Запись при обновлении `AppSettings.shared.selectedCurrencyCode`
И при срабатывания publisher `$AppSettings.shared.selectedCurrencyCode` тоже была попытка прочитать 
`AppSettings.shared.selectedCurrencyCode`

Crash:
>Simultaneous accesses to 0x10b974d10, but modification requires exclusive access