### PR TITLE
IOS-2534: Fix for missing wallets at the end of twinning

### DIFF
--- a/Tangem/Modules/Onboarding/Twins/TwinsWalletCreationUtil.swift
+++ b/Tangem/Modules/Onboarding/Twins/TwinsWalletCreationUtil.swift
@@ -137,6 +137,7 @@ class TwinsWalletCreationUtil {
             switch result {
             case .success(let response):
                 self.card.onTwinWalletCreated(response.walletData)
+                self.card.appendDefaultBlockchains()
                 self.card.userWalletModel?.updateAndReloadWalletModels { [weak self] in
                     self?.step.send(.done)
                 }


### PR DESCRIPTION
Не сохранялся в хранилище биток