### PR TITLE
IOS-2339 Fix interrupted onboarded wallet flow

### DIFF
--- a/Tangem/App/Models/UserWallet/Implementations/GenericConfig.swift
+++ b/Tangem/App/Models/UserWallet/Implementations/GenericConfig.swift
@@ -16,6 +16,10 @@ struct GenericConfig {
     private let card: Card
 
     private var _backupSteps: [WalletOnboardingStep] {
+        if card.backupStatus?.isActive == true {
+            return []
+        }
+
         if !card.settings.isBackupAllowed {
             return []
         }

--- a/Tangem/App/Models/UserWallet/Implementations/GenericDemoConfig.swift
+++ b/Tangem/App/Models/UserWallet/Implementations/GenericDemoConfig.swift
@@ -16,6 +16,10 @@ struct GenericDemoConfig {
     private let card: Card
 
     private var _backupSteps: [WalletOnboardingStep] {
+        if card.backupStatus?.isActive == true {
+            return []
+        }
+        
         if !card.settings.isBackupAllowed {
             return []
         }


### PR DESCRIPTION
После прерванного бэкапа на этапе добавления бэкапных карт и последующем отказе от возобновления, скан карты теперь снова ведет на главный экран.