### PR TITLE
IOS-3033 Refactor total balance

### DIFF
--- a/Tangem/Common/Extensions/Decimal+.swift
+++ b/Tangem/Common/Extensions/Decimal+.swift
@@ -36,7 +36,7 @@ extension Decimal {
         return formatter.string(from: self as NSDecimalNumber) ?? "\(self)"
     }
 
-    func decimalSeparator() -> String {
+    static func decimalSeparator() -> String {
         let formatter = NumberFormatter()
         formatter.locale = Locale.current
         formatter.numberStyle = .currency

--- a/Tangem/Modules/Main/TotalSumBalance/TotalSumBalanceView.swift
+++ b/Tangem/Modules/Main/TotalSumBalance/TotalSumBalanceView.swift
@@ -40,6 +40,8 @@ struct TotalSumBalanceView: View {
             .padding(.bottom, 4)
 
             balanceView
+
+            messageView
         }
     }
 
@@ -55,6 +57,16 @@ struct TotalSumBalanceView: View {
                     .style(Fonts.Regular.footnote, color: Colors.Text.tertiary)
                     .layoutPriority(1)
             }
+        }
+    }
+
+    @ViewBuilder
+    private var messageView: some View {
+        if viewModel.hasError {
+            Text(Localization.mainProcessingFullAmount)
+                .foregroundColor(Color.tangemWarning)
+                .font(.system(size: 13, weight: .regular))
+                .padding(.top, 2)
         }
     }
 }

--- a/Tangem/Modules/Send/SendViewModel.swift
+++ b/Tangem/Modules/Send/SendViewModel.swift
@@ -650,7 +650,7 @@ class SendViewModel: ObservableObject {
 
         let isDemo = walletModel.isDemo
 
-        //TODO: refactor
+        // TODO: refactor
         let walletUpdatePublisher = walletModel
             .$state
             .tryMap { state -> WalletModel.State in

--- a/Tangem/Modules/UserWalletList/UserWalletListCellViewModel.swift
+++ b/Tangem/Modules/UserWalletList/UserWalletListCellViewModel.swift
@@ -89,7 +89,7 @@ class UserWalletListCellViewModel: ObservableObject {
                     self.hasError = false
                 case .loaded(let value):
                     self.isBalanceLoading = false
-                    self.balance = value.balance.currencyFormatted(code: value.currencyCode)
+                    self.balance = value.balanceFormatted
                     self.hasError = value.hasError
                 }
             }

--- a/Tangem/Resources/Localizations/de.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/de.lproj/Localizable.strings
@@ -146,6 +146,7 @@
 "main_no_backup_warning_subtitle" = "To protect your assets, we advise you to carry out this procedure";
 "main_no_backup_warning_title" = "Your wallet has not been backed up";
 "main_page_balance" = "Total balance";
+"main_processing_full_amount" = "The amount does not include some of your funds";
 "main_scan_card_warning_view_subtitle" = "To access all the networks you need to scan the card";
 "main_scan_card_warning_view_title" = "Scan your card";
 "main_tokens" = "Tokens";

--- a/Tangem/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/en.lproj/Localizable.strings
@@ -146,6 +146,7 @@
 "main_no_backup_warning_subtitle" = "To protect your assets, we advise you to carry out this procedure";
 "main_no_backup_warning_title" = "Your wallet has not been backed up";
 "main_page_balance" = "Total balance";
+"main_processing_full_amount" = "The amount does not include some of your funds";
 "main_scan_card_warning_view_subtitle" = "To access all the networks you need to scan the card";
 "main_scan_card_warning_view_title" = "Scan your card";
 "main_tokens" = "Tokens";

--- a/Tangem/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/fr.lproj/Localizable.strings
@@ -146,6 +146,7 @@
 "main_no_backup_warning_subtitle" = "To protect your assets, we advise you to carry out this procedure";
 "main_no_backup_warning_title" = "Your wallet has not been backed up";
 "main_page_balance" = "Total balance";
+"main_processing_full_amount" = "The amount does not include some of your funds";
 "main_scan_card_warning_view_subtitle" = "To access all the networks you need to scan the card";
 "main_scan_card_warning_view_title" = "Scan your card";
 "main_tokens" = "Tokens";

--- a/Tangem/Resources/Localizations/it.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/it.lproj/Localizable.strings
@@ -146,6 +146,7 @@
 "main_no_backup_warning_subtitle" = "To protect your assets, we advise you to carry out this procedure";
 "main_no_backup_warning_title" = "Your wallet has not been backed up";
 "main_page_balance" = "Total balance";
+"main_processing_full_amount" = "The amount does not include some of your funds";
 "main_scan_card_warning_view_subtitle" = "To access all the networks you need to scan the card";
 "main_scan_card_warning_view_title" = "Scan your card";
 "main_tokens" = "Tokens";

--- a/Tangem/Resources/Localizations/ru.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/ru.lproj/Localizable.strings
@@ -146,6 +146,7 @@
 "main_no_backup_warning_subtitle" = "Чтобы защитить свои активы, мы советуем вам выполнить эту процедуру";
 "main_no_backup_warning_title" = "Бэкап кошелька не был произведен";
 "main_page_balance" = "Баланс";
+"main_processing_full_amount" = "В сумме учтены не все монеты";
 "main_scan_card_warning_view_subtitle" = "Чтобы получить доступ ко всем сетям, вам необходимо отсканировать карту";
 "main_scan_card_warning_view_title" = "Отсканируйте карту";
 "main_tokens" = "Токены";

--- a/Tangem/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -146,6 +146,7 @@
 "main_no_backup_warning_subtitle" = "為了保護您的資產，我們建議您執行此程序";
 "main_no_backup_warning_title" = "您的錢包尚未備份";
 "main_page_balance" = "總餘額";
+"main_processing_full_amount" = "該金額不包括您的部分資金";
 "main_scan_card_warning_view_subtitle" = "要訪問所有的網路您需要掃描卡片";
 "main_scan_card_warning_view_title" = "掃描卡片";
 "main_tokens" = "代幣";


### PR DESCRIPTION
Привел тотал в соответствие новым требованиям. Вынес общий код из вьюмодели, чтобы не расходилось поведение с MyWallets
Теперь работает так:
- если не смогли загрузить тотал из-за ошибки или отсутствия деривации - пишем прочерк
- если не смогли загрузить из-за кастомного токена - то пишем баланс с предупреждением как раньше, в шторке иконка желтая