### PR TITLE
IOS-3075: Display not only WC error but also network errors

### DIFF
--- a/Tangem/App/Services/WalletConnect/WalletConnectV1Service/WalletConnectV1Service.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV1Service/WalletConnectV1Service.swift
@@ -130,14 +130,11 @@ class WalletConnectV1Service {
 
         AppLog.shared.error(error: error, params: action.map { [.walletConnectAction: $0.rawValue] } ?? [:])
 
-        if let wcError = error as? WalletConnectServiceError {
-            switch wcError {
-            case .switchChainNotSupported:
-                break
-            default:
-                AppPresenter.shared.show(WalletConnectUIBuilder.makeErrorAlert(error), delay: delay)
-            }
+        if let wcError = error as? WalletConnectServiceError, case .switchChainNotSupported = wcError {
+            return
         }
+
+        AppPresenter.shared.show(WalletConnectUIBuilder.makeErrorAlert(error), delay: delay)
     }
 
     private func resetSessionConnectTimer() {


### PR DESCRIPTION
пока что добавил вывод не только WC ошибок, но и сетевых, которые могут возникнуть после успешной подписи транзакции. Правда логи все равно не будут полные, надо затащить полноценные логи в BlockchainSdk и подтюнить логирование в приложении. Но точно не в рамках этой задачи.