### PR TITLE
IOS-2198 Append default blockchain if needed

### DIFF
--- a/Tangem/App/ViewModels/CardViewModel.swift
+++ b/Tangem/App/ViewModels/CardViewModel.swift
@@ -213,6 +213,7 @@ class CardViewModel: Identifiable, ObservableObject {
         updateCardPinSettings()
         updateCurrentSecurityOption()
         bind()
+        appendDefaultBlockchainIfNeeded()
     }
 
     func setupWarnings() {
@@ -519,6 +520,13 @@ class CardViewModel: Identifiable, ObservableObject {
             userTokenListManager: userTokenListManager,
             walletListManager: walletListManager
         )
+    }
+
+    private func appendDefaultBlockchainIfNeeded() {
+        // For single wallet only
+        guard !isMultiWallet, walletModels.isEmpty else { return }
+
+        appendDefaultBlockchains()
     }
 }
 


### PR DESCRIPTION
Баг интересный, по факту не должен у пользователей повториться. 
При мердже синхронизации токенов, был баг, что для одновалюток удалялось все из локального хранилища

Добавил проверку на всякий случай