### PR TITLE
IOS-2659 Fix welcome ui glitches

### DIFF
--- a/Tangem/App/Services/UserWalletRepository/CommonUserWalletRepository.swift
+++ b/Tangem/App/Services/UserWalletRepository/CommonUserWalletRepository.swift
@@ -74,6 +74,9 @@ class CommonUserWalletRepository: UserWalletRepository {
     func bind() {
         minimizedAppTimer
             .timer
+            .filter { [weak self] in
+                self?.isUnlocked ?? false
+            }
             .receive(on: RunLoop.main)
             .sink { [weak self] in
                 self?.lock()

--- a/Tangem/Modules/App/AppCoordinator.swift
+++ b/Tangem/Modules/App/AppCoordinator.swift
@@ -111,6 +111,8 @@ class AppCoordinator: NSObject, CoordinatorObject {
     }
 
     private func handleLock() {
+        guard welcomeCoordinator == nil && authCoordinator == nil else { return } // already locked, prevent glitches
+
         closeAllSheetsIfNeeded(animated: false)
 
         UIApplication.performWithoutAnimations {

--- a/Tangem/Modules/Welcome/Stories/StoriesViewModel.swift
+++ b/Tangem/Modules/Welcome/Stories/StoriesViewModel.swift
@@ -26,14 +26,12 @@ class StoriesViewModel: ObservableObject {
 
     func onAppear() {
         NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)
-            .dropFirst()
             .sink { [weak self] _ in
                 self?.pauseTimer()
             }
             .store(in: &bag)
 
         NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
-            .dropFirst()
             .sink { [weak self] _ in
                 self?.resumeTimer()
             }


### PR DESCRIPTION
-Добавил проверку в AppCoordinatore, чтобы не вызывался лок, если уже заблокировано.  (Удалили последний кошелек, вышли на главный, через 5 минут репа лочится, прилетает ивент)
-Добавил проверку в репозитории, чтобы он не лочился, если уже залочен.
-Сторисы не возобновлялись почему-то, убрал dropFirst