### PR TITLE
IOS-2843 av capture session on main thread

### DIFF
--- a/Tangem/Modules/Send/QRScannerView.swift
+++ b/Tangem/Modules/Send/QRScannerView.swift
@@ -125,11 +125,6 @@ extension UIQRScannerView {
         return captureSession?.isRunning ?? false
     }
 
-    func startScanning() {
-        feedbackGenerator?.prepare()
-        captureSession?.startRunning()
-    }
-
     func stopScanning() {
         captureSession?.stopRunning()
         delegate?.qrScanningDidStop()
@@ -188,7 +183,9 @@ extension UIQRScannerView {
         layer.session = captureSession
         layer.videoGravity = .resizeAspectFill
 
-        captureSession?.startRunning()
+        DispatchQueue.global(qos: .userInitiated).async {
+            self.captureSession?.startRunning()
+        }
     }
 
     func scanningDidFail() {


### PR DESCRIPTION
On iOS 16 shows alert that you shouldn't start AVCaptureSession, because it can cause UI unresponsiveness and it should start from background thread. Now we have small delay between modal screen appearance on screen and camera start. I think this delay is acceptable.
Also remove not used function.