### PR TITLE
IOS-3070 swap high price impact issues

### DIFF
--- a/Tangem/Modules/Swapping/SwappingViewModel.swift
+++ b/Tangem/Modules/Swapping/SwappingViewModel.swift
@@ -103,8 +103,7 @@ final class SwappingViewModel: ObservableObject {
 
     func userDidTapMaxAmount() {
         let sourceBalance = exchangeManager.getExchangeItems().sourceBalance
-        sendDecimalValue = .external(sourceBalance)
-        pendingValidatingAmount = sourceBalance
+        setupExternalSendValue(sourceBalance)
     }
 
     func userDidRequestChangeDestination(to currency: Currency) {
@@ -137,8 +136,7 @@ final class SwappingViewModel: ObservableObject {
         // If amount have been set we'll should to round and update it with new decimalCount
         if let amount = sendDecimalValue?.value {
             let roundedAmount = amount.rounded(scale: items.source.decimalCount, roundingMode: .plain)
-            sendDecimalValue = .external(roundedAmount)
-            pendingValidatingAmount = roundedAmount
+            setupExternalSendValue(roundedAmount)
 
             exchangeManager.update(amount: roundedAmount)
         }
@@ -178,6 +176,11 @@ final class SwappingViewModel: ObservableObject {
 
     func didTapWaringRefresh() {
         exchangeManager.refresh(type: .full)
+    }
+    
+    private func setupExternalSendValue(_ amount: Decimal) {
+        sendDecimalValue = .external(amount)
+        pendingValidatingAmount = amount
     }
 }
 
@@ -534,7 +537,7 @@ private extension SwappingViewModel {
             amount: sendDecimalValue
         )
 
-        let lossesInPercents = 100 - (destinationFiatAmount * 100) / sourceFiatAmount
+        let lossesInPercents = (1 - destinationFiatAmount / sourceFiatAmount) * 100
 
         await runOnMain {
             if lossesInPercents >= Constants.highPriceImpactWarningLimit {

--- a/Tangem/Modules/Swapping/SwappingViewModel.swift
+++ b/Tangem/Modules/Swapping/SwappingViewModel.swift
@@ -499,15 +499,23 @@ private extension SwappingViewModel {
             return
         }
 
+        if sendDecimalValue.isZero {
+            // No need to calculate price impact with zero input
+            await runOnMain {
+                highPriceImpactWarningRowViewModel = nil
+            }
+            return
+        }
+
         let sourceFiatAmount = try await fiatRatesProvider.getFiat(
             for: exchangeManager.getExchangeItems().source,
             amount: sendDecimalValue
         )
 
-        let lostInPercents = (sourceFiatAmount / destinationFiatAmount - 1) * 100
+        let lossesInPercents = 100 - (destinationFiatAmount * 100) / sourceFiatAmount
 
         await runOnMain {
-            if lostInPercents >= Constants.highPriceImpactWarningLimit {
+            if lossesInPercents >= Constants.highPriceImpactWarningLimit {
                 highPriceImpactWarningRowViewModel = DefaultWarningRowViewModel(
                     title: Localization.swappingHighPriceImpact,
                     subtitle: Localization.swappingHighPriceImpactDescription,

--- a/Tangem/Modules/Swapping/SwappingViewModel.swift
+++ b/Tangem/Modules/Swapping/SwappingViewModel.swift
@@ -260,6 +260,14 @@ extension SwappingViewModel: ExchangeManagerDelegate {
 // MARK: - View updates
 
 private extension SwappingViewModel {
+    func resetViews() {
+        refreshWarningRowViewModel = nil
+        feeWarningRowViewModel = nil
+        permissionInfoRowViewModel = nil
+        highPriceImpactWarningRowViewModel = nil
+        swapButtonIsLoading = false
+    }
+
     func updateView(exchangeItems: ExchangeItems) {
         updateSendView(exchangeItems: exchangeItems)
         updateReceiveView(exchangeItems: exchangeItems)
@@ -336,9 +344,7 @@ private extension SwappingViewModel {
 
         switch state {
         case .idle:
-            refreshWarningRowViewModel = nil
-            feeWarningRowViewModel = nil
-            permissionInfoRowViewModel = nil
+            resetViews()
 
             receiveCurrencyViewModel?.update(cryptoAmountState: .loaded(0))
             receiveCurrencyViewModel?.update(fiatAmountState: .loaded(0))
@@ -499,7 +505,7 @@ private extension SwappingViewModel {
             return
         }
 
-        if sendDecimalValue.isZero {
+        if sendDecimalValue.isZero || destinationFiatAmount.isZero {
             // No need to calculate price impact with zero input
             await runOnMain {
                 highPriceImpactWarningRowViewModel = nil
@@ -558,6 +564,7 @@ private extension SwappingViewModel {
             .removeDuplicates()
             .debounce(for: 1, scheduler: DispatchQueue.main)
             .sink { [weak self] amount in
+                self?.resetViews()
                 self?.exchangeManager.update(amount: amount)
                 self?.updateSendFiatValue()
             }

--- a/Tangem/Modules/Swapping/SwappingViewModel.swift
+++ b/Tangem/Modules/Swapping/SwappingViewModel.swift
@@ -510,7 +510,7 @@ private extension SwappingViewModel {
             return
         }
 
-        if sendDecimalValue.isZero || destinationFiatAmount.isZero {
+        if sendDecimalValue.isZero {
             // No need to calculate price impact with zero input
             await runOnMain {
                 highPriceImpactWarningRowViewModel = nil

--- a/Tangem/Modules/Swapping/SwappingViewModel.swift
+++ b/Tangem/Modules/Swapping/SwappingViewModel.swift
@@ -101,7 +101,9 @@ final class SwappingViewModel: ObservableObject {
     }
 
     func userDidTapMaxAmount() {
-        sendDecimalValue = .external(exchangeManager.getExchangeItems().sourceBalance)
+        let sourceBalance = exchangeManager.getExchangeItems().sourceBalance
+        sendDecimalValue = .external(sourceBalance)
+        pendingValidatingAmount = sourceBalance
     }
 
     func userDidRequestChangeDestination(to currency: Currency) {
@@ -135,6 +137,7 @@ final class SwappingViewModel: ObservableObject {
         if let amount = sendDecimalValue?.value {
             let roundedAmount = amount.rounded(scale: items.source.decimalCount, roundingMode: .plain)
             sendDecimalValue = .external(roundedAmount)
+            pendingValidatingAmount = roundedAmount
 
             exchangeManager.update(amount: roundedAmount)
         }
@@ -511,6 +514,7 @@ private extension SwappingViewModel {
         }
 
         if sendDecimalValue.isZero {
+            pendingValidatingAmount = nil
             // No need to calculate price impact with zero input
             await runOnMain {
                 highPriceImpactWarningRowViewModel = nil
@@ -535,6 +539,7 @@ private extension SwappingViewModel {
             } else {
                 highPriceImpactWarningRowViewModel = nil
             }
+            pendingValidatingAmount = nil
         }
     }
 

--- a/Tangem/Modules/Swapping/SwappingViewModel.swift
+++ b/Tangem/Modules/Swapping/SwappingViewModel.swift
@@ -66,6 +66,7 @@ final class SwappingViewModel: ObservableObject {
     // MARK: - Private
 
     private lazy var refreshDataTimer = Timer.publish(every: 1, on: .main, in: .common)
+    private var pendingValidatingAmount: Decimal?
     private var refreshDataTimerBag: AnyCancellable?
     private var bag: Set<AnyCancellable> = []
 
@@ -501,7 +502,11 @@ private extension SwappingViewModel {
     }
 
     func checkForHighPriceImpact(destinationFiatAmount: Decimal) async throws {
-        guard let sendDecimalValue = sendDecimalValue?.value else {
+        guard
+            let sendDecimalValue = sendDecimalValue?.value,
+            pendingValidatingAmount?.isEqual(to: sendDecimalValue) ?? false
+        else {
+            // Current send decimal value was changed during old update. We can ignore this check
             return
         }
 
@@ -564,6 +569,12 @@ private extension SwappingViewModel {
             .removeDuplicates()
             .debounce(for: 1, scheduler: DispatchQueue.main)
             .sink { [weak self] amount in
+                // TODO: Refactor send decimal value storage logic
+                // Currently sendDecimalValue is updating directly from UI
+                // but requesting update in exchange manager with 1 second delay.
+                // So when all necessary information already loaded in exchange manager
+                // we will face wrong send decimal value while checking high price impact.
+                self?.pendingValidatingAmount = amount
                 self?.resetViews()
                 self?.exchangeManager.update(amount: amount)
                 self?.updateSendFiatValue()

--- a/Tangem/Modules/Swapping/SwappingViewModel.swift
+++ b/Tangem/Modules/Swapping/SwappingViewModel.swift
@@ -66,6 +66,7 @@ final class SwappingViewModel: ObservableObject {
     // MARK: - Private
 
     private lazy var refreshDataTimer = Timer.publish(every: 1, on: .main, in: .common)
+    // TODO: Remove this variable and refactor Task cancellation in DefaultExchangeManager
     private var pendingValidatingAmount: Decimal?
     private var refreshDataTimerBag: AnyCancellable?
     private var bag: Set<AnyCancellable> = []

--- a/TangemExchange/Managers/DefaultExchangeManager.swift
+++ b/TangemExchange/Managers/DefaultExchangeManager.swift
@@ -106,6 +106,7 @@ extension DefaultExchangeManager: ExchangeManager {
 
     func refresh(type: ExchangeManagerRefreshType) {
         refreshTask?.cancel()
+        refreshTask = nil
         if let amount = amount, amount > 0 {
             refreshValues(refreshType: type)
         } else {

--- a/TangemExchange/Managers/DefaultExchangeManager.swift
+++ b/TangemExchange/Managers/DefaultExchangeManager.swift
@@ -19,9 +19,7 @@ class DefaultExchangeManager {
 
     // MARK: - Internal
 
-    private var availabilityState: ExchangeAvailabilityState = .idle {
-        didSet { delegate?.exchangeManager(self, didUpdate: availabilityState) }
-    }
+    private var availabilityState: ExchangeAvailabilityState = .idle
 
     private var exchangeItems: ExchangeItems {
         didSet { delegate?.exchangeManager(self, didUpdate: exchangeItems) }
@@ -149,6 +147,11 @@ private extension DefaultExchangeManager {
 private extension DefaultExchangeManager {
     func updateState(_ state: ExchangeAvailabilityState) {
         availabilityState = state
+        if Task.isCancelled {
+            // Task was cancelled so we don't need to update UI for staled refresh request
+            return
+        }
+        delegate?.exchangeManager(self, didUpdate: state)
     }
 }
 


### PR DESCRIPTION
Много проблем было с обновлением балансов, фи, получаемого значения и появление плашки о высоких потерях.

Добавил отмененные запущенных задач, чтобы не выполнять ненужные операции, а так же не проводить обновление UI по старым данным. @Balashov152 надо чтобы ты погонял у себя и проверил все ли соответствует старой логике.