### PR TITLE
Ios 3046 reduce balances

### DIFF
--- a/Tangem/Common/AppConstants.swift
+++ b/Tangem/Common/AppConstants.swift
@@ -18,4 +18,5 @@ enum AppConstants {
 
     static let messageForWalletID = "UserWalletID"
     static let messageForTokensKey = "TokensSymmetricKey"
+    static let maximumFractionDigitsForBalance = 8
 }

--- a/Tangem/Common/Extensions/Decimal+.swift
+++ b/Tangem/Common/Extensions/Decimal+.swift
@@ -24,16 +24,9 @@ extension Decimal {
         return formatter.string(from: self as NSDecimalNumber) ?? "\(self) \(code)"
     }
 
-    func groupedFormatted(
-        minimumFractionDigits: Int = 0,
-        maximumFractionDigits: Int = 8
-    ) -> String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.minimumFractionDigits = minimumFractionDigits
-        formatter.maximumFractionDigits = maximumFractionDigits
-
-        return formatter.string(from: self as NSDecimalNumber) ?? "\(self)"
+    func groupedFormatted(maximumFractionDigits: Int = 8) -> String {
+        let formatter = GroupedNumberFormatter(maximumFractionDigits: maximumFractionDigits)
+        return formatter.format(from: description)
     }
 
     static func decimalSeparator() -> String {

--- a/Tangem/Common/Extensions/Decimal+.swift
+++ b/Tangem/Common/Extensions/Decimal+.swift
@@ -24,7 +24,7 @@ extension Decimal {
         return formatter.string(from: self as NSDecimalNumber) ?? "\(self) \(code)"
     }
 
-    func groupedFormatted(maximumFractionDigits: Int = 8) -> String {
+    func groupedFormatted(maximumFractionDigits: Int = AppConstants.maximumFractionDigitsForBalance) -> String {
         let formatter = GroupedNumberFormatter(maximumFractionDigits: maximumFractionDigits)
         return formatter.format(from: description)
     }

--- a/Tangem/Common/UI/ExchangeComponets/ReceiveCurrencyView/ReceiveCurrencyViewModel.swift
+++ b/Tangem/Common/UI/ExchangeComponets/ReceiveCurrencyView/ReceiveCurrencyViewModel.swift
@@ -18,7 +18,7 @@ struct ReceiveCurrencyViewModel: Identifiable {
     let tokenIcon: SwappingTokenIconViewModel
 
     var balanceString: String? {
-        Localization.commonBalance((balance ?? 0).groupedFormatted())
+        Localization.commonBalance((balance ?? 0).groupedFormatted(maximumFractionDigits: 8))
     }
 
     var cryptoAmountFormatted: String {

--- a/Tangem/Common/UI/ExchangeComponets/ReceiveCurrencyView/ReceiveCurrencyViewModel.swift
+++ b/Tangem/Common/UI/ExchangeComponets/ReceiveCurrencyView/ReceiveCurrencyViewModel.swift
@@ -18,7 +18,7 @@ struct ReceiveCurrencyViewModel: Identifiable {
     let tokenIcon: SwappingTokenIconViewModel
 
     var balanceString: String? {
-        Localization.commonBalance((balance ?? 0).groupedFormatted(maximumFractionDigits: 8))
+        Localization.commonBalance((balance ?? 0).groupedFormatted())
     }
 
     var cryptoAmountFormatted: String {

--- a/Tangem/Common/UI/ExchangeComponets/SendCurrencyView/SendCurrencyViewModel.swift
+++ b/Tangem/Common/UI/ExchangeComponets/SendCurrencyView/SendCurrencyViewModel.swift
@@ -22,7 +22,7 @@ struct SendCurrencyViewModel: Identifiable {
     var balanceString: String {
         let balance = balance.value ?? 0
         return Localization.commonBalance(
-            balance.groupedFormatted(maximumFractionDigits: maximumFractionDigits)
+            balance.groupedFormatted(maximumFractionDigits: 8)
         )
     }
 

--- a/Tangem/Common/UI/ExchangeComponets/SendCurrencyView/SendCurrencyViewModel.swift
+++ b/Tangem/Common/UI/ExchangeComponets/SendCurrencyView/SendCurrencyViewModel.swift
@@ -21,9 +21,7 @@ struct SendCurrencyViewModel: Identifiable {
 
     var balanceString: String {
         let balance = balance.value ?? 0
-        return Localization.commonBalance(
-            balance.groupedFormatted(maximumFractionDigits: 8)
-        )
+        return Localization.commonBalance(balance.groupedFormatted())
     }
 
     var fiatValueString: String {

--- a/Tangem/Common/UI/SendGroupedNumberTextField/GroupedNumberFormatter.swift
+++ b/Tangem/Common/UI/SendGroupedNumberTextField/GroupedNumberFormatter.swift
@@ -51,7 +51,8 @@ struct GroupedNumberFormatter {
         return string
     }
 
-    func format(from value: Decimal) -> String {
+    /// Use it only for number without floating point
+    private func format(from value: Decimal) -> String {
         guard let string = numberFormatter.string(from: value as NSDecimalNumber) else {
             assertionFailure("number \(value) can not formatted")
             return "\(value)"

--- a/Tangem/Common/UI/SendGroupedNumberTextField/GroupedNumberFormatter.swift
+++ b/Tangem/Common/UI/SendGroupedNumberTextField/GroupedNumberFormatter.swift
@@ -21,6 +21,7 @@ struct GroupedNumberFormatter {
     ) {
         self.numberFormatter = numberFormatter
 
+        numberFormatter.roundingMode = .down
         numberFormatter.numberStyle = .decimal
         numberFormatter.minimumFractionDigits = 0 // Just for case
         numberFormatter.maximumFractionDigits = maximumFractionDigits

--- a/Tangem/Common/UI/SendGroupedNumberTextField/GroupedNumberTextField.swift
+++ b/Tangem/Common/UI/SendGroupedNumberTextField/GroupedNumberTextField.swift
@@ -45,7 +45,7 @@ struct GroupedNumberTextField: View {
                 case .external(let value):
                     // If the decimalValue did updated from external place
                     // We have to update the private values
-                    let formattedNewValue = groupedNumberFormatter.format(from: value)
+                    let formattedNewValue = groupedNumberFormatter.format(from: value.description)
                     updateValues(with: formattedNewValue)
                 }
             }


### PR DESCRIPTION
- NSNumber сокращает кол-во знаков после запятой до 13 штук
Все решил делать через GroupedNumberFormatter, там если логика отдельного форматирования целого и дробного