### PR TITLE
IOS-1067: Remove skeletonable from coin name

### DIFF
--- a/Tangem/Modules/Main/WalletsList/TokenItemView.swift
+++ b/Tangem/Modules/Main/WalletsList/TokenItemView.swift
@@ -47,7 +47,6 @@ struct TokenItemView: View {
                         .font(.system(size: 15, weight: .medium))
                         .layoutPriority(2)
                         .fixedSize(horizontal: false, vertical: true)
-                        .skeletonable(isShown: item.isLoading, size: CGSize(width: 70, height: 11))
 
                     Spacer()
 
@@ -75,7 +74,7 @@ struct TokenItemView: View {
                         .fixedSize(horizontal: false, vertical: true)
                         .lineLimit(1)
                         .fixedSize()
-                        .skeletonable(isShown: item.isLoading, size: CGSize(width: 50, height: 11))
+                        .skeletonable(isShown: item.isLoading, size: CGSize(width: 100, height: 11))
                 }
                 .font(.system(size: 13, weight: .regular))
                 .frame(minHeight: 20)

--- a/Tangem/Modules/Main/WalletsList/TokenItemView.swift
+++ b/Tangem/Modules/Main/WalletsList/TokenItemView.swift
@@ -55,7 +55,7 @@ struct TokenItemView: View {
                         .multilineTextAlignment(.trailing)
                         .truncationMode(.middle)
                         .fixedSize(horizontal: false, vertical: true)
-                        .skeletonable(isShown: item.isLoading, size: CGSize(width: 50, height: 11))
+                        .skeletonable(isShown: item.isLoading, size: CGSize(width: 50, height: 13))
                 }
                 .lineLimit(2)
                 .minimumScaleFactor(0.8)


### PR DESCRIPTION
убрал скелетон с названии монеты
сделал на валюте скелетон шире, т.к. значения там обычно большие
![IMG_8E87C0D6EFDB-3](https://user-images.githubusercontent.com/24321494/207552431-01d92bbd-1f76-40b8-8bf9-052593b0ce21.jpeg)
![IMG_8E87C0D6EFDB-4](https://user-images.githubusercontent.com/24321494/207552443-476fa194-a788-4c21-80b4-aca2a0eb31e7.jpeg)
