### PR TITLE
IOS-1981 Wrong list style on iOS 13/14

### DIFF
--- a/Tangem/Assets/Assets.xcassets/SocialNetwork/Facebook.imageset/Contents.json
+++ b/Tangem/Assets/Assets.xcassets/SocialNetwork/Facebook.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/Tangem/Assets/Assets.xcassets/SocialNetwork/GitHub.imageset/Contents.json
+++ b/Tangem/Assets/Assets.xcassets/SocialNetwork/GitHub.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/Tangem/Assets/Assets.xcassets/SocialNetwork/Instagram.imageset/Contents.json
+++ b/Tangem/Assets/Assets.xcassets/SocialNetwork/Instagram.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/Tangem/Assets/Assets.xcassets/SocialNetwork/LinkedIn.imageset/Contents.json
+++ b/Tangem/Assets/Assets.xcassets/SocialNetwork/LinkedIn.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/Tangem/Assets/Assets.xcassets/SocialNetwork/Tangem.imageset/Contents.json
+++ b/Tangem/Assets/Assets.xcassets/SocialNetwork/Tangem.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/Tangem/Assets/Assets.xcassets/SocialNetwork/Telegram.imageset/Contents.json
+++ b/Tangem/Assets/Assets.xcassets/SocialNetwork/Telegram.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/Tangem/Assets/Assets.xcassets/SocialNetwork/Twitter.imageset/Contents.json
+++ b/Tangem/Assets/Assets.xcassets/SocialNetwork/Twitter.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/Tangem/Assets/Assets.xcassets/SocialNetwork/YouTube.imageset/Contents.json
+++ b/Tangem/Assets/Assets.xcassets/SocialNetwork/YouTube.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/Tangem/Assets/Assets.xcassets/chevron.imageset/Contents.json
+++ b/Tangem/Assets/Assets.xcassets/chevron.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/Tangem/Assets/Assets.xcassets/circleChecked.imageset/Contents.json
+++ b/Tangem/Assets/Assets.xcassets/circleChecked.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/Tangem/Assets/Assets.xcassets/circleEmpty.imageset/Contents.json
+++ b/Tangem/Assets/Assets.xcassets/circleEmpty.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/Tangem/Assets/Assets.xcassets/walletConnect.imageset/Contents.json
+++ b/Tangem/Assets/Assets.xcassets/walletConnect.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
   }
 }

--- a/Tangem/Common/Extensions/List+.swift
+++ b/Tangem/Common/Extensions/List+.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 extension List {
-    @ViewBuilder func groupedListStyleCompact() -> some View {
+    @ViewBuilder func groupedListStyleCompatibility() -> some View {
         if #available(iOS 14.0, *) {
             self.listStyle(.insetGrouped)
         } else {

--- a/Tangem/Common/Extensions/List+.swift
+++ b/Tangem/Common/Extensions/List+.swift
@@ -1,0 +1,19 @@
+//
+//  List+.swift
+//  Tangem
+//
+//  Created by Sergey Balashov on 05.08.2022.
+//  Copyright © 2022 Tangem AG. All rights reserved.
+//
+
+import SwiftUI
+
+extension List {
+    @ViewBuilder func groupedListStyleCompact() -> some View {
+        if #available(iOS 14.0, *) {
+            self.listStyle(.insetGrouped)
+        } else {
+            self.listStyle(.grouped)
+        }
+    }
+}

--- a/Tangem/Modules/AppSettings/AppSettingsView.swift
+++ b/Tangem/Modules/AppSettings/AppSettingsView.swift
@@ -25,7 +25,7 @@ struct AppSettingsView: View {
 
             savingAccessCodesSection
         }
-        .listStyle(DefaultListStyle())
+        .groupedListStyleCompact()
         .alert(item: $viewModel.alert) { $0.alert }
         .background(Colors.Background.secondary.edgesIgnoringSafeArea(.all))
         .navigationBarTitle("app_settings_title", displayMode: .inline)

--- a/Tangem/Modules/AppSettings/AppSettingsView.swift
+++ b/Tangem/Modules/AppSettings/AppSettingsView.swift
@@ -25,7 +25,7 @@ struct AppSettingsView: View {
 
             savingAccessCodesSection
         }
-        .groupedListStyleCompact()
+        .groupedListStyleCompatibility()
         .alert(item: $viewModel.alert) { $0.alert }
         .background(Colors.Background.secondary.edgesIgnoringSafeArea(.all))
         .navigationBarTitle("app_settings_title", displayMode: .inline)

--- a/Tangem/Modules/CardSettings/CardSettingsView.swift
+++ b/Tangem/Modules/CardSettings/CardSettingsView.swift
@@ -27,7 +27,7 @@ struct CardSettingsView: View {
 
             resetToFactorySection
         }
-        .listStyle(DefaultListStyle())
+        .groupedListStyleCompact()
         .alert(item: $viewModel.alert) { $0.alert }
         .background(Colors.Background.secondary.edgesIgnoringSafeArea(.all))
         .navigationBarTitle("card_settings_title", displayMode: .inline)

--- a/Tangem/Modules/CardSettings/CardSettingsView.swift
+++ b/Tangem/Modules/CardSettings/CardSettingsView.swift
@@ -27,7 +27,7 @@ struct CardSettingsView: View {
 
             resetToFactorySection
         }
-        .groupedListStyleCompact()
+        .groupedListStyleCompatibility()
         .alert(item: $viewModel.alert) { $0.alert }
         .background(Colors.Background.secondary.edgesIgnoringSafeArea(.all))
         .navigationBarTitle("card_settings_title", displayMode: .inline)

--- a/Tangem/Modules/Details/DetailsView.swift
+++ b/Tangem/Modules/Details/DetailsView.swift
@@ -23,7 +23,7 @@ struct DetailsView: View {
 
             legalSection
         }
-        .groupedListStyleCompact()
+        .groupedListStyleCompatibility()
         .alert(item: $viewModel.error) { $0.alert }
         .background(Colors.Background.secondary.edgesIgnoringSafeArea(.all))
         .navigationBarTitle("details_title", displayMode: .inline)

--- a/Tangem/Modules/Details/DetailsView.swift
+++ b/Tangem/Modules/Details/DetailsView.swift
@@ -23,7 +23,7 @@ struct DetailsView: View {
 
             legalSection
         }
-        .listStyle(DefaultListStyle())
+        .groupedListStyleCompact()
         .alert(item: $viewModel.error) { $0.alert }
         .background(Colors.Background.secondary.edgesIgnoringSafeArea(.all))
         .navigationBarTitle("details_title", displayMode: .inline)

--- a/Tangem/SceneDelegate.swift
+++ b/Tangem/SceneDelegate.swift
@@ -22,7 +22,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         if let windowScene = scene as? UIWindowScene {
             let window = UIWindow(windowScene: windowScene)
             let appView = AppCoordinatorView(coordinator: appCoordinator)
-            window.rootViewController = UIHostingController(rootView: appView)
+            let cardViewModel = CardViewModel(cardInfo: CardInfo(card: .card, isTangemNote: false, isTangemWallet: true))
+            let details = DetailsView(viewModel: DetailsViewModel(cardModel: cardViewModel, coordinator: DetailsCoordinator(dismissAction: {
+
+            }, popToRootAction: { _ in
+
+            })))
+            window.rootViewController = UIHostingController(rootView: details)
             self.window = window
             window.makeKeyAndVisible()
         }

--- a/Tangem/SceneDelegate.swift
+++ b/Tangem/SceneDelegate.swift
@@ -22,13 +22,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         if let windowScene = scene as? UIWindowScene {
             let window = UIWindow(windowScene: windowScene)
             let appView = AppCoordinatorView(coordinator: appCoordinator)
-            let cardViewModel = CardViewModel(cardInfo: CardInfo(card: .card, isTangemNote: false, isTangemWallet: true))
-            let details = DetailsView(viewModel: DetailsViewModel(cardModel: cardViewModel, coordinator: DetailsCoordinator(dismissAction: {
-
-            }, popToRootAction: { _ in
-
-            })))
-            window.rootViewController = UIHostingController(rootView: details)
+            window.rootViewController = UIHostingController(rootView: appView)
             self.window = window
             window.makeKeyAndVisible()
         }

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -523,6 +523,7 @@
 		DCE5C67128899C42000C7F67 /* AppStorageCompat.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE5C66F2889964A000C7F67 /* AppStorageCompat.swift */; };
 		DCE7119F28784F6700969857 /* DisclaimerRoutable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE7119E28784F6700969857 /* DisclaimerRoutable.swift */; };
 		DCE7E02C287BF92400063EEC /* SwitchChainHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE7E02B287BF92400063EEC /* SwitchChainHandler.swift */; };
+		EF07F3AD289D43580065549C /* List+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF07F3AC289D43580065549C /* List+.swift */; };
 		EF08A0EF283D1914008BD923 /* Moya+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF08A0EE283D1914008BD923 /* Moya+.swift */; };
 		EF08A0F1283D2382008BD923 /* CoinsListRequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF08A0F0283D2382008BD923 /* CoinsListRequestModel.swift */; };
 		EF0F99AA289028F8008B01DF /* AppSettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0F99A5289028F8008B01DF /* AppSettingsCoordinator.swift */; };
@@ -1113,6 +1114,7 @@
 		DCE7E02B287BF92400063EEC /* SwitchChainHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchChainHandler.swift; sourceTree = "<group>"; };
 		DFEC35A94293DE7EB96CEBC1 /* Pods-Tangem.debug(production).xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tangem.debug(production).xcconfig"; path = "Target Support Files/Pods-Tangem/Pods-Tangem.debug(production).xcconfig"; sourceTree = "<group>"; };
 		E53081CA3060D2785F9D22F0 /* Pods-Tangem-TangemUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tangem-TangemUITests.release.xcconfig"; path = "Target Support Files/Pods-Tangem-TangemUITests/Pods-Tangem-TangemUITests.release.xcconfig"; sourceTree = "<group>"; };
+		EF07F3AC289D43580065549C /* List+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "List+.swift"; sourceTree = "<group>"; };
 		EF08A0EE283D1914008BD923 /* Moya+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Moya+.swift"; sourceTree = "<group>"; };
 		EF08A0F0283D2382008BD923 /* CoinsListRequestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinsListRequestModel.swift; sourceTree = "<group>"; };
 		EF0F99A5289028F8008B01DF /* AppSettingsCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppSettingsCoordinator.swift; sourceTree = "<group>"; };
@@ -1558,6 +1560,7 @@
 				5D49035127BE9D550072C642 /* Data+.swift */,
 				EFB997B2287DB948002F45F6 /* Font+.swift */,
 				EF50A5B0288976140081C5BB /* View+ConditionalModifiers.swift */,
+				EF07F3AC289D43580065549C /* List+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -3516,6 +3519,7 @@
 				DAE6F76D2800011400411F45 /* AppError.swift in Sources */,
 				6563B8BB2859EA82009A8A7D /* SupportChatService.swift in Sources */,
 				B068A7E725678A8800D28CD2 /* TwinCardsUtils.swift in Sources */,
+				EF07F3AD289D43580065549C /* List+.swift in Sources */,
 				DC66BC0A285B755800CDF765 /* PushTxRoutable.swift in Sources */,
 				EF0F99AC289028F8008B01DF /* AppSettingsViewModel.swift in Sources */,
 			);


### PR DESCRIPTION
по дефолту или ListStyle.automatic на
iOS 13 идет `.plain` с перекраской всех иконок в стандартный синий( 
iOS 14 идет `.plain` просто без разбития по группам.

Фикс рабочий, но вероятно стоит задуматься использовать `ScrollView { LazyVStack {} }` и все view рисовать полностью, не надеясь на дефолтую отрисовку iOS.