### PR TITLE
IOS-2485 Cancel previous CI action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,10 @@ on:
     - 'master'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
Очень важная вещь, которую забыли сделать, если в течении выполнения тестов, сделали коммит, то предыдущий action будет отменен, и начнется сразу последний. 
Должно сильно сократить время работы CI машины