### PR TITLE
IOS-2650: Remove signed hashes warning for Wallet cards

### DIFF
--- a/Tangem/App/Models/UserWallet/Implementations/LegacyConfig.swift
+++ b/Tangem/App/Models/UserWallet/Implementations/LegacyConfig.swift
@@ -153,7 +153,7 @@ extension LegacyConfig: UserWalletConfig {
         case .longHashes:
             return .hidden
         case .signedHashesCounter:
-            if isMultiwallet || card.firmwareVersion.type != .release {
+            if card.firmwareVersion.type != .release {
                 return .hidden
             } else {
                 return .available

--- a/Tangem/App/Models/UserWallet/UserWalletConfigFeatures.swift
+++ b/Tangem/App/Models/UserWallet/UserWalletConfigFeatures.swift
@@ -29,6 +29,7 @@ enum UserWalletFeature: Int, CaseIterable { // TODO: Add comments
     case multiCurrency
     case tokensSearch
     case resetToFactory
+    /// Count signed hashes to display warning for user if card already sign hashes in the past.
     case signedHashesCounter
     case onlineImage
     /// Is wallet allowed to participate in referral program

--- a/Tangem/App/Services/WarningsService/WarningsService.swift
+++ b/Tangem/App/Services/WarningsService/WarningsService.swift
@@ -120,6 +120,12 @@ private extension WarningsService {
             return
         }
 
+        guard canCountHashes else {
+            AppSettings.shared.validatedSignedHashesCards.append(cardId)
+            didFinishCountingHashes()
+            return
+        }
+
         guard cardSignedHashes > 0 else {
             AppSettings.shared.validatedSignedHashesCards.append(cardId)
             didFinishCountingHashes()
@@ -128,12 +134,6 @@ private extension WarningsService {
 
         guard !isMultiWallet else {
             showAlertAnimated(.multiWalletSignedHashes)
-            didFinishCountingHashes()
-            return
-        }
-
-        guard canCountHashes else {
-            AppSettings.shared.validatedSignedHashesCards.append(cardId)
             didFinishCountingHashes()
             return
         }


### PR DESCRIPTION
Убрал подсчет количества подписанных хэшей для Tangem Wallet.