### PR TITLE
IOS-3244 Fix crash for TokenListViewModel with compact map unowned

### DIFF
--- a/Tangem/Modules/TokenList/TokenListViewModel.swift
+++ b/Tangem/Modules/TokenList/TokenListViewModel.swift
@@ -182,8 +182,8 @@ private extension TokenListViewModel {
         let loader = ListDataLoader(networkIds: networkIds)
 
         loader.$items
-            .map { [unowned self] items -> [CoinViewModel] in
-                items.compactMap { self.mapToCoinViewModel(coinModel: $0) }
+            .map { [weak self] items -> [CoinViewModel] in
+                items.compactMap { self?.mapToCoinViewModel(coinModel: $0) }
             }
             .receive(on: DispatchQueue.main)
             .weakAssign(to: \.coinViewModels, on: self)


### PR DESCRIPTION
Сделал, вывод что крашится, потому что self захватывается как unowned, а висит на паблишере, влияние не большое, предлагаю такой фикс.

Фикс краша по firabase:

6
libswiftCore.dylib
swift_unownedRetainStrong + 156
7
Tangem
TokenListViewModel.swift - Line 182
specialized Sequence.compactMap<A>(_:) + 182
8
Tangem
TokenListViewModel.swift - Line 182
partial apply for closure #2 in TokenListViewModel.setupListDataLoader() + 182