### PR TITLE
IOS-2915: Fix issue with doubling participate event

### DIFF
--- a/Tangem/Modules/Referral/ReferralViewModel.swift
+++ b/Tangem/Modules/Referral/ReferralViewModel.swift
@@ -41,6 +41,11 @@ class ReferralViewModel: ObservableObject {
 
     @MainActor
     func participateInReferralProgram() async {
+        if isProcessingRequest {
+            return
+        }
+        
+        isProcessingRequest = true
         Analytics.log(.referralButtonParticipate)
 
         guard
@@ -52,18 +57,18 @@ class ReferralViewModel: ObservableObject {
                 message: Localization.referralErrorFailedToLoadInfo,
                 okAction: coordinator.dismiss
             )
+            isProcessingRequest = false
             return
         }
 
         let token = award.token
 
         guard let address = cardModel.wallets.first(where: { $0.blockchain == blockchain })?.address else {
-            await requestDerivation(for: blockchain, with: token)
+            requestDerivation(for: blockchain, with: token)
             return
         }
 
         saveToStorageIfNeeded(token, for: blockchain)
-        isProcessingRequest = true
         do {
             let referralProgramInfo = try await runInTask {
                 try await self.tangemApiService.participateInReferralProgram(using: token, for: address, with: self.userWalletId.hexString)
@@ -106,8 +111,7 @@ class ReferralViewModel: ObservableObject {
         }
     }
 
-    @MainActor
-    private func requestDerivation(for blockchain: Blockchain, with referralToken: ReferralProgramInfo.Token) async {
+    private func requestDerivation(for blockchain: Blockchain, with referralToken: ReferralProgramInfo.Token) {
         let network = cardModel.getBlockchainNetwork(for: blockchain, derivationPath: nil)
         let token = convertToStorageToken(from: referralToken)
 
@@ -124,6 +128,7 @@ class ReferralViewModel: ObservableObject {
             case .success:
                 runTask(self.participateInReferralProgram)
             case .failure(let error):
+                self.isProcessingRequest = false
                 if case .userCancelled = error.toTangemSdkError() {
                     return
                 }

--- a/Tangem/Modules/SwappingTokenList/Components/SwappingTokenItemView/SwappingTokenItemView.swift
+++ b/Tangem/Modules/SwappingTokenList/Components/SwappingTokenItemView/SwappingTokenItemView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct SwappingTokenItemView: View {
     static let iconSize = CGSize(width: 40, height: 40)
     static let horizontalInteritemSpacing: CGFloat = 12
-    
+
     private let viewModel: SwappingTokenItemViewModel
 
     init(viewModel: SwappingTokenItemViewModel) {


### PR DESCRIPTION
в аналитику отправлялся дважды ивент о нажатии на кнопку. Проблема была в том что кнопка не блокировалась во всех случаях