### PR TITLE
IOS-2025 Fix ios13 navbar issues

### DIFF
--- a/Tangem/Modules/Welcome/WelcomeCoordinator.swift
+++ b/Tangem/Modules/Welcome/WelcomeCoordinator.swift
@@ -29,22 +29,20 @@ class WelcomeCoordinator: CoordinatorObject {
 
     // MARK: - Helpers
     @Published var modalOnboardingCoordinatorKeeper: Bool = false
-    // Fix ios13 navbar glitches
-    @Published private(set) var navBarHidden: Bool = true
 
     // MARK: - Private
     private var welcomeLifecycleSubscription: AnyCancellable? = nil
 
     private var lifecyclePublisher: AnyPublisher<Bool, Never> {
-        let p1 = $mailViewModel.dropFirst().map { $0 == nil }
-        let p2 = $disclaimerViewModel.dropFirst().map { $0 == nil }
-        let p3 = $shopCoordinator.dropFirst().map { $0 == nil }
-        let p4 = $modalOnboardingCoordinator.dropFirst().map { $0 == nil }
-        let p5 = $tokenListCoordinator.dropFirst().map { $0 == nil }
-        let p6 = $mailViewModel.dropFirst().map { $0 == nil }
-        let p7 = $disclaimerViewModel.dropFirst().map { $0 == nil }
+        //Only modals, because the modal presentation will not trigger onAppear/onDissapear events
+        var publishers: [AnyPublisher<Bool, Never>] = []
+        publishers.append($mailViewModel.dropFirst().map { $0 == nil }.eraseToAnyPublisher())
+        publishers.append($shopCoordinator.dropFirst().map { $0 == nil }.eraseToAnyPublisher())
+        publishers.append($modalOnboardingCoordinator.dropFirst().map { $0 == nil }.eraseToAnyPublisher())
+        publishers.append($tokenListCoordinator.dropFirst().map { $0 == nil }.eraseToAnyPublisher())
+        publishers.append($disclaimerViewModel.dropFirst().map { $0 == nil }.eraseToAnyPublisher())
 
-        return p1.merge(with: p2, p3, p4, p5, p6, p7)
+        return Publishers.MergeMany(publishers)
             .eraseToAnyPublisher()
     }
 
@@ -98,7 +96,6 @@ extension WelcomeCoordinator: WelcomeRoutable {
         }
 
         let popToRootAction: ParamsAction<PopToRootOptions> = { [weak self] options in
-            self?.navBarHidden = true
             self?.pushedOnboardingCoordinator = nil
 
             if options.newScan {
@@ -113,9 +110,7 @@ extension WelcomeCoordinator: WelcomeRoutable {
     }
 
     func openMain(with cardModel: CardViewModel) {
-        navBarHidden = false
         let popToRootAction: ParamsAction<PopToRootOptions> = { [weak self] options in
-            self?.navBarHidden = true
             self?.mainCoordinator = nil
 
             if options.newScan {

--- a/Tangem/Modules/Welcome/WelcomeCoordinatorView.swift
+++ b/Tangem/Modules/Welcome/WelcomeCoordinatorView.swift
@@ -22,8 +22,6 @@ struct WelcomeCoordinatorView: CoordinatorView {
 
                 sheets
             }
-            .navigationBarTitle("") // fix ios13 navbar glitches. We should change navbar's state before transition
-            .navigationBarHidden(coordinator.navBarHidden)
         }
         .navigationViewStyle(.stack)
     }

--- a/Tangem/Modules/Welcome/WelcomeView.swift
+++ b/Tangem/Modules/Welcome/WelcomeView.swift
@@ -21,6 +21,8 @@ struct WelcomeView: View {
                     searchTokens: viewModel.openTokensList
                 )
             }
+            .navigationBarHidden(true)
+            .navigationBarTitle("")
             .statusBar(hidden: true)
             .environment(\.colorScheme, viewModel.storiesModel.currentPage.colorScheme)
             .actionSheet(item: $viewModel.discardAlert, content: { $0.sheet })


### PR DESCRIPTION
С рефакторингом навигации больше не нужны костыли с навбаром на иос 13. Можно управлять им из конкретных вьюх. главное не забывать проставлять еще и пустой navigationTitle, иначе не скроется на iOS13.