### PR TITLE
IOS-3046: Use decimal instead of decimal description

### DIFF
--- a/Tangem/Common/Extensions/Decimal+.swift
+++ b/Tangem/Common/Extensions/Decimal+.swift
@@ -26,7 +26,7 @@ extension Decimal {
 
     func groupedFormatted(maximumFractionDigits: Int = AppConstants.maximumFractionDigitsForBalance) -> String {
         let formatter = GroupedNumberFormatter(maximumFractionDigits: maximumFractionDigits)
-        return formatter.format(from: description)
+        return formatter.format(self)
     }
 
     static func decimalSeparator() -> String {

--- a/Tangem/Common/UI/SendGroupedNumberTextField/GroupedNumberFormatter.swift
+++ b/Tangem/Common/UI/SendGroupedNumberTextField/GroupedNumberFormatter.swift
@@ -31,6 +31,14 @@ struct GroupedNumberFormatter {
         numberFormatter.maximumFractionDigits = maximumFractionDigits
     }
 
+    func format(_ decimal: Decimal) -> String {
+        guard let string = numberFormatter.string(for: decimal) else {
+            return ""
+        }
+
+        return format(from: string)
+    }
+
     func format(from string: String) -> String {
         // Exclude unnecessary logic
         guard !string.isEmpty else { return "" }


### PR DESCRIPTION
Проблема была в том что брали Decimal.description. Тип разделителя десятичной части отличается. description печатался с ".", а разделитель в форматтере использует ",". Думаю лучше везде гонять через форматтер, а не через системные удобные проперти