### PR TITLE
IOS-3006 Passing warning sign symbol as a parameter

### DIFF
--- a/Tangem/App/Services/WarningsService/Warnings/WarningEvent+.swift
+++ b/Tangem/App/Services/WarningsService/Warnings/WarningEvent+.swift
@@ -50,7 +50,7 @@ fileprivate enum WarningsList {
     static let numberOfSignedHashesIncorrect = AppWarning(title: warningTitle, message: Localization.alertCardSignedTransactions, priority: .info, type: .temporary, event: .numberOfSignedHashesIncorrect)
     static let rateApp = AppWarning(title: Localization.warningRateAppTitle, message: Localization.warningRateAppMessage, priority: .info, type: .temporary, event: .rateApp)
     static let failedToVerifyCard = AppWarning(title: Localization.warningFailedToVerifyCardTitle, message: Localization.warningFailedToVerifyCardMessage, priority: .critical, type: .permanent, event: .failedToValidateCard)
-    static let multiWalletSignedHashes = AppWarning(title: Localization.warningImportantSecurityInfo, message: Localization.warningSignedTxPreviously, priority: .info, type: .temporary, location: [.main], event: .multiWalletSignedHashes)
+    static let multiWalletSignedHashes = AppWarning(title: Localization.warningImportantSecurityInfo("\u{26A0}"), message: Localization.warningSignedTxPreviously, priority: .info, type: .temporary, location: [.main], event: .multiWalletSignedHashes)
     static let testnetCard = AppWarning(title: warningTitle, message: Localization.warningTestnetCardMessage, priority: .critical, type: .permanent, location: [.main, .send], event: .testnetCard)
     static let demoCard = AppWarning(title: warningTitle, message: Localization.alertDemoMessage, priority: .critical, type: .permanent, location: [.main, .send], event: .demoCard)
     static let legacyDerivation = AppWarning(title: warningTitle, message: Localization.alertManageTokensAddressesMessage, priority: .critical, type: .permanent, location: [.manageTokens], event: .legacyDerivation)

--- a/Tangem/Resources/Localizations/de.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/de.lproj/Localizable.strings
@@ -475,7 +475,7 @@
 "warning_existential_deposit_message" = "%1$@ network has a concept of Existential Deposit. If your account drops below %2$@ it will be deactivated and any remaining funds will be destroyed.";
 "warning_failed_to_verify_card_message" = "This card might be a production sample or counterfeit";
 "warning_failed_to_verify_card_title" = "Authenticity check failed";
-"warning_important_security_info" = "Important security information \U26A0";
+"warning_important_security_info" = "Important security information %@";
 "warning_low_signatures_format" = "There are only %@ signatures available on this card. You must withdraw all of your funds.";
 "warning_rate_app_message" = "How do you like Tangem?";
 "warning_rate_app_title" = "One question";

--- a/Tangem/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/en.lproj/Localizable.strings
@@ -475,7 +475,7 @@
 "warning_existential_deposit_message" = "%1$@ network has a concept of Existential Deposit. If your account drops below %2$@ it will be deactivated and any remaining funds will be destroyed.";
 "warning_failed_to_verify_card_message" = "This card might be a production sample or counterfeit";
 "warning_failed_to_verify_card_title" = "Authenticity check failed";
-"warning_important_security_info" = "Important security information \U26A0";
+"warning_important_security_info" = "Important security information %@";
 "warning_low_signatures_format" = "There are only %@ signatures available on this card. You must withdraw all of your funds.";
 "warning_rate_app_message" = "How do you like Tangem?";
 "warning_rate_app_title" = "One question";

--- a/Tangem/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/fr.lproj/Localizable.strings
@@ -475,7 +475,7 @@
 "warning_existential_deposit_message" = "%1$@ network has a concept of Existential Deposit. If your account drops below %2$@ it will be deactivated and any remaining funds will be destroyed.";
 "warning_failed_to_verify_card_message" = "This card might be a production sample or counterfeit";
 "warning_failed_to_verify_card_title" = "Authenticity check failed";
-"warning_important_security_info" = "Important security information \U26A0";
+"warning_important_security_info" = "Important security information %@";
 "warning_low_signatures_format" = "There are only %@ signatures available on this card. You must withdraw all of your funds.";
 "warning_rate_app_message" = "How do you like Tangem?";
 "warning_rate_app_title" = "One question";

--- a/Tangem/Resources/Localizations/it.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/it.lproj/Localizable.strings
@@ -475,7 +475,7 @@
 "warning_existential_deposit_message" = "%1$@ network has a concept of Existential Deposit. If your account drops below %2$@ it will be deactivated and any remaining funds will be destroyed.";
 "warning_failed_to_verify_card_message" = "This card might be a production sample or counterfeit";
 "warning_failed_to_verify_card_title" = "Authenticity check failed";
-"warning_important_security_info" = "Important security information \U26A0";
+"warning_important_security_info" = "Important security information %@";
 "warning_low_signatures_format" = "There are only %@ signatures available on this card. You must withdraw all of your funds.";
 "warning_rate_app_message" = "How do you like Tangem?";
 "warning_rate_app_title" = "One question";

--- a/Tangem/Resources/Localizations/ru.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/ru.lproj/Localizable.strings
@@ -475,7 +475,7 @@
 "warning_existential_deposit_message" = "Сеть %1$@ использует концепцию экзистенциального депозита. Если баланс вашего счета опустится ниже %2$@, он будет деактивирован, а все оставшиеся средства будут уничтожены.";
 "warning_failed_to_verify_card_message" = "Эта карта может быть производственным образцом или подделкой";
 "warning_failed_to_verify_card_title" = "Проверка подлинности не удалась";
-"warning_important_security_info" = "Важная информация о безопасности \U26A0";
+"warning_important_security_info" = "Важная информация о безопасности %@";
 "warning_low_signatures_format" = "На этой карте осталось только %@ подписей. Вы должны вывести все свои средства.";
 "warning_rate_app_message" = "Как вам Tangem?";
 "warning_rate_app_title" = "Один вопрос";

--- a/Tangem/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -475,7 +475,7 @@
 "warning_existential_deposit_message" = "%1$@ 網絡有一個 Existential Deposit 的概念。如果您的帳戶低於 %2$@，它將被停用，所有剩餘資金將被銷毀";
 "warning_failed_to_verify_card_message" = "此卡可能是生產樣本或偽造品";
 "warning_failed_to_verify_card_title" = "認證檢查失敗";
-"warning_important_security_info" = "重要安全信息\U26A0";
+"warning_important_security_info" = "重要安全信息 %@";
 "warning_low_signatures_format" = "此卡上只有 %@ 個簽名可用。您必須提取所有資金";
 "warning_rate_app_message" = "你喜歡 Tangem 嗎？";
 "warning_rate_app_title" = "一個問題";


### PR DESCRIPTION
Из-за различий написания юникод-символов с андроидом пришлось вынести его из локалайза