### PR TITLE
IOS-2648 Refactor derivation for biometrics

### DIFF
--- a/Tangem/App/Services/DerivationManager/DerivationManager.swift
+++ b/Tangem/App/Services/DerivationManager/DerivationManager.swift
@@ -27,7 +27,7 @@ struct DerivationManager {
         self.cardInfo = cardInfo
     }
 
-    func deriveIfNeeded(entries: [StorageEntry], completion: @escaping (Result<[Data: [DerivationPath: ExtendedPublicKey]]?, TangemSdkError>) -> Void) {
+    func deriveIfNeeded(entries: [StorageEntry], completion: @escaping (Result<DerivationResult?, TangemSdkError>) -> Void) {
         guard config.hasFeature(.hdWallets) else {
             completion(.success(nil))
             return
@@ -51,7 +51,7 @@ struct DerivationManager {
         deriveKeys(entries: nonDeriveEntries, completion: completion)
     }
 
-    private func deriveKeys(entries: [StorageEntry], completion: @escaping (Result<[Data: [DerivationPath: ExtendedPublicKey]]?, TangemSdkError>) -> Void) {
+    private func deriveKeys(entries: [StorageEntry], completion: @escaping (Result<DerivationResult?, TangemSdkError>) -> Void) {
         let card = cardInfo.card
         var derivations: [Data: [DerivationPath]] = [:]
 
@@ -74,3 +74,6 @@ struct DerivationManager {
         }
     }
 }
+
+
+typealias DerivationResult = DeriveMultipleWalletPublicKeysTask.Response

--- a/Tangem/App/Services/DerivationManager/DerivationManager.swift
+++ b/Tangem/App/Services/DerivationManager/DerivationManager.swift
@@ -14,12 +14,20 @@ struct DerivationManager {
     private let config: UserWalletConfig
     private let cardInfo: CardInfo
 
+    private var cardId: String? {
+        if config.cardsCount == 1 {
+            return cardInfo.card.cardId
+        }
+
+        return nil
+    }
+
     init(config: UserWalletConfig, cardInfo: CardInfo) {
         self.config = config
         self.cardInfo = cardInfo
     }
 
-    func deriveIfNeeded(entries: [StorageEntry], completion: @escaping (Result<Card?, TangemSdkError>) -> Void) {
+    func deriveIfNeeded(entries: [StorageEntry], completion: @escaping (Result<[Data: [DerivationPath: ExtendedPublicKey]]?, TangemSdkError>) -> Void) {
         guard config.hasFeature(.hdWallets) else {
             completion(.success(nil))
             return
@@ -43,21 +51,22 @@ struct DerivationManager {
         deriveKeys(entries: nonDeriveEntries, completion: completion)
     }
 
-    private func deriveKeys(entries: [StorageEntry], completion: @escaping (Result<Card?, TangemSdkError>) -> Void) {
+    private func deriveKeys(entries: [StorageEntry], completion: @escaping (Result<[Data: [DerivationPath: ExtendedPublicKey]]?, TangemSdkError>) -> Void) {
         let card = cardInfo.card
-        var derivations: [EllipticCurve: [DerivationPath]] = [:]
+        var derivations: [Data: [DerivationPath]] = [:]
 
         for entry in entries {
             if let path = entry.blockchainNetwork.derivationPath {
-                derivations[entry.blockchainNetwork.blockchain.curve, default: []].append(path)
+                if let wallet = card.wallets.first(where: { $0.curve == entry.blockchainNetwork.blockchain.curve }) {
+                    derivations[wallet.publicKey, default: []].append(path)
+                }
             }
         }
 
-        tangemSdkProvider.sdk.config.defaultDerivationPaths = derivations
-        tangemSdkProvider.sdk.startSession(with: ScanTask(), cardId: card.cardId) { result in
+        tangemSdkProvider.sdk.startSession(with: DeriveMultipleWalletPublicKeysTask(derivations), cardId: cardId) { result in
             switch result {
-            case .success(let card):
-                completion(.success(card))
+            case .success(let response):
+                completion(.success(response))
             case .failure(let error):
                 Analytics.logCardSdkError(error, for: .purgeWallet, card: card)
                 completion(.failure(error))

--- a/Tangem/App/ViewModels/CardViewModel.swift
+++ b/Tangem/App/ViewModels/CardViewModel.swift
@@ -447,7 +447,7 @@ class CardViewModel: Identifiable, ObservableObject {
         onUpdate()
     }
 
-    func onDerived(_ response: [Data: [DerivationPath: ExtendedPublicKey]]) {
+    func onDerived(_ response: DerivationResult) {
         for updatedWallet in response {
             for derivedKey in updatedWallet.value {
                 cardInfo.card.wallets[updatedWallet.key]?.derivedKeys[derivedKey.key] = derivedKey.value

--- a/Tangem/App/ViewModels/CardViewModel.swift
+++ b/Tangem/App/ViewModels/CardViewModel.swift
@@ -447,10 +447,10 @@ class CardViewModel: Identifiable, ObservableObject {
         onUpdate()
     }
 
-    func onDerived(_ card: Card) {
-        for updatedWallet in card.wallets {
-            for derivedKey in updatedWallet.derivedKeys {
-                cardInfo.card.wallets[updatedWallet.publicKey]?.derivedKeys[derivedKey.key] = derivedKey.value
+    func onDerived(_ response: [Data: [DerivationPath: ExtendedPublicKey]]) {
+        for updatedWallet in response {
+            for derivedKey in updatedWallet.value {
+                cardInfo.card.wallets[updatedWallet.key]?.derivedKeys[derivedKey.key] = derivedKey.value
             }
         }
 
@@ -723,9 +723,9 @@ extension CardViewModel {
         let alreadySaved = userWalletModel?.getSavedEntries() ?? []
         derivationManager.deriveIfNeeded(entries: alreadySaved + entries, completion: { [weak self] result in
             switch result {
-            case let .success(card):
-                if let card = card {
-                    self?.onDerived(card)
+            case let .success(response):
+                if let response {
+                    self?.onDerived(response)
                 }
 
                 completion(.success(()))


### PR DESCRIPTION
Для деривации вновь используется соответствующий таск. Биометрия будет вызываться в соответствии с общей политикой. Можно делать деривацию любой картой из набора, если приложить неправильную карту, получим ошибку, аналогичную ошибке при подписи не той картой