### PR TITLE
IOS-2537 Fix total balance

### DIFF
--- a/Tangem/App/Services/TotalBalanceProvider/TotalBalanceProvider.swift
+++ b/Tangem/App/Services/TotalBalanceProvider/TotalBalanceProvider.swift
@@ -18,11 +18,13 @@ class TotalBalanceProvider {
     private var refreshSubscription: AnyCancellable?
     private let userWalletAmountType: Amount.AmountType?
     private var isFirstLoadForCardInSession: Bool = true
+    private var bag: Set<AnyCancellable> = .init()
 
     init(userWalletModel: UserWalletModel, userWalletAmountType: Amount.AmountType?, totalBalanceAnalyticsService: TotalBalanceAnalyticsService) {
         self.userWalletModel = userWalletModel
         self.userWalletAmountType = userWalletAmountType
         self.totalBalanceAnalyticsService = totalBalanceAnalyticsService
+        bind()
     }
 }
 
@@ -32,32 +34,52 @@ extension TotalBalanceProvider: TotalBalanceProviding {
     func totalBalancePublisher() -> AnyPublisher<LoadingValue<TotalBalance>, Never> {
         totalBalanceSubject.eraseToAnyPublisher()
     }
-
-    func updateTotalBalance() {
-        totalBalanceSubject.send(.loading)
-        loadCurrenciesAndUpdateBalance()
-    }
 }
 
 private extension TotalBalanceProvider {
-    func loadCurrenciesAndUpdateBalance() {
-        refreshSubscription = tangemApiService.loadCurrencies()
-            .receive(on: DispatchQueue.global())
-            .tryMap { [weak self] currencies -> TotalBalance in
-                guard let self = self,
-                      let currency = currencies.first(where: { $0.code == AppSettings.shared.selectedCurrencyCode }) else {
-                    throw CommonError.noData
+    func bind() {
+        // Subscription to handle token changes
+        userWalletModel.subscribeToWalletModels()
+            .combineLatest(AppSettings.shared.$selectedCurrencyCode)
+            .receive(on: DispatchQueue.main)
+            .sink { [unowned self] walletModels, currencyCode  in
+                let hasLoading = !walletModels.filter { $0.state.isLoading }.isEmpty
+
+                // We should wait for balance loading to complete
+                if hasLoading {
+                    self.totalBalanceSubject.send(.loading)
+                    return
                 }
 
-                return self.mapToTotalBalance(currency: currency)
+                self.updateTotalBalance(with: currencyCode)
             }
+            .store(in: &bag)
+
+        // Subscription to handle balance loading completion
+        userWalletModel.subscribeToWalletModels()
+            .filter { !$0.isEmpty }
             .receive(on: DispatchQueue.main)
-            .receiveValue { [weak self] balance in
-                self?.totalBalanceSubject.send(.loaded(balance))
+            .map { walletModels -> AnyPublisher<Void, Never> in
+                walletModels.map { $0.walletDidChange }
+                    .combineLatest()
+                    .filter { $0.allConforms { !$0.isLoading } }
+                    .mapVoid()
+                    .eraseToAnyPublisher()
             }
+            .switchToLatest()
+            .delay(for: 0.2, scheduler: DispatchQueue.main) // Hide skeleton with delay
+            .sink { [unowned self] walletModels in
+                self.updateTotalBalance(with: AppSettings.shared.selectedCurrencyCode)
+            }
+            .store(in: &bag)
     }
 
-    func mapToTotalBalance(currency: CurrenciesResponse.Currency) -> TotalBalance {
+    func updateTotalBalance(with currencyCode: String) {
+        let totalBalance = self.mapToTotalBalance(currencyCode: currencyCode)
+        self.totalBalanceSubject.send(.loaded(totalBalance))
+    }
+
+    func mapToTotalBalance(currencyCode: String) -> TotalBalance {
         let tokenItemViewModels = getTokenItemViewModels()
 
         var hasError: Bool = false
@@ -86,7 +108,7 @@ private extension TotalBalanceProvider {
             isFirstLoadForCardInSession = false
         }
 
-        return TotalBalance(balance: balance, currency: currency, hasError: hasError)
+        return TotalBalance(balance: balance, currencyCode: currencyCode, hasError: hasError)
     }
 
     func getTokenItemViewModels() -> [TokenItemViewModel] {
@@ -103,7 +125,7 @@ private extension TotalBalanceProvider {
 extension TotalBalanceProvider {
     struct TotalBalance {
         let balance: Decimal
-        let currency: CurrenciesResponse.Currency
+        let currencyCode: String
         let hasError: Bool
     }
 }

--- a/Tangem/App/Services/TotalBalanceProvider/TotalBalanceProviding.swift
+++ b/Tangem/App/Services/TotalBalanceProvider/TotalBalanceProviding.swift
@@ -10,5 +10,4 @@ import Combine
 
 protocol TotalBalanceProviding {
     func totalBalancePublisher() -> AnyPublisher<LoadingValue<TotalBalanceProvider.TotalBalance>, Never>
-    func updateTotalBalance()
 }

--- a/Tangem/Modules/Main/TotalSumBalance/TotalSumBalanceViewModel.swift
+++ b/Tangem/Modules/Main/TotalSumBalance/TotalSumBalanceViewModel.swift
@@ -81,7 +81,6 @@ class TotalSumBalanceViewModel: ObservableObject {
 
         // Skeleton subscription
         totalBalanceManager.totalBalancePublisher()
-            .print()
             .map { $0.isLoading }
             .weakAssignAnimated(to: \.isLoading, on: self)
             .store(in: &bag)

--- a/Tangem/Modules/Main/TotalSumBalance/TotalSumBalanceViewModel.swift
+++ b/Tangem/Modules/Main/TotalSumBalance/TotalSumBalanceViewModel.swift
@@ -43,10 +43,6 @@ class TotalSumBalanceViewModel: ObservableObject {
         bind()
     }
 
-    func updateBalance() {
-        totalBalanceManager.updateTotalBalance()
-    }
-
     func updateForSingleCoinCard() {
         guard let cardAmountType = self.cardAmountType else { return }
         let walletModels = userWalletModel.getWalletModels()
@@ -58,51 +54,14 @@ class TotalSumBalanceViewModel: ObservableObject {
         tapOnCurrencySymbol.openCurrencySelection()
     }
 
-    func beginUpdates() {
-        tapOnCurrencySymbol.openCurrencySelection()
-    }
-
     private func bind() {
-        Publishers.Merge(
-            userWalletModel.subscribeToWalletModels().filter { $0.isEmpty }.mapVoid(),
-            AppSettings.shared.$selectedCurrencyCode.mapVoid()
-        )
-        .map { [unowned self] _ in
-            addAttributeForBalance(0, withCurrencyCode: AppSettings.shared.selectedCurrencyCode)
-        }
-        .receive(on: DispatchQueue.main)
-        .sink { [unowned self] balance in
-            isLoading = false
-            totalFiatValueString = balance
-        }
-        .store(in: &bag)
-
-        userWalletModel.subscribeToWalletModels()
-            .filter { !$0.isEmpty }
-            .receive(on: DispatchQueue.main)
-            .map { [unowned self] walletModels -> AnyPublisher<Void, Never> in
-                isLoading = true
-
-                return walletModels.map { $0.walletDidChange }
-                    .combineLatest()
-                    .filter { $0.allConforms { !$0.isLoading } }
-                    .mapVoid()
-                    .eraseToAnyPublisher()
-            }
-            .switchToLatest()
-            // Hide skeleton with delay
-            .delay(for: 0.2, scheduler: DispatchQueue.main)
-            .sink { [unowned self] walletModels in
-                updateForSingleCoinCard()
-                updateBalance()
-            }
-            .store(in: &bag)
-
+        // Total balance main subscription
         totalBalanceManager.totalBalancePublisher()
             .compactMap { $0.value }
             .map { [unowned self] balance in
                 checkPositiveBalance()
-                return addAttributeForBalance(balance.balance, withCurrencyCode: balance.currency.code)
+                updateForSingleCoinCard()
+                return addAttributeForBalance(balance.balance, withCurrencyCode: balance.currencyCode)
             }
             .weakAssign(to: \.totalFiatValueString, on: self)
             .store(in: &bag)
@@ -120,10 +79,10 @@ class TotalSumBalanceViewModel: ObservableObject {
             .weakAssign(to: \.hasError, on: self)
             .store(in: &bag)
 
+        // Skeleton subscription
         totalBalanceManager.totalBalancePublisher()
+            .print()
             .map { $0.isLoading }
-            .filter { !$0 }
-            .debounce(for: 0.5, scheduler: DispatchQueue.main)
             .weakAssignAnimated(to: \.isLoading, on: self)
             .store(in: &bag)
     }


### PR DESCRIPTION
С виду изменений много, на самом деле кода стало меньше :) Минимально переделал подписки, лишнего не рефакторил.

1) Сильно упростил TotalSumBalanceViewModel. Там теперь только тупые подписки на total balance.  Одна подписка, как и была - смотрит на строку баланса. Вторая - отвечает за скелетон. Раньше только отключала, теперь и включает.

2) TotalBalanceProvider теперь делает все сам. У него две подписки. 1 реагирует на любые изменения токенов и обновляет тотал баланс сразу, без скелетона, если возможно. Если невозможно, надо дождаться загрузки балансов,  то паблишит loading. Вторая - ждет загрузку балансов и потом уже обновляет тотал баланс.

3) Из тотал баланса удалена загрузка списка валют. Эта загрузка нужна только экрану списка этих самых валют, она там и осталась.
