### PR TITLE
IOS-2622 Update signer whenever config changed

### DIFF
--- a/Tangem/App/ViewModels/CardViewModel.swift
+++ b/Tangem/App/ViewModels/CardViewModel.swift
@@ -22,7 +22,7 @@ class CardViewModel: Identifiable, ObservableObject {
 
     @Published private(set) var currentSecurityOption: SecurityModeOption = .longTap
 
-    lazy var signer: TangemSigner = config.tangemSigner
+    var signer: TangemSigner { _signer }
 
     var cardId: String { cardInfo.card.cardId }
 
@@ -256,6 +256,16 @@ class CardViewModel: Identifiable, ObservableObject {
 
     private var searchBlockchainsCancellable: AnyCancellable? = nil
     private var bag = Set<AnyCancellable>()
+    private var signSubscription: AnyCancellable?
+
+    private var _signer: TangemSigner {
+        didSet {
+            signSubscription = _signer.signPublisher
+                .sink { [weak self] card in // TODO: TBD remaining signatures feature
+                    self?.onSigned(card)
+                }
+        }
+    }
 
     convenience init(userWallet: UserWallet) {
         let cardInfo = userWallet.cardInfo()
@@ -271,7 +281,7 @@ class CardViewModel: Identifiable, ObservableObject {
     ) {
         self.cardInfo = cardInfo
         self.config = config
-
+        self._signer = config.tangemSigner
         createUserWalletModelIfNeeded(with: userWallet)
         updateCurrentSecurityOption()
         appendPersistentBlockchains()
@@ -440,10 +450,6 @@ class CardViewModel: Identifiable, ObservableObject {
             cardInfo.card.wallets[updatedWallet.publicKey]?.remainingSignatures = updatedWallet.remainingSignatures
         }
 
-        let cardDto = CardDTO(card: card)
-        let walletData = cardInfo.walletData
-        userWalletRepository.didScan(card: cardDto, walletData: walletData)
-
         onUpdate()
     }
 
@@ -476,6 +482,7 @@ class CardViewModel: Identifiable, ObservableObject {
     private func onUpdate() {
         print("🔄 Updating CardViewModel with new Card")
         config = UserWalletConfigFactory(cardInfo).makeConfig()
+        _signer = config.tangemSigner
         updateModel()
         updateUserWallet()
     }
@@ -635,11 +642,6 @@ class CardViewModel: Identifiable, ObservableObject {
     }
 
     private func bind() {
-        signer.signPublisher.sink { [unowned self] card in
-            self.onSigned(card)
-        }
-        .store(in: &bag)
-
         AppSettings.shared.$saveUserWallets
             .combineLatest(AppSettings.shared.$saveAccessCodes)
             .sink { [weak self] _ in


### PR DESCRIPTION
-Сайнер пересоздается с изменением конфига
-Сайнер ретейнится, чтобы не было проблем как в WC и чтобы не менять поведение сейчас
-Убрал didscan,  сохранение и так происходит дальше
