### PR TITLE
IOS-2674: Adding missing section for PIN1

### DIFF
--- a/Tangem/Common/UI/DefaultListViews/DefaultRowView/DefaultRowView.swift
+++ b/Tangem/Common/UI/DefaultListViews/DefaultRowView/DefaultRowView.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 
 struct DefaultRowView: View {
+    // TODO: Make @ObservedObject
     private let viewModel: DefaultRowViewModel
 
     init(viewModel: DefaultRowViewModel) {

--- a/Tangem/Common/UI/DefaultListViews/DefaultRowView/DefaultRowViewModel.swift
+++ b/Tangem/Common/UI/DefaultListViews/DefaultRowView/DefaultRowViewModel.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+// TODO: Make ObservableObject
 struct DefaultRowViewModel {
     let title: String
     let detailsType: DetailsType?

--- a/Tangem/Modules/CardSettings/CardSettingsViewModel.swift
+++ b/Tangem/Modules/CardSettings/CardSettingsViewModel.swift
@@ -83,16 +83,6 @@ private extension CardSettingsViewModel {
 
         setupSecurityOptions()
 
-        if isChangeAccessCodeVisible {
-            securityModeSection.append(
-                DefaultRowViewModel(
-                    title: "card_settings_change_access_code".localized,
-                    detailsType: isChangeAccessCodeLoading ? .loader : .none,
-                    action: openChangeAccessCodeWarningView
-                )
-            )
-        }
-
         if isResetToFactoryAvailable {
             resetToFactoryViewModel = DefaultRowViewModel(
                 title: "card_settings_reset_card_to_factory".localized,
@@ -107,6 +97,16 @@ private extension CardSettingsViewModel {
             detailsType: .text(securityModeTitle),
             action: hasSingleSecurityMode ? nil : openSecurityMode
         )]
+
+        if isChangeAccessCodeVisible {
+            securityModeSection.append(
+                DefaultRowViewModel(
+                    title: "card_settings_change_access_code".localized,
+                    detailsType: isChangeAccessCodeLoading ? .loader : .none,
+                    action: openChangeAccessCodeWarningView
+                )
+            )
+        }
     }
 
     private func deleteWallet(_ userWallet: UserWallet) {
@@ -148,9 +148,11 @@ extension CardSettingsViewModel {
     func openChangeAccessCodeWarningView() {
         Analytics.log(.buttonChangeUserCode)
         isChangeAccessCodeLoading = true
+        setupSecurityOptions()
         cardModel.changeSecurityOption(.accessCode) { [weak self] result in
             DispatchQueue.main.async {
                 self?.isChangeAccessCodeLoading = false
+                self?.setupSecurityOptions()
             }
         }
     }


### PR DESCRIPTION
Не обратил внимания, что в `securityModeSection` ещё добавляется одно поле для access code, теперь добавляется.
добавил тудушки на изменение вью модели и вьюхи, потому что они не обновляются.
Собственно изначально это и стало причиной бага:
вью модели не являются ObservableObject и они не наблюдают ни за какими полями, в итоге рутовые объекты меняются и чтобы обновить вьюху приходится полностью пересоздавать весь массив вью моделей `DefaultRowViewModel` чтобы опубликовать изменения, т.к. вьюха `CardSettingsView` подписывается на массив вью моделей.
Два `setupSecurityOptions()` в `func openChangeAccessCodeWarningView()` пришлось добавить из-за того что лоадер вообще не появлялся при попытке изменить access code, все по той же причине.