### PR TITLE
IOS-3278 Fix refresh retain

### DIFF
--- a/Tangem/Common/UI/RefreshableScrollView.swift
+++ b/Tangem/Common/UI/RefreshableScrollView.swift
@@ -26,8 +26,6 @@ struct RefreshableScrollView<Content: View>: View {
     var body: some View {
         if #available(iOS 16.0, *) {
             refreshableScrollView
-        } else if #available(iOS 15.0, *) {
-            refreshableList
         } else {
             scrollViewWithHacks
         }
@@ -38,24 +36,6 @@ struct RefreshableScrollView<Content: View>: View {
         ScrollView(.vertical, showsIndicators: false) {
             self.content
         }
-        .refreshable {
-            await withCheckedContinuation { continuation in
-                onRefresh {
-                    continuation.resume()
-                }
-            }
-        }
-    }
-
-    @available(iOS 15.0, *)
-    private var refreshableList: some View {
-        List {
-            self.content
-                .listRowSeparatorTint(.clear)
-                .listRowBackground(Color.clear)
-                .listRowInsets(.init())
-        }
-        .listStyle(.plain)
         .refreshable {
             await withCheckedContinuation { continuation in
                 onRefresh {

--- a/Tangem/Modules/Main/MainViewModel.swift
+++ b/Tangem/Modules/Main/MainViewModel.swift
@@ -212,8 +212,8 @@ class MainViewModel: ObservableObject {
 
         AppSettings.shared.$saveUserWallets
             .dropFirst()
-            .sink { _ in
-                self.objectWillChange.send()
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
             }
             .store(in: &bag)
     }


### PR DESCRIPTION
Если в refreshable y листа передать хоть что-то извне (класс, структуру, кложур), то весь экран перестает удаляться из памяти. Пробовал и делегаты и асинхронные функции и все возможные боксы, но нет. Перестает держать намертво, только если написать внутри refreshable await Task.Sleep() без зависимостей. Оставил старую реализацию - там все ок. На 16 тоже ок