### PR TITLE
IOS-2743 Use plain rounding mode for the model used in the calculation of the total balance

### DIFF
--- a/Tangem/App/ViewModels/WalletModel.swift
+++ b/Tangem/App/ViewModels/WalletModel.swift
@@ -524,7 +524,7 @@ extension WalletModel {
                 balance: balanceViewModel.balance,
                 fiatBalance: balanceViewModel.fiatBalance,
                 rate: getRateFormatted(for: amountType),
-                fiatValue: getFiat(for: wallet.amounts[amountType]) ?? 0,
+                fiatValue: getFiat(for: wallet.amounts[amountType], roundingMode: .plain) ?? 0,
                 blockchainNetwork: blockchainNetwork,
                 amountType: amountType,
                 hasTransactionInProgress: wallet.hasPendingTx(for: amountType),

--- a/Tangem/App/ViewModels/WalletModel.swift
+++ b/Tangem/App/ViewModels/WalletModel.swift
@@ -506,7 +506,7 @@ extension WalletModel {
             balance: balanceViewModel.balance,
             fiatBalance: balanceViewModel.fiatBalance,
             rate: getRateFormatted(for: amountType),
-            fiatValue: getFiat(for: wallet.amounts[amountType]) ?? 0,
+            fiatValue: getFiat(for: wallet.amounts[amountType], roundingMode: .plain) ?? 0,
             blockchainNetwork: blockchainNetwork,
             amountType: amountType,
             hasTransactionInProgress: wallet.hasPendingTx(for: amountType),


### PR DESCRIPTION
Теперь у тотал баланса и ячеек одинаковое округление. Проверил на данных из кейса и на одной эфировской копейке.