### PR TITLE
IOS-3134 Use simple placeholder for Manage Tokens IconView without skeleton

### DIFF
--- a/Tangem/Common/UI/IconView/IconView.swift
+++ b/Tangem/Common/UI/IconView/IconView.swift
@@ -65,7 +65,7 @@ struct IconView: View {
             .renderingMode(.original) // iOS 13 needs this to properly display an image inside a button label
             .cancelOnDisappear(true)
             .setProcessor(DownsamplingImageProcessor(size: size))
-            .placeholder { placeholder }
+            .placeholder { CircleImageTextView(name: "", color: .tangemSkeletonGray) }
             .fade(duration: 0.3)
             .cacheOriginalImage()
             .scaleFactor(UIScreen.main.scale)


### PR DESCRIPTION
Не на 100% уверен что в этом причина, но с этим фиксом у меня во всех случаях не было дергания, без фикса чаще были чем нет. Если убирать модификатор cacheOriginalImage у KFImage то чаще воспроизводилось