### PR TITLE
IOS-3192 Fix crash at append if for display controllers

### DIFF
--- a/Tangem/Modules/Onboarding/BaseModels/OnboardingTopupViewModel.swift
+++ b/Tangem/Modules/Onboarding/BaseModels/OnboardingTopupViewModel.swift
@@ -88,8 +88,14 @@ class OnboardingTopupViewModel<Step: OnboardingStep, Coordinator: OnboardingTopu
 
                     self.resetRefreshButtonState()
                 case .failed(let error):
-                    self.alert = error.alertBinder
                     self.resetRefreshButtonState()
+
+                    // Need check is display alert yet, because not to present an error if it is already shown
+                    guard self.alert == nil else {
+                        return
+                    }
+
+                    self.alert = error.alertBinder
                 case .loading, .created, .noDerivation:
                     return
                 }


### PR DESCRIPTION
Thread 1: "Application tried to present modally a view controller <SwiftUI.PlatformAlertController: 0x11192bc00> that is already being presented by <_TtGC7SwiftUI29PresentationHostingControllerVS_7AnyView_: 0x1103cb370>."

Ошибка по которой воспроизводился краш, срабатывала потому что publisher для state wallet получал несколько значений в короткое время, а alert при подхвате ошибки, пытался показать на уже презентованный Алерт в связи с чем был эксепшен. Пришло добавить guard для того чтобы проверять презентуется ошибка уже или нет.

По возможности мне помочь, в логике, все ли правильно ли я сделал, потому что есть вероятность того, что guard не самое оптимальное решение.