### PR TITLE
IOS-2520 Update GenericConfig for hide backup buttons

### DIFF
--- a/Tangem/App/Models/UserWallet/Implementations/GenericConfig.swift
+++ b/Tangem/App/Models/UserWallet/Implementations/GenericConfig.swift
@@ -174,7 +174,7 @@ extension GenericConfig: UserWalletConfig {
                 return .available
             }
 
-            return .disabled()
+            return .hidden
         case .twinning:
             return .hidden
         case .exchange:


### PR DESCRIPTION
Была проблема в том, что кнопки нужно именно скрывать, а .disabled() используется для Demo карт