### PR TITLE
Ios 3017 swift UI compiler generated line 2147483647

### DIFF
--- a/Tangem/Modules/Welcome/Stories/StoriesViewModel.swift
+++ b/Tangem/Modules/Welcome/Stories/StoriesViewModel.swift
@@ -148,7 +148,7 @@ class StoriesViewModel: ObservableObject {
         let progress = elapsedTime / currentPage.duration
 
         timerSubscription = nil
-        
+
         withAnimation(.linear(duration: 0)) { [weak self] in
             self?.currentProgress = progress
         }

--- a/Tangem/Modules/Welcome/WelcomeView.swift
+++ b/Tangem/Modules/Welcome/WelcomeView.swift
@@ -36,8 +36,6 @@ struct WelcomeView: View {
                     orderCard: viewModel.orderCard,
                     searchTokens: viewModel.openTokensList
                 )
-            } else {
-                EmptyView()
             }
         }
         .statusBar(hidden: true)

--- a/Tangem/Modules/Welcome/WelcomeView.swift
+++ b/Tangem/Modules/Welcome/WelcomeView.swift
@@ -28,13 +28,17 @@ struct WelcomeView: View {
     }
 
     var storiesView: some View {
-        StoriesView(viewModel: viewModel.storiesModel) { // TODO: refactor
-            viewModel.storiesModel.currentStoryPage(
-                isScanning: viewModel.isScanningCard,
-                scanCard: viewModel.scanCardTapped,
-                orderCard: viewModel.orderCard,
-                searchTokens: viewModel.openTokensList
-            )
+        StoriesView(viewModel: viewModel.storiesModel) { [weak viewModel] in
+            if let viewModel = viewModel {
+                viewModel.storiesModel.currentStoryPage(
+                    isScanning: viewModel.isScanningCard,
+                    scanCard: viewModel.scanCardTapped,
+                    orderCard: viewModel.orderCard,
+                    searchTokens: viewModel.openTokensList
+                )
+            } else {
+                EmptyView()
+            }
         }
         .statusBar(hidden: true)
         .environment(\.colorScheme, viewModel.storiesModel.currentPage.colorScheme)


### PR DESCRIPTION
Фикс по самому популярному крашу фаербейза.

1   libsystem_pthread.dylib        0x2a9c pthread_kill + 272
2   libsystem_c.dylib              0x77b84 abort + 124
3   libswiftCore.dylib             0x380fc4 swift_vasprintf(char**, char const*, char*) + 58
4   libswiftCore.dylib             0x38111c swift::swift_abortRetainUnowned(void const*) + 36
5   libswiftCore.dylib             0x3bf280 swift_unknownObjectUnownedTakeStrong + 74
6   SwiftUI                        0x4eb084 ViewGraph.graphDelegate.getter + 16

<compiler-generated> - Line 4368122812
partial apply for implicit closure #6 in implicit closure #5 in WelcomeView.body.getter + 4368122812

На что пришлось обратить внимание:

Сбегающее замыкание в классе, которое сильно захвает viewModel в кложуре. Добавил ViewModel в capture list как weak, будем наблюдать дальше.

Особенность краша: только iOS 14я