### PR TITLE
Fix total

### DIFF
--- a/Tangem/AppDelegate.swift
+++ b/Tangem/AppDelegate.swift
@@ -54,7 +54,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 .foregroundColor: UIColor(named: "TextPrimary1") ?? UIColor.black,
             ]
         }
-        // test 
 
         servicesManager.initialize()
         return true


### PR DESCRIPTION
В чем была проблема. Влияло два фактора.
1) Мы подписываемся на события об обновлениях на все кошельки сразу при каждом изменении состава этих кошельков.
2) Некоторые блокчейны отвечают очень быстро (трон). К моменту активации подписки баланс уже загружен.

Механика проблемы.
Есть 1 кошелек. Добавляем второй.  В системе висит старая подписка на апдейты 1 кошелька.  Происходит подписывание второй раз, баланс на троне уже прогрузился к этому моменту. Событие обновления от второй подписки не приходит, зато приходит от первой, где всего 1 кошелек.

Воcпроизводилось на иос15 в релизной сборке при удалении-добавлении трона с балансом, но думаю проблема общая.

Я сделал так, что подписка на апдейты теперь всегда одна и за ее пересоздание отвечает первая подписка, чтобы не было гонок.

Структуру и логику подписок оставил прежней. В целом все еще выглядит сложно, с общим рефакторингом поправим