### PR TITLE
IOS-2603 Only remove twin user wallet if it was NOT changed during the re-twin operation

### DIFF
--- a/Tangem/Modules/Onboarding/Twins/TwinsOnboardingViewModel.swift
+++ b/Tangem/Modules/Onboarding/Twins/TwinsOnboardingViewModel.swift
@@ -289,7 +289,10 @@ class TwinsOnboardingViewModel: OnboardingTopupViewModel<TwinsOnboardingStep, On
         try super.saveUserWalletIfNeeded()
 
         if let originalUserWallet,
-           AppSettings.shared.saveUserWallets {
+           let currentUserWalletId = input.cardInput.cardModel?.userWalletId,
+           originalUserWallet.userWalletId != currentUserWalletId,
+           AppSettings.shared.saveUserWallets
+        {
             userWalletRepository.delete(originalUserWallet)
         }
     }


### PR DESCRIPTION
Проверил перетвинивание, работает, удаляет старый кошелек