### PR TITLE
IOS-2616 Move load url

### DIFF
--- a/Tangem/Common/UI/WebView.swift
+++ b/Tangem/Common/UI/WebView.swift
@@ -101,15 +101,15 @@ struct WebView: UIViewRepresentable {
             view.scrollView.contentInset = contentInset
         }
 
+        if let url = url {
+            print("Loading request with url: \(url)")
+            view.load(URLRequest(url: url))
+        }
+
         return view
     }
 
-    func updateUIView(_ uiView: WKWebView, context: Context) {
-        if let url = url { // ios13 load only from within updateUIView
-            print("Loading request with url: \(url)")
-            uiView.load(URLRequest(url: url))
-        }
-    }
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
 
     class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
         let urlActions: [String: ((String) -> Void)]


### PR DESCRIPTION
Вернул код в инициализацию, это все же более правильное место, иначе появляются перезагрузки на апдейтах.  Передвинул его в конец, после инициализации делегатов. На всех иосах работает, что были у меня за проблемы не ясно, вероятно впн