### PR TITLE
IOS-2439: Fix for unowned crash

### DIFF
--- a/Tangem/App/Services/WalletConnectService/WalletConnect/WalletConnectService.swift
+++ b/Tangem/App/Services/WalletConnectService/WalletConnect/WalletConnectService.swift
@@ -156,9 +156,9 @@ class WalletConnectService: ObservableObject {
     private func setupSessionConnectTimer() {
         isWaitingToConnect = true
         isServiceBusy.send(true)
-        timer = DispatchWorkItem(block: { [unowned self] in
-            self.isWaitingToConnect = false
-            self.handle(WalletConnectServiceError.timeout)
+        timer = DispatchWorkItem(block: { [weak self] in
+            self?.isWaitingToConnect = false
+            self?.handle(WalletConnectServiceError.timeout)
         })
         DispatchQueue.main.asyncAfter(deadline: .now() + 20, execute: timer!)
     }


### PR DESCRIPTION
Раньше был unowned, т.к. сервис создавался при старте приложения и жил все время, теперь WС сервис пересоздается при сканировании карточки, поэтому краш и был.