### PR TITLE
IOS-2645: Fix for access code appear

### DIFF
--- a/Tangem/App/Services/UserWalletRepository/CommonUserWalletRepository.swift
+++ b/Tangem/App/Services/UserWalletRepository/CommonUserWalletRepository.swift
@@ -551,6 +551,7 @@ class CommonUserWalletRepository: UserWalletRepository {
         let cardInfo = selectedModel.cardInfo
         startInitializingServices(for: cardInfo)
         finishInitializingServices(for: selectedModel, cardInfo: cardInfo)
+        selectedModel.updateSdkConfig()
     }
 
     private func sendEvent(_ event: UserWalletRepositoryEvent) {


### PR DESCRIPTION
не обновлялся сдк конфиг при переключении между карточками. из-за этого после добавления карточки с access code он запрашивался у всех карточек подряд