### PR TITLE
IOS-1992: Add alert if user scanned wrong card

### DIFF
--- a/Tangem/Common/Localizations/de.lproj/Localizable.strings
+++ b/Tangem/Common/Localizations/de.lproj/Localizable.strings
@@ -404,6 +404,9 @@ URL: %@";
 "main_processing_full_amount" = "The amount does not include some of your funds";
 "main_tokens" = "Tokens";
 
+// MARK: Errors
+"error_wrong_wallet_tapped" = "You have used a card from another wallet. Tap the card associated with this wallet";
+
 // MARK: Token details
 
 "token_details_hide_alert_title" = "Hide %@";

--- a/Tangem/Common/Localizations/en.lproj/Localizable.strings
+++ b/Tangem/Common/Localizations/en.lproj/Localizable.strings
@@ -404,6 +404,9 @@ URL: %@";
 "main_processing_full_amount" = "The amount does not include some of your funds";
 "main_tokens" = "Tokens";
 
+// MARK: Errors
+"error_wrong_wallet_tapped" = "You have used a card from another wallet. Tap the card associated with this wallet";
+
 // MARK: Token details
 
 "token_details_hide_alert_title" = "Hide %@";

--- a/Tangem/Common/Localizations/fr.lproj/Localizable.strings
+++ b/Tangem/Common/Localizations/fr.lproj/Localizable.strings
@@ -404,6 +404,9 @@ URL: %@";
 "main_processing_full_amount" = "The amount does not include some of your funds";
 "main_tokens" = "Tokens";
 
+// MARK: Errors
+"error_wrong_wallet_tapped" = "You have used a card from another wallet. Tap the card associated with this wallet";
+
 // MARK: Token details
 
 "token_details_hide_alert_title" = "Hide %@";

--- a/Tangem/Common/Localizations/it.lproj/Localizable.strings
+++ b/Tangem/Common/Localizations/it.lproj/Localizable.strings
@@ -404,6 +404,9 @@ URL: %@";
 "main_processing_full_amount" = "The amount does not include some of your funds";
 "main_tokens" = "Tokens";
 
+// MARK: Errors
+"error_wrong_wallet_tapped" = "You have used a card from another wallet. Tap the card associated with this wallet";
+
 // MARK: Token details
 
 "token_details_hide_alert_title" = "Hide %@";

--- a/Tangem/Common/Localizations/ru.lproj/Localizable.strings
+++ b/Tangem/Common/Localizations/ru.lproj/Localizable.strings
@@ -404,6 +404,9 @@ URL: %@";
 "main_processing_full_amount" = "В сумме учтены не все монеты";
 "main_tokens" = "Токены";
 
+// MARK: Errors
+"error_wrong_wallet_tapped" = "Вы использовали карту от другого кошелька. Приложите карту, связанную с этим кошельком.";
+
 // MARK: Token details
 
 "token_details_hide_alert_title" = "Cкрыть %@";

--- a/Tangem/Common/UI/AlertBinder.swift
+++ b/Tangem/Common/UI/AlertBinder.swift
@@ -61,6 +61,12 @@ enum AlertBuilder {
                            dismissButton: .default(Text("warning_button_ok"), action: okAction)))
     }
 
+    static func makeOkErrorAlert(message: String, okAction: @escaping (() -> Void) = { }) -> AlertBinder {
+        .init(alert: Alert(title: Text("common_error"),
+                           message: Text(message),
+                           dismissButton: .default(Text("warning_button_ok"), action: okAction)))
+    }
+
     static func makeDemoAlert(_ message: String, okAction: @escaping (() -> Void) = {}) -> AlertBinder {
         .init(alert: Alert(title: Text("common_warning"),
                            message: Text(message),

--- a/Tangem/Common/UI/AppError.swift
+++ b/Tangem/Common/UI/AppError.swift
@@ -10,11 +10,14 @@ import Foundation
 
 enum AppError: Error, LocalizedError {
     case serverUnavailable
+    case wrongCardWasTapped
 
     var errorDescription: String? {
         switch self {
         case .serverUnavailable:
             return "common_server_unavailable".localized
+        case .wrongCardWasTapped:
+            return "error_wrong_wallet_tapped".localized
         }
     }
 }

--- a/Tangem/Modules/Details/DetailsCoordinator.swift
+++ b/Tangem/Modules/Details/DetailsCoordinator.swift
@@ -88,8 +88,8 @@ extension DetailsCoordinator: DetailsRoutable {
         disclaimerViewModel = .init(url: url, style: .navbar, coordinator: nil)
     }
 
-    func openScanCardSettings() {
-        scanCardSettingsViewModel = ScanCardSettingsViewModel(coordinator: self)
+    func openScanCardSettings(with userWalletId: Data) {
+        scanCardSettingsViewModel = ScanCardSettingsViewModel(cardOnMainWalletId: userWalletId, coordinator: self)
     }
 
     func openAppSettings() {

--- a/Tangem/Modules/Details/DetailsCoordinator.swift
+++ b/Tangem/Modules/Details/DetailsCoordinator.swift
@@ -89,7 +89,7 @@ extension DetailsCoordinator: DetailsRoutable {
     }
 
     func openScanCardSettings(with userWalletId: Data) {
-        scanCardSettingsViewModel = ScanCardSettingsViewModel(cardOnMainWalletId: userWalletId, coordinator: self)
+        scanCardSettingsViewModel = ScanCardSettingsViewModel(expectedUserWalletId: userWalletId, coordinator: self)
     }
 
     func openAppSettings() {

--- a/Tangem/Modules/Details/DetailsRoutable.swift
+++ b/Tangem/Modules/Details/DetailsRoutable.swift
@@ -14,7 +14,7 @@ protocol DetailsRoutable: AnyObject {
     func openWalletConnect(with cardModel: CardViewModel)
     func openCurrencySelection()
     func openDisclaimer(at url: URL)
-    func openScanCardSettings()
+    func openScanCardSettings(with userWalletId: Data)
     func openAppSettings()
     func openSupportChat(cardId: String, dataCollector: EmailDataCollector)
     func openInSafari(url: URL)

--- a/Tangem/Modules/Details/DetailsViewModel.swift
+++ b/Tangem/Modules/Details/DetailsViewModel.swift
@@ -117,8 +117,14 @@ extension DetailsViewModel {
     }
 
     func openCardSettings() {
+        guard let userWalletId = cardModel.userWalletId else {
+            // This shouldn't be the case, because currently user can't reach this screen
+            // with card that doesn't have a wallet.
+            return
+        }
+
         Analytics.log(.buttonCardSettings)
-        coordinator.openScanCardSettings()
+        coordinator.openScanCardSettings(with: userWalletId)
     }
 
     func openAppSettings() {

--- a/Tangem/Modules/ScanCardSettings/ScanCardSettingsView.swift
+++ b/Tangem/Modules/ScanCardSettings/ScanCardSettingsView.swift
@@ -49,7 +49,7 @@ struct ScanCardSettingsView: View {
 }
 
 struct ScanCardSettingsView_Preview: PreviewProvider {
-    static let viewModel = ScanCardSettingsViewModel(cardOnMainWalletId: Data(), coordinator: DetailsCoordinator())
+    static let viewModel = ScanCardSettingsViewModel(expectedUserWalletId: Data(), coordinator: DetailsCoordinator())
 
     static var previews: some View {
         ScanCardSettingsView(viewModel: viewModel)

--- a/Tangem/Modules/ScanCardSettings/ScanCardSettingsView.swift
+++ b/Tangem/Modules/ScanCardSettings/ScanCardSettingsView.swift
@@ -49,7 +49,7 @@ struct ScanCardSettingsView: View {
 }
 
 struct ScanCardSettingsView_Preview: PreviewProvider {
-    static let viewModel = ScanCardSettingsViewModel(coordinator: DetailsCoordinator())
+    static let viewModel = ScanCardSettingsViewModel(cardOnMainWalletId: Data(), coordinator: DetailsCoordinator())
 
     static var previews: some View {
         ScanCardSettingsView(viewModel: viewModel)

--- a/Tangem/Modules/ScanCardSettings/ScanCardSettingsViewModel.swift
+++ b/Tangem/Modules/ScanCardSettings/ScanCardSettingsViewModel.swift
@@ -17,11 +17,11 @@ final class ScanCardSettingsViewModel: ObservableObject, Identifiable {
     @Published var isLoading: Bool = false
     @Published var alert: AlertBinder?
 
-    private let cardOnMainWalletId: Data
+    private let expectedUserWalletId: Data
     private unowned let coordinator: ScanCardSettingsRoutable
 
-    init(cardOnMainWalletId: Data, coordinator: ScanCardSettingsRoutable) {
-        self.cardOnMainWalletId = cardOnMainWalletId
+    init(expectedUserWalletId: Data, coordinator: ScanCardSettingsRoutable) {
+        self.expectedUserWalletId = expectedUserWalletId
         self.coordinator = coordinator
     }
 }
@@ -46,7 +46,7 @@ extension ScanCardSettingsViewModel {
         let cardModel = CardViewModel(cardInfo: cardInfo)
         guard
             let userWalletId = cardModel.userWalletId,
-            userWalletId == cardOnMainWalletId
+            userWalletId == expectedUserWalletId
         else {
             showErrorAlert(error: AppError.wrongCardWasTapped)
             return

--- a/Tangem/Modules/ScanCardSettings/ScanCardSettingsViewModel.swift
+++ b/Tangem/Modules/ScanCardSettings/ScanCardSettingsViewModel.swift
@@ -17,9 +17,11 @@ final class ScanCardSettingsViewModel: ObservableObject, Identifiable {
     @Published var isLoading: Bool = false
     @Published var alert: AlertBinder?
 
+    private let cardOnMainWalletId: Data
     private unowned let coordinator: ScanCardSettingsRoutable
 
-    init(coordinator: ScanCardSettingsRoutable) {
+    init(cardOnMainWalletId: Data, coordinator: ScanCardSettingsRoutable) {
+        self.cardOnMainWalletId = cardOnMainWalletId
         self.coordinator = coordinator
     }
 }
@@ -29,15 +31,29 @@ final class ScanCardSettingsViewModel: ObservableObject, Identifiable {
 extension ScanCardSettingsViewModel {
     func scanCard() {
         scan { [weak self] result in
+            guard let self = self else { return }
+
             switch result {
             case let .success(cardInfo):
-                let cardModel = CardViewModel(cardInfo: cardInfo)
-                cardModel.didScan() // TODO: refactor
-                self?.coordinator.openCardSettings(cardModel: cardModel)
+                self.processSuccessScan(for: cardInfo)
             case let .failure(error):
-                self?.showErrorAlert(error: error)
+                self.showErrorAlert(error: error)
             }
         }
+    }
+
+    private func processSuccessScan(for cardInfo: CardInfo) {
+        let cardModel = CardViewModel(cardInfo: cardInfo)
+        guard
+            let userWalletId = cardModel.userWalletId,
+            userWalletId == cardOnMainWalletId
+        else {
+            showErrorAlert(error: AppError.wrongCardWasTapped)
+            return
+        }
+
+        cardModel.didScan() // TODO: refactor
+        self.coordinator.openCardSettings(cardModel: cardModel)
     }
 }
 
@@ -62,12 +78,6 @@ extension ScanCardSettingsViewModel {
     }
 
     func showErrorAlert(error: Error) {
-        let alert = Alert(
-            title: Text("common_error"),
-            message: Text(error.localizedDescription),
-            dismissButton: .default(Text("common_ok"))
-        )
-
-        self.alert = AlertBinder(alert: alert)
+        self.alert = AlertBuilder.makeOkErrorAlert(message: error.localizedDescription)
     }
 }


### PR DESCRIPTION
Теперь при попытке прочитать другую карточку на экране настроек пользователь должен прикладывать карточку с таким же userWalletId, если он отличается - появится алерт с ошибкой.