### PR TITLE
IOS-2392: Reset twin swipe to story

### DIFF
--- a/Tangem/Common/Extensions/List+.swift
+++ b/Tangem/Common/Extensions/List+.swift
@@ -16,6 +16,7 @@ extension List {
                 .scrollContentBackground(.hidden)
         } else if #available(iOS 14.0, *) {
             self.listStyle(.insetGrouped)
+                .background(background)
         } else {
             self.listStyle(.grouped)
         }

--- a/Tangem/Modules/CardSettings/CardSettingsCoordinator.swift
+++ b/Tangem/Modules/CardSettings/CardSettingsCoordinator.swift
@@ -52,13 +52,17 @@ extension CardSettingsCoordinator {
 
 extension CardSettingsCoordinator: CardSettingsRoutable {
     func openOnboarding(with input: OnboardingInput) {
-        let dismissAction: Action = { [weak self] in
+        let popToRootAction: ParamsAction<PopToRootOptions> = { [weak self] options in
             self?.modalOnboardingCoordinator = nil
             self?.resetCardDidFinish()
         }
+        
+        let dismissAction: Action = { [weak self] in
+            self?.modalOnboardingCoordinator = nil
+        }
 
-        let coordinator = OnboardingCoordinator(dismissAction: dismissAction)
-        let options = OnboardingCoordinator.Options(input: input, shouldOpenMainOnFinish: false)
+        let coordinator = OnboardingCoordinator(dismissAction: dismissAction, popToRootAction: popToRootAction)
+        let options = OnboardingCoordinator.Options(input: input, destination: .root)
         coordinator.start(with: options)
         modalOnboardingCoordinator = coordinator
     }

--- a/Tangem/Modules/Details/DetailsCoordinator.swift
+++ b/Tangem/Modules/Details/DetailsCoordinator.swift
@@ -67,7 +67,7 @@ extension DetailsCoordinator: DetailsRoutable {
         }
 
         let coordinator = OnboardingCoordinator(dismissAction: dismissAction)
-        let options = OnboardingCoordinator.Options(input: input, shouldOpenMainOnFinish: false)
+        let options = OnboardingCoordinator.Options(input: input, destination: .dismiss)
         coordinator.start(with: options)
         modalOnboardingCoordinator = coordinator
     }

--- a/Tangem/Modules/Main/MainCoordinator.swift
+++ b/Tangem/Modules/Main/MainCoordinator.swift
@@ -69,7 +69,7 @@ extension MainCoordinator: MainRoutable {
         }
 
         let coordinator = OnboardingCoordinator(dismissAction: dismissAction)
-        let options = OnboardingCoordinator.Options(input: input, shouldOpenMainOnFinish: false)
+        let options = OnboardingCoordinator.Options(input: input, destination: .dismiss)
         coordinator.start(with: options)
         modalOnboardingCoordinator = coordinator
     }

--- a/Tangem/Modules/Onboarding/OnboardingCoordinator.swift
+++ b/Tangem/Modules/Onboarding/OnboardingCoordinator.swift
@@ -57,9 +57,12 @@ class OnboardingCoordinator: CoordinatorObject {
 }
 
 extension OnboardingCoordinator {
+    enum DestinationOnFinish {
+        case main, root, dismiss
+    }
     struct Options {
         let input: OnboardingInput
-        let shouldOpenMainOnFinish: Bool
+        let destination: DestinationOnFinish
     }
 }
 
@@ -96,10 +99,17 @@ extension OnboardingCoordinator: WalletOnboardingRoutable {
 
 extension OnboardingCoordinator: OnboardingRoutable {
     func onboardingDidFinish() {
-        if let card = options.input.cardInput.cardModel,
-           options.shouldOpenMainOnFinish {
+        switch options.destination {
+        case .main:
+            guard let card = options.input.cardInput.cardModel else {
+                closeOnboarding()
+                return
+            }
+            
             openMain(with: card)
-        } else {
+        case .root:
+            popToRoot()
+        case .dismiss:
             closeOnboarding()
         }
     }

--- a/Tangem/Modules/Onboarding/Twins/TwinsOnboardingViewModel.swift
+++ b/Tangem/Modules/Onboarding/Twins/TwinsOnboardingViewModel.swift
@@ -245,16 +245,14 @@ class TwinsOnboardingViewModel: OnboardingTopupViewModel<TwinsOnboardingStep, On
             alert = AlertBuilder.makeOkGotItAlert(message: "onboarding_twin_exit_warning".localized)
         default:
             alert = AlertBuilder.makeExitAlert() { [weak self] in
-                self?.back()
+                guard let self else { return }
+                
+                if self.currentStep.isOnboardingFinished {
+                    self.onboardingDidFinish()
+                } else {
+                    self.closeOnboarding()
+                }
             }
-        }
-    }
-
-    private func back() {
-        if isFromMain {
-            onboardingDidFinish()
-        } else {
-            closeOnboarding()
         }
     }
 

--- a/Tangem/Modules/Onboarding/Twins/TwinsOnboardingViewModel.swift
+++ b/Tangem/Modules/Onboarding/Twins/TwinsOnboardingViewModel.swift
@@ -247,6 +247,9 @@ class TwinsOnboardingViewModel: OnboardingTopupViewModel<TwinsOnboardingStep, On
             alert = AlertBuilder.makeExitAlert() { [weak self] in
                 guard let self else { return }
                 
+                // This part is related only to the twin cards, because for other card types
+                // reset to factory settings goes not through onboarding screens. If back button
+                // appearance logic will change in future - recheck also this code and update it accordingly
                 if self.currentStep.isOnboardingFinished {
                     self.onboardingDidFinish()
                 } else {

--- a/Tangem/Modules/Welcome/WelcomeCoordinator.swift
+++ b/Tangem/Modules/Welcome/WelcomeCoordinator.swift
@@ -85,7 +85,7 @@ extension WelcomeCoordinator: WelcomeRoutable {
         }
 
         let coordinator = OnboardingCoordinator(dismissAction: dismissAction)
-        let options = OnboardingCoordinator.Options(input: input, shouldOpenMainOnFinish: false)
+        let options = OnboardingCoordinator.Options(input: input, destination: .dismiss)
         coordinator.start(with: options)
         modalOnboardingCoordinator = coordinator
     }
@@ -104,7 +104,7 @@ extension WelcomeCoordinator: WelcomeRoutable {
         }
 
         let coordinator = OnboardingCoordinator(dismissAction: dismissAction, popToRootAction: popToRootAction)
-        let options = OnboardingCoordinator.Options(input: input, shouldOpenMainOnFinish: true)
+        let options = OnboardingCoordinator.Options(input: input, destination: .main)
         coordinator.start(with: options)
         pushedOnboardingCoordinator = coordinator
     }


### PR DESCRIPTION
Обновил немного навигацию онбординга, чтобы можно было указывать куда именно после успешного завершения онбординга должен направиться пользователь
Изменил логику для твинов, что только при успешном завершении онбординга, будет прогоняться через `onboardingDidFinish`
поправил маленький UI бажок в настройках