### PR TITLE
IOS-3115 Crashfix on init

### DIFF
--- a/Tangem/AppDelegate.swift
+++ b/Tangem/AppDelegate.swift
@@ -13,6 +13,8 @@ import AppsFlyerLib
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var loadingView: UIView?
 
+    private lazy var servicesManager = ServicesManager()
+
     func addLoadingView() {
         if let window = UIApplication.shared.windows.first(where: { $0.isKeyWindow }) {
             let view = UIView(frame: window.bounds)
@@ -53,6 +55,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             ]
         }
 
+        servicesManager.initialize()
         return true
     }
 

--- a/Tangem/Modules/App/AppCoordinator.swift
+++ b/Tangem/Modules/App/AppCoordinator.swift
@@ -26,13 +26,9 @@ class AppCoordinator: CoordinatorObject {
 
     // MARK: - Private
 
-    private let servicesManager: ServicesManager = .init()
     private var bag: Set<AnyCancellable> = []
 
-    init() {}
-
-    func initialize() {
-        servicesManager.initialize()
+    init() {
         bind()
     }
 

--- a/Tangem/SceneDelegate.swift
+++ b/Tangem/SceneDelegate.swift
@@ -16,11 +16,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-    private lazy var appCoordinator: AppCoordinator = {
-        let coordinator = AppCoordinator()
-        coordinator.initialize()
-        return coordinator
-    }()
+    private lazy var appCoordinator = AppCoordinator()
 
     // This method can be called during app close, so we have to move out the one-time initialization code outside.
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {


### PR DESCRIPTION
Перенес инициализацию сервисов из координатора в единственное стабильное место в аппке - AppDelegate, даже как-бужто и правильнее, чем держать код в координаторе