### PR TITLE
IOS-2628: Fix for wrong separators layout on iOS 14.6

### DIFF
--- a/Tangem/Modules/UserWalletList/UserWalletListView.swift
+++ b/Tangem/Modules/UserWalletList/UserWalletListView.swift
@@ -74,19 +74,8 @@ extension UserWalletListView {
         if #available(iOS 16, *) {
             userWalletsList()
                 .scrollContentBackground(.hidden)
-        } else if #available(iOS 14, *) {
-            userWalletsList()
         } else {
-            // Using ScrollView because we can't hide default separators in List on prior OS versions.
-            // And since we don't use List we can't use onDelete for the swipe action either.
-            ScrollView(.vertical) {
-                VStack(spacing: 0) {
-                    sections()
-                }
-            }
-            .background(Colors.Background.primary)
-            .cornerRadius(14)
-            .padding(.horizontal, listHorizontalPadding)
+            userWalletsScrollView()
         }
     }
 
@@ -107,10 +96,10 @@ extension UserWalletListView {
             VStack(spacing: 0) {
                 sections()
             }
+            .background(Colors.Background.primary)
+            .cornerRadius(14)
+            .padding(.horizontal, listHorizontalPadding)
         }
-        .background(Colors.Background.primary)
-        .cornerRadius(14)
-        .padding(.horizontal, listHorizontalPadding)
     }
 
     // MARK: - Sections


### PR DESCRIPTION
пробовал с разных сторон подъехать, чтобы не удалять List для 14 оси, но все равно разделители остаются между заголовком и под разделителем между картами.
Пришлось переехать на ScrollView + немного обновил его, чтобы как в 16 оси область была (заканчивается после последнего элемента, а не растягивается на всю длину)