### PR TITLE
IOS-2755 remove struct LocalizedString

### DIFF
--- a/Tangem/Common/Extensions/String+.swift
+++ b/Tangem/Common/Extensions/String+.swift
@@ -9,17 +9,14 @@
 import Foundation
 
 extension String {
-    @available(*, deprecated, message: "Use L10n instead")
     var localized: String {
         return NSLocalizedString(self, comment: "")
     }
 
-    @available(*, deprecated, message: "Use L10n instead")
     func localized(_ arguments: [CVarArg]) -> String {
         return String(format: localized, arguments: arguments)
     }
 
-    @available(*, deprecated, message: "Use L10n instead")
     func localized(_ arguments: CVarArg) -> String {
         return String(format: localized, arguments)
     }

--- a/Tangem/Common/Extensions/String+.swift
+++ b/Tangem/Common/Extensions/String+.swift
@@ -9,14 +9,17 @@
 import Foundation
 
 extension String {
+    @available(*, deprecated, message: "Use L10n instead")
     var localized: String {
         return NSLocalizedString(self, comment: "")
     }
 
+    @available(*, deprecated, message: "Use L10n instead")
     func localized(_ arguments: [CVarArg]) -> String {
         return String(format: localized, arguments: arguments)
     }
 
+    @available(*, deprecated, message: "Use L10n instead")
     func localized(_ arguments: CVarArg) -> String {
         return String(format: localized, arguments)
     }

--- a/Utilites/swiftui-strings-template.stencil
+++ b/Utilites/swiftui-strings-template.stencil
@@ -38,7 +38,7 @@ import SwiftUI
     return L10n.tr("{{table}}", "{{string.key}}", {% call argumentsBlock string.types %})
   }
   {% else %}
-  public static let {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = LocalizedString(stringKey: "{{string.key}}")
+  public static let {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = L10n.tr("Localizable", "{{string.key}}")
   {% endif %}
   {% endfor %}
   {% for child in item.children %}
@@ -67,21 +67,6 @@ private extension L10n {
   static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = {{param.bundle|default:"BundleToken.bundle"}}.localizedString(forKey: key, value: nil, table: table)
     return String(format: format, locale: Locale.current, arguments: args)
-  }
-}
-
-public struct LocalizedString {
-  private let stringKey: String
-  init(stringKey: String) {
-    self.stringKey = stringKey
-  }
-
-  var key: LocalizedStringKey {
-    LocalizedStringKey(stringKey)
-  }
-
-  var text: String {
-    L10n.tr("Localizable", stringKey)
   }
 }
 {% if not param.bundle %}


### PR DESCRIPTION
- еще раз с утра подумал, что не нужна нам эта структура `struct LocalizedString`
получается что для строк с параметрами она не подходит, и там просто возвращается `String`, по этому для унификации везде сразу будет `String`  без промежуточных структур
- Сделал `var localized` deprecated