### PR TITLE
IOS-2918 Fix analytics binding

### DIFF
--- a/Tangem/Modules/Onboarding/BaseModels/OnboardingViewModel.swift
+++ b/Tangem/Modules/Onboarding/BaseModels/OnboardingViewModel.swift
@@ -278,9 +278,10 @@ class OnboardingViewModel<Step: OnboardingStep, Coordinator: OnboardingRoutable>
     private func bindAnalytics() {
         $currentStepIndex
             .removeDuplicates()
-            .combineLatest($steps)
-            .receiveValue { index, steps in
-                guard index < steps.count else { return }
+            .delay(for: 0.1, scheduler: DispatchQueue.main)
+            .receiveValue { [weak self] index in
+                guard let steps = self?.steps,
+                      index < steps.count else { return }
 
                 let currentStep = steps[index]
 


### PR DESCRIPTION
Проблема в том, что combineLatest присылает два ивента. Задержка решает и проблему с паблишед и проблему, если меняются и steps и index, как в случае с режектом по KYC