### PR TITLE
IOS-2569 Extend activation to legacy cards

### DIFF
--- a/Tangem/App/Models/UserWallet/Implementations/LegacyConfig.swift
+++ b/Tangem/App/Models/UserWallet/Implementations/LegacyConfig.swift
@@ -62,7 +62,11 @@ extension LegacyConfig: UserWalletConfig {
             return .singleWallet([.createWallet] + userWalletSavingSteps + [.success])
         }
 
-        return .singleWallet([])
+        if !AppSettings.shared.cardsStartedActivation.contains(card.cardId) {
+            return .singleWallet([])
+        }
+
+        return .singleWallet(userWalletSavingSteps + [.success])
     }
 
     var backupSteps: OnboardingSteps? {

--- a/Tangem/Modules/Onboarding/Note/SingleCardOnboardingViewModel.swift
+++ b/Tangem/Modules/Onboarding/Note/SingleCardOnboardingViewModel.swift
@@ -201,13 +201,11 @@ class SingleCardOnboardingViewModel: OnboardingTopupViewModel<SingleCardOnboardi
 
             self.cardModel?.appendDefaultBlockchains()
 
-            if case let .singleWallet(steps) = self.input.steps, steps.contains(.topup) {
-                if let cardId = self.cardModel?.cardId {
-                    AppSettings.shared.cardsStartedActivation.insert(cardId)
-                }
-
-                Analytics.log(.onboardingStarted)
+            if let cardId = self.cardModel?.cardId {
+                AppSettings.shared.cardsStartedActivation.insert(cardId)
             }
+
+            Analytics.log(.onboardingStarted)
 
             self.cardModel?.userWalletModel?.updateAndReloadWalletModels()
             self.walletCreatedWhileOnboarding = true


### PR DESCRIPTION
Расширил "активацию" и на старые карты для единообразия и чтобы покрыть кейс, когда пользователь создал кошелек и выгрузил приложение. Теперь онбординг возобновится с того же места и пользователь сможет дать апрув на сохранение