### PR TITLE
IOS-2493 Don't show unreachable for empty rates

### DIFF
--- a/Tangem/App/ViewModels/WalletModel.swift
+++ b/Tangem/App/ViewModels/WalletModel.swift
@@ -236,6 +236,9 @@ class WalletModel: ObservableObject, Identifiable {
 
         return tangemApiService
             .loadRates(for: currenciesToExchange)
+            .replaceError(with: [:])
+            /// Hack that use `switchToLatest()` which is available in iOS 14.0. Remove it after update target version
+            .setFailureType(to: Error.self)
             .eraseToAnyPublisher()
     }
 


### PR DESCRIPTION
- Игнорируем ошибку для загрузки rates. Сделал через хак, что бы оставить логику отмены запроса через 
`.map().switchToLatest()`