### PR TITLE
IOS-2313: Currency filtering crash

### DIFF
--- a/Tangem/Modules/Details/CurrencySelect/CurrencySelectView.swift
+++ b/Tangem/Modules/Details/CurrencySelect/CurrencySelectView.swift
@@ -47,6 +47,7 @@ struct CurrencySelectView: View {
                                         presentationMode.wrappedValue.dismiss()
                                     }
                                 }
+                                .id(currency.id)
                             }
                     }
 


### PR DESCRIPTION
Crash occurred on iOS 14.6 when removing text from search bar on currency selector
 - Add id for each row in currency selector screen