### PR TITLE
Handle biometrics changed

### DIFF
--- a/Tangem/App/Services/UserWalletRepository/CommonUserWalletRepository.swift
+++ b/Tangem/App/Services/UserWalletRepository/CommonUserWalletRepository.swift
@@ -39,7 +39,7 @@ class CommonUserWalletRepository: UserWalletRepository {
 
     private(set) var models = [CardViewModel]()
 
-    private(set) var isLocked: Bool = true
+    var isLocked: Bool { userWallets.contains { $0.isLocked } }
 
     private var userWallets: [UserWallet] = []
 
@@ -71,8 +71,7 @@ class CommonUserWalletRepository: UserWalletRepository {
             .filter { [weak self] in
                 guard let self else { return false }
 
-                let allWalletsLocked = self.userWallets.allSatisfy { $0.isLocked }
-                return !self.isLocked || !allWalletsLocked
+                return !self.isLocked
             }
             .receive(on: RunLoop.main)
             .sink { [weak self] in
@@ -406,7 +405,6 @@ class CommonUserWalletRepository: UserWalletRepository {
     }
 
     private func discardSensitiveData() {
-        isLocked = true
         encryptionKeyByUserWalletId = [:]
         models = []
         userWallets = savedUserWallets(withSensitiveData: false)
@@ -478,10 +476,13 @@ class CommonUserWalletRepository: UserWalletRepository {
                     self.loadModels()
                     self.initializeServicesForSelectedModel()
                     self.selectedModel?.userWalletModel?.initialUpdate()
-                    self.isLocked = false
 
                     if let selectedModel = self.selectedModel {
-                        completion(.success(selectedModel))
+                        if keys.count == self.userWallets.count {
+                            completion(.success(selectedModel))
+                        } else {
+                            completion(.partial(selectedModel, UserWalletRepositoryError.biometricsChanged))
+                        }
                     } else {
                         completion(nil) // TODO: throw error?
                     }
@@ -499,7 +500,6 @@ class CommonUserWalletRepository: UserWalletRepository {
                     case .success(let cardModel) = result,
                     AppSettings.shared.saveUserWallets
                 else {
-                    self?.isLocked = false
                     completion(result)
                     return
                 }
@@ -546,7 +546,6 @@ class CommonUserWalletRepository: UserWalletRepository {
                 self.setSelectedUserWalletId(savedUserWallet.userWalletId, reason: .userSelected)
                 self.initializeServicesForSelectedModel()
                 self.selectedModel?.userWalletModel?.initialUpdate()
-                self.isLocked = false
 
                 self.sendEvent(.updated(userWalletModel: userWalletModel))
 

--- a/Tangem/App/Services/UserWalletRepository/UserWalletRepository.swift
+++ b/Tangem/App/Services/UserWalletRepository/UserWalletRepository.swift
@@ -45,6 +45,7 @@ enum UserWalletRepositoryResult {
     case onboarding(OnboardingInput)
     case troubleshooting
     case error(Error)
+    case partial(CardViewModel, Error)
 
     var isSuccess: Bool {
         switch self {

--- a/Tangem/Modules/AppSettings/AppSettingsViewModel.swift
+++ b/Tangem/Modules/AppSettings/AppSettingsViewModel.swift
@@ -77,10 +77,10 @@ private extension AppSettingsViewModel {
     }
 
     func unlockWithBiometry(completion: @escaping (_ success: Bool) -> Void) {
-        userWalletRepository.unlock(with: .biometry) { [weak self] result in
+        BiometricsUtil.requestAccess(localizedReason: Localization.biometryTouchIdReason) { [weak self] result in
             guard let self else { return }
 
-            if case .error = result {
+            if case .failure = result {
                 self.updateView()
                 completion(false)
             } else {

--- a/Tangem/Modules/Auth/AuthViewModel.swift
+++ b/Tangem/Modules/Auth/AuthViewModel.swift
@@ -55,8 +55,11 @@ final class AuthViewModel: ObservableObject {
         userWalletRepository.unlock(with: .biometry) { [weak self] result in
             self?.didFinishUnlocking(result)
 
-            if case .success = result {
+            switch result {
+            case .success, .partial:
                 Analytics.log(.signedIn, params: [.signInType: .signInTypeBiometrics])
+            default:
+                break
             }
         }
     }
@@ -68,8 +71,11 @@ final class AuthViewModel: ObservableObject {
         userWalletRepository.unlock(with: .card(userWallet: nil)) { [weak self] result in
             self?.didFinishUnlocking(result)
 
-            if case .success = result {
+            switch result {
+            case .success, .partial:
                 Analytics.log(.signedIn, params: [.signInType: .signInTypeCard])
+            default:
+                break
             }
         }
     }
@@ -115,7 +121,7 @@ final class AuthViewModel: ObservableObject {
             } else {
                 self.error = error.alertBinder
             }
-        case .success(let cardModel):
+        case .success(let cardModel), .partial(let cardModel, _):
             openMain(with: cardModel)
         }
     }

--- a/Tangem/Modules/Onboarding/BaseModels/OnboardingViewModel.swift
+++ b/Tangem/Modules/Onboarding/BaseModels/OnboardingViewModel.swift
@@ -370,19 +370,19 @@ extension OnboardingViewModel {
 
 extension OnboardingViewModel: UserWalletStorageAgreementRoutable {
     func didAgreeToSaveUserWallets() {
-        userWalletRepository.unlock(with: .biometry) { [weak self] result in
+        BiometricsUtil.requestAccess(localizedReason: Localization.biometryTouchIdReason) { [weak self] result in
             let biometryAccessGranted: Bool
             switch result {
-            case .error(let error):
-                if let tangemSdkError = error as? TangemSdkError,
-                   case .userCancelled = tangemSdkError {
+            case .failure(let error):
+                if error.isUserCancelled {
                     return
                 }
+
                 AppLog.shared.error(error)
 
                 biometryAccessGranted = false
                 self?.didAskToSaveUserWallets(agreed: false)
-            default:
+            case .success:
                 biometryAccessGranted = true
                 self?.didAskToSaveUserWallets(agreed: true)
             }

--- a/Tangem/Modules/UserWalletList/UserWalletListViewModel.swift
+++ b/Tangem/Modules/UserWalletList/UserWalletListViewModel.swift
@@ -76,7 +76,7 @@ final class UserWalletListViewModel: ObservableObject, Identifiable {
 
         userWalletRepository.unlock(with: .biometry) { [weak self] result in
             switch result {
-            case .error(let error):
+            case .error(let error), .partial(_, let error):
                 self?.error = error.alertBinder
             default:
                 self?.updateModels()
@@ -108,7 +108,7 @@ final class UserWalletListViewModel: ObservableObject, Identifiable {
                 } else {
                     self.error = error.alertBinder
                 }
-            case .success(let cardModel):
+            case .success(let cardModel), .partial(let cardModel, _):
                 self.add(cardModel: cardModel)
             }
         }

--- a/Tangem/Modules/Welcome/WelcomeViewModel.swift
+++ b/Tangem/Modules/Welcome/WelcomeViewModel.swift
@@ -98,7 +98,7 @@ class WelcomeViewModel: ObservableObject {
                 self.openOnboarding(with: input)
             case .error(let error):
                 self.error = error.alertBinder
-            case .success(let cardModel):
+            case .success(let cardModel), .partial(let cardModel, _): // partial unlock is impossible in this case
                 Analytics.log(.signedIn, params: [.signInType: .signInTypeCard])
                 self.openMain(with: cardModel)
             }


### PR DESCRIPTION
Добавил еще один result анлока репы - частичный, когда открывается только одна карта. Потому что нам нужно по разному реагировать на такую разблокировку на скане и на кнопке разблокировать все при разблокировке по биометрии.

Сделал isLocked у репозитория вычисляемым, чтобы кнопка разблокировать все всегда вела себя одинаково.

Поменял вызов разблокировки репозитория в настройках и онбординге на запрос доступа к биометрии