### PR TITLE
IOS-3109 Refactor the app's start

### DIFF
--- a/Tangem/App/Services/UserWalletRepository/CommonUserWalletRepository.swift
+++ b/Tangem/App/Services/UserWalletRepository/CommonUserWalletRepository.swift
@@ -595,6 +595,7 @@ extension CommonUserWalletRepository {
     func initialize() {
         // Removing UserWallet-related data from Keychain
         if AppSettings.shared.numberOfLaunches == 1 {
+            AppLog.shared.debug("Clean CommonUserWalletRepository")
             clearUserWallets()
         }
 

--- a/Tangem/App/Services/UserWalletRepository/UserWalletRepositoryUtil.swift
+++ b/Tangem/App/Services/UserWalletRepository/UserWalletRepositoryUtil.swift
@@ -34,6 +34,7 @@ class UserWalletRepositoryUtil {
     func savedUserWallets(encryptionKeyByUserWalletId: [Data: SymmetricKey]) -> [UserWallet] {
         do {
             guard fileManager.fileExists(atPath: userWalletListPath().path) else {
+                AppLog.shared.debug("Detected empty saved user wallets")
                 return []
             }
 
@@ -108,6 +109,7 @@ class UserWalletRepositoryUtil {
                 try sensitiveDataEncoded.write(to: sensitiveDataPath, options: .atomic)
                 try excludeFromBackup(url: sensitiveDataPath)
             }
+            AppLog.shared.debug("User wallets were saved successfully")
         } catch {
             AppLog.shared.debug("Failed to save user wallets")
             AppLog.shared.error(error)

--- a/Tangem/App/ServicesManager.swift
+++ b/Tangem/App/ServicesManager.swift
@@ -8,6 +8,9 @@
 
 import Foundation
 import Combine
+import Firebase
+import AppsFlyerLib
+import Amplitude
 
 class ServicesManager {
     @Injected(\.exchangeService) private var exchangeService: ExchangeService
@@ -17,9 +20,53 @@ class ServicesManager {
     private var bag = Set<AnyCancellable>()
 
     func initialize() {
+        AppLog.shared.configure()
+
+        if !AppEnvironment.current.isDebug {
+            configureFirebase()
+            configureAppsFlyer()
+            configureAmplitude()
+        }
+
+        let currentLaunches = AppSettings.shared.numberOfLaunches + 1
+        AppSettings.shared.numberOfLaunches = currentLaunches
+        AppLog.shared.debug("Current launches: \(currentLaunches)")
+        S2CTOUMigrator().migrate()
+
         exchangeService.initialize()
         tangemApiService.initialize()
         userWalletRepository.initialize()
+    }
+
+    private func configureFirebase() {
+        let plistName = "GoogleService-Info-\(AppEnvironment.current.rawValue.capitalizingFirstLetter())"
+
+        guard let filePath = Bundle.main.path(forResource: plistName, ofType: "plist"),
+              let options = FirebaseOptions(contentsOfFile: filePath) else {
+            assertionFailure("GoogleService-Info.plist not found")
+            return
+        }
+
+        FirebaseApp.configure(options: options)
+    }
+
+    private func configureAppsFlyer() {
+        guard AppEnvironment.current.isProduction else {
+            return
+        }
+
+        do {
+            let keysManager = try CommonKeysManager()
+            AppsFlyerLib.shared().appsFlyerDevKey = keysManager.appsFlyer.appsFlyerDevKey
+            AppsFlyerLib.shared().appleAppID = keysManager.appsFlyer.appsFlyerAppID
+        } catch {
+            assertionFailure("CommonKeysManager not initialized with error: \(error.localizedDescription)")
+        }
+    }
+
+    private func configureAmplitude() {
+        Amplitude.instance().trackingSessionEvents = true
+        Amplitude.instance().initializeApiKey(try! CommonKeysManager().amplitudeApiKey)
     }
 }
 

--- a/Tangem/AppDelegate.swift
+++ b/Tangem/AppDelegate.swift
@@ -7,9 +7,7 @@
 //
 
 import UIKit
-import Firebase
 import AppsFlyerLib
-import Amplitude
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -35,7 +33,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        AppLog.shared.configure()
         // Override point for customization after application launch.
         UISwitch.appearance().onTintColor = .tangemBlue
         UITableView.appearance().backgroundColor = .clear
@@ -56,14 +53,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             ]
         }
 
-        if !AppEnvironment.current.isDebug {
-            configureFirebase()
-            configureAppsFlyer()
-            configureAmplitude()
-        }
-
-        AppSettings.shared.numberOfLaunches += 1
-        S2CTOUMigrator().migrate()
         return true
     }
 
@@ -79,38 +68,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         guard AppEnvironment.current.isProduction else { return }
 
         AppsFlyerLib.shared().start()
-    }
-}
-
-private extension AppDelegate {
-    func configureFirebase() {
-        let plistName = "GoogleService-Info-\(AppEnvironment.current.rawValue.capitalizingFirstLetter())"
-
-        guard let filePath = Bundle.main.path(forResource: plistName, ofType: "plist"),
-              let options = FirebaseOptions(contentsOfFile: filePath) else {
-            assertionFailure("GoogleService-Info.plist not found")
-            return
-        }
-
-        FirebaseApp.configure(options: options)
-    }
-
-    func configureAppsFlyer() {
-        guard AppEnvironment.current.isProduction else {
-            return
-        }
-
-        do {
-            let keysManager = try CommonKeysManager()
-            AppsFlyerLib.shared().appsFlyerDevKey = keysManager.appsFlyer.appsFlyerDevKey
-            AppsFlyerLib.shared().appleAppID = keysManager.appsFlyer.appsFlyerAppID
-        } catch {
-            assertionFailure("CommonKeysManager not initialized with error: \(error.localizedDescription)")
-        }
-    }
-
-    func configureAmplitude() {
-        Amplitude.instance().trackingSessionEvents = true
-        Amplitude.instance().initializeApiKey(try! CommonKeysManager().amplitudeApiKey)
     }
 }

--- a/Tangem/Modules/App/AppCoordinator.swift
+++ b/Tangem/Modules/App/AppCoordinator.swift
@@ -29,7 +29,9 @@ class AppCoordinator: CoordinatorObject {
     private let servicesManager: ServicesManager = .init()
     private var bag: Set<AnyCancellable> = []
 
-    init() {
+    init() {}
+
+    func initialize() {
         servicesManager.initialize()
         bind()
     }

--- a/Tangem/SceneDelegate.swift
+++ b/Tangem/SceneDelegate.swift
@@ -16,9 +16,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-    private let appCoordinator: AppCoordinator = .init()
+    private lazy var appCoordinator: AppCoordinator = .init()
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        appCoordinator.initialize()
+
         if !handleUrlContexts(connectionOptions.urlContexts) {
             handleActivities(connectionOptions.userActivities)
         }


### PR DESCRIPTION
Проблема была в том, что на продакшен сборках из TF, код инициализации сервисов вызывался раньше, чем didFinishLaunching у AppDelegate. Он лежал в конструторе AppCoordinator, который лежал как проперти в SceneDelegate. В сборках из икскода все ок даже с оптимизацией.

- перенес все инициализации в ServicesManager
- перенес вызов инициализаций из конструктора AppCoordinator  в метод, чтобы было более явно
- дополнительно сделал AppCoordinator lazy, чтобы никак не влиял на скорость запуска приложения.
- добавил логов, благодаря которым и вычислил проблему