### PR TITLE
IOS-2741: Remove default gas limit

### DIFF
--- a/Tangem/Common/UI/ExchangeComponets/SendCurrencyView/SendCurrencyViewModel.swift
+++ b/Tangem/Common/UI/ExchangeComponets/SendCurrencyView/SendCurrencyViewModel.swift
@@ -44,7 +44,7 @@ struct SendCurrencyViewModel: Identifiable {
         self.canChangeCurrency = canChangeCurrency
         self.tokenIcon = tokenIcon
     }
-    
+
     func textFieldDidTapped() {
         Analytics.log(.swapSendTokenBalanceClicked)
     }


### PR DESCRIPTION
Error must be thrown if gas limit wasn't loaded. Discussed with Mr. Osokin