### PR TITLE
IOS-2624: WC Add ETH support for pancakeswap

### DIFF
--- a/Tangem/App/Services/WalletConnectService/WalletConnect/WalletConnectNetworkParserUtility.swift
+++ b/Tangem/App/Services/WalletConnectService/WalletConnect/WalletConnectNetworkParserUtility.swift
@@ -12,9 +12,7 @@ import BlockchainSdk
 
 enum WalletConnectNetworkParserUtility {
     static func parse(dAppInfo: Session.DAppInfo, isTestnet: Bool) -> Blockchain? {
-        if dAppInfo.peerMeta.url.absoluteString.contains("pancakeswap.finance") {
-            return Blockchain.bsc(testnet: isTestnet)
-        } else if let id = dAppInfo.chainId {
+        if let id = dAppInfo.chainId {
             if let blockchain = makeBlockchain(from: id) {
                 return blockchain
             }


### PR DESCRIPTION
раньше pancake swap не присылали chainId, теперь присылают и можно определить это BSC или ETH