### PR TITLE
IOS-2862: Update wallet balance before send tx

### DIFF
--- a/Tangem/Modules/Send/SendViewModel.swift
+++ b/Tangem/Modules/Send/SendViewModel.swift
@@ -641,7 +641,12 @@ class SendViewModel: ObservableObject {
         appDelegate.addLoadingView()
 
         let isDemo = walletModel.isDemo
-        walletModel.send(tx, signer: cardViewModel.signer)
+        walletModel.update(silent: true)
+            .flatMap { [weak self] _ -> AnyPublisher<Void, Error> in
+                guard let self else { return .justWithError(output: ()) }
+
+                return self.walletModel.send(tx, signer: self.cardViewModel.signer)
+            }
             .sink(receiveCompletion: { [weak self] completion in
                 guard let self = self else { return }
 


### PR DESCRIPTION
Проблема:
В некоторых специфичных случаях у пользователя перед отправкой транзакции может оказаться неверный nonce (для эфироподобных сетей) или же другой подобный показатель (sequence для XRP, например), который зависит от количества транзакций по адресу. Например появилась входящая транзакция и уже прошла успешно.
Решение: кейс довольно специфический, но такого решения должно быть достаточно. Если пользователю пришли новые деньги, то транзакция у нас уже готова и новый инпут ни на что толком не повлияет. Если же у пользователя не хватало денег и он перевел сам себе денежку, то у него в любом случае кнопка отправки была заблокирована и транзакции готовой не было.
Обсуждали это с Саней Осокиным, вроде должно покрыть все кейсы, будем наблюдать 