### PR TITLE
IOS-2675: Remove deinitialization for WC

### DIFF
--- a/Tangem/App/Services/UserWalletRepository/CommonUserWalletRepository.swift
+++ b/Tangem/App/Services/UserWalletRepository/CommonUserWalletRepository.swift
@@ -175,10 +175,11 @@ class CommonUserWalletRepository: UserWalletRepository {
 
         let oldConfig = sdkProvider.sdk.config
         var config = TangemSdkConfigFactory().makeDefaultConfig()
+
         if AppSettings.shared.saveUserWallets {
             config.accessCodeRequestPolicy = .alwaysWithBiometrics
         } else {
-            walletConnectServiceProvider.reset()
+            resetServices()
         }
 
         sdkProvider.setup(with: config)
@@ -408,17 +409,16 @@ class CommonUserWalletRepository: UserWalletRepository {
     }
 
     // TODO: refactor
-    private func startInitializingServices(for cardInfo: CardInfo) {
-        let interaction = INInteraction(intent: ScanTangemCardIntent(), response: nil)
-        interaction.donate(completion: nil)
-
+    private func resetServices() {
+        walletConnectServiceProvider.reset()
         saltPayRegistratorProvider.reset()
+    }
+
+    private func initializeServices(for cardModel: CardViewModel, cardInfo: CardInfo) {
         if let primaryCard = cardInfo.primaryCard {
             backupServiceProvider.backupService.setPrimaryCard(primaryCard)
         }
-    }
 
-    private func finishInitializingServices(for cardModel: CardViewModel, cardInfo: CardInfo) {
         tangemApiService.setAuthData(cardInfo.card.tangemApiAuthData)
         supportChatService.initialize(with: cardModel.supportChatEnvironment)
         walletConnectServiceProvider.initialize(with: cardModel)
@@ -432,13 +432,13 @@ class CommonUserWalletRepository: UserWalletRepository {
     }
 
     private func processScan(_ cardInfo: CardInfo) -> CardViewModel {
-        startInitializingServices(for: cardInfo)
+        resetServices()
 
         // TODO: Remove CardViewModel from here, use CardInfo
         let config = UserWalletConfigFactory(cardInfo).makeConfig()
         let cardModel = CardViewModel(cardInfo: cardInfo, config: config)
 
-        finishInitializingServices(for: cardModel, cardInfo: cardInfo)
+        initializeServices(for: cardModel, cardInfo: cardInfo)
 
         cardModel.didScan()
         return cardModel
@@ -555,8 +555,8 @@ class CommonUserWalletRepository: UserWalletRepository {
         guard let selectedModel else { return }
 
         let cardInfo = selectedModel.cardInfo
-        startInitializingServices(for: cardInfo)
-        finishInitializingServices(for: selectedModel, cardInfo: cardInfo)
+        resetServices()
+        initializeServices(for: selectedModel, cardInfo: cardInfo)
         selectedModel.updateSdkConfig()
     }
 

--- a/Tangem/App/Services/UserWalletRepository/CommonUserWalletRepository.swift
+++ b/Tangem/App/Services/UserWalletRepository/CommonUserWalletRepository.swift
@@ -172,13 +172,15 @@ class CommonUserWalletRepository: UserWalletRepository {
     private func scanInternal(with batch: String? = nil, _ completion: @escaping (Result<CardViewModel, Error>) -> Void) {
         Analytics.reset()
         Analytics.log(.readyToScan)
-        walletConnectServiceProvider.reset()
 
         let oldConfig = sdkProvider.sdk.config
         var config = TangemSdkConfigFactory().makeDefaultConfig()
         if AppSettings.shared.saveUserWallets {
             config.accessCodeRequestPolicy = .alwaysWithBiometrics
+        } else {
+            walletConnectServiceProvider.reset()
         }
+
         sdkProvider.setup(with: config)
 
         sendEvent(.scan(isScanning: true))


### PR DESCRIPTION
Надо подумать как бы сделать правильную логику инициализации и сброса всех сторонних сервисов, которые зависят от выбранной карточки.

Вынес очистку WC сервиса только для случаев, когда у пользователя не включено сохранение карточек.