### PR TITLE
IOS-3072 Added a hack to force the Kingfisher implementation in Manage Tokens

### DIFF
--- a/Tangem/Common/UI/IconView/IconView.swift
+++ b/Tangem/Common/UI/IconView/IconView.swift
@@ -17,7 +17,7 @@ struct IconView: View {
     // TODO: on 16.2 on the first run of the first time this screen is opened
     private let forceKingfisher: Bool
 
-    init(url: URL?, size: CGSize = CGSize(width: 36, height: 36), forceKingfisher: Bool = false) {
+    init(url: URL?, size: CGSize = CGSize(width: 36, height: 36), forceKingfisher: Bool = true) {
         self.url = url
         self.size = size
         self.forceKingfisher = forceKingfisher

--- a/Tangem/Common/UI/IconView/IconView.swift
+++ b/Tangem/Common/UI/IconView/IconView.swift
@@ -17,7 +17,7 @@ struct IconView: View {
     // TODO: on 16.2 on the first run of the first time this screen is opened
     private let forceKingfisher: Bool
 
-    init(url: URL?, size: CGSize = CGSize(width: 36, height: 36), forceKingfisher: Bool = true) {
+    init(url: URL?, size: CGSize = CGSize(width: 36, height: 36), forceKingfisher: Bool = false) {
         self.url = url
         self.size = size
         self.forceKingfisher = forceKingfisher

--- a/Tangem/Common/UI/IconView/IconView.swift
+++ b/Tangem/Common/UI/IconView/IconView.swift
@@ -13,13 +13,18 @@ struct IconView: View {
     private let url: URL?
     private let size: CGSize
 
-    init(url: URL?, size: CGSize = CGSize(width: 36, height: 36)) {
+    // TODO: HACK - figure out why CachedAsyncImage is making Manage Tokens screen jump
+    // TODO: on 16.2 on the first run of the first time this screen is opened
+    private let forceKingfisher: Bool
+
+    init(url: URL?, size: CGSize = CGSize(width: 36, height: 36), forceKingfisher: Bool = false) {
         self.url = url
         self.size = size
+        self.forceKingfisher = forceKingfisher
     }
 
     var body: some View {
-        if #available(iOS 15.0, *) {
+        if #available(iOS 15.0, *), !forceKingfisher {
             cachedAsyncImage
         } else {
             kfImage

--- a/Tangem/Modules/TokenList/CoinView.swift
+++ b/Tangem/Modules/TokenList/CoinView.swift
@@ -19,7 +19,7 @@ struct CoinView: View {
     var body: some View {
         VStack(spacing: 10) {
             HStack(spacing: 0) {
-                IconView(url: model.imageURL, size: CGSize(width: iconWidth, height: iconWidth))
+                IconView(url: model.imageURL, size: CGSize(width: iconWidth, height: iconWidth), forceKingfisher: true)
                     .padding(.trailing, 14)
 
                 VStack(alignment: .leading, spacing: 6) {


### PR DESCRIPTION
На 16.2 при первом запуске приложения, первом открытии manage tokens и при отображении результатов поиска дергались ячейки. Методом тыка дошел до реализации замены кингфишера, которую Серега добавлял — проблема в ней, проверил раз 10. Баг гарантированно воспроизводится с ней, и гарантированно не воспроизводится со старым добрым кингфишером. 

Эта реализация решала проблемы в свапалке, поэтому убрал ее только в Manage Tokens — https://github.com/tangem/tangem-app-ios/pull/1241