### PR TITLE
IOS-2295 Skip hashes counting without alert

### DIFF
--- a/Tangem/Modules/Main/MainViewModel.swift
+++ b/Tangem/Modules/Main/MainViewModel.swift
@@ -348,9 +348,15 @@ class MainViewModel: ObservableObject {
             didFinishCountingHashes()
             return
         }
+        
+        guard !cardModel.isMultiWallet else {
+            showAlertAnimated(.multiWalletSignedHashes)
+            didFinishCountingHashes()
+            return
+        }
 
         guard cardModel.canCountHashes else {
-            showAlertAnimated(.multiWalletSignedHashes)
+            AppSettings.shared.validatedSignedHashesCards.append(cardModel.cardId)
             didFinishCountingHashes()
             return
         }


### PR DESCRIPTION
Все же пришлось разделить логику мультивалюток от всех остальных. Для карт типа солтпея никаких алертов быть не должно