### PR TITLE
IOS-3218 wc 2 task timeout for pairing

### DIFF
--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/Models/WalletConnectV2Error.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/Models/WalletConnectV2Error.swift
@@ -22,6 +22,7 @@ enum WalletConnectV2Error: LocalizedError {
     case missingTransaction
     case transactionSentButNotFoundInManager
     case wrongCardSelected
+    case sessionConnetionTimeout
 
     case unknown(String)
 
@@ -40,6 +41,7 @@ enum WalletConnectV2Error: LocalizedError {
         case .missingTransaction: return 8011
         case .transactionSentButNotFoundInManager: return 8012
         case .wrongCardSelected: return 8013
+        case .sessionConnetionTimeout: return 8014
 
         case .unknown: return 8999
         }

--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/Utilities/WalletConnectV2MessageComposer.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/Utilities/WalletConnectV2MessageComposer.swift
@@ -72,6 +72,8 @@ struct WalletConnectV2MessageComposer: WalletConnectV2MessageComposable {
             return Localization.walletConnectErrorWrongCardSelected
         case .unknown(let errorMessage):
             return Localization.walletConnectErrorWithFrameworkMessage(errorMessage)
+        case .sessionConnetionTimeout:
+            return Localization.walletConnectErrorTimeout
         default:
             return Localization.walletConnectGenericErrorWithCode(error.code)
         }

--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
@@ -88,7 +88,13 @@ final class WalletConnectV2Service {
 
     func openSession(with uri: WalletConnectV2URI) {
         canEstablishNewSessionSubject.send(false)
-        pairClient(with: uri)
+        runTask(withTimeout: 20) { [weak self] in
+            await self?.pairClient(with: uri)
+            self?.canEstablishNewSessionSubject.send(true)
+        } timeoutHandler: { [weak self] in
+            self?.displayErrorUI(WalletConnectV2Error.sessionConnetionTimeout)
+            self?.canEstablishNewSessionSubject.send(true)
+        }
     }
 
     func disconnectSession(with id: Int) async {
@@ -115,16 +121,14 @@ final class WalletConnectV2Service {
         }
     }
 
-    private func pairClient(with url: WalletConnectURI) {
+    private func pairClient(with url: WalletConnectURI) async {
         log("Trying to pair client: \(url)")
-        runTask { [weak self] in
-            do {
-                try await self?.pairApi.pair(uri: url)
-                self?.log("Established pair for \(url)")
-            } catch {
-                AppLog.shared.error("[WC 2.0] Failed to connect to \(url) with error: \(error)")
-            }
-            self?.canEstablishNewSessionSubject.send(true)
+        do {
+            try await pairApi.pair(uri: url)
+            try Task.checkCancellation()
+            log("Established pair for \(url)")
+        } catch {
+            AppLog.shared.error("[WC 2.0] Failed to connect to \(url) with error: \(error)")
         }
     }
 
@@ -264,7 +268,7 @@ final class WalletConnectV2Service {
     private func sessionRejected(with proposal: Session.Proposal) {
         runTask { [weak self] in
             do {
-                try await self?.signApi.reject(proposalId: proposal.id, reason: .userRejectedChains)
+                try await self?.signApi.reject(proposalId: proposal.id, reason: .userRejected)
                 self?.log("User reject WC connection")
             } catch {
                 AppLog.shared.error("[WC 2.0] Failed to reject WC connection with error: \(error)")

--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
@@ -91,7 +91,7 @@ final class WalletConnectV2Service {
         runTask(withTimeout: 20) { [weak self] in
             await self?.pairClient(with: uri)
             self?.canEstablishNewSessionSubject.send(true)
-        } timeoutHandler: { [weak self] in
+        } onTimeout: { [weak self] in
             self?.displayErrorUI(WalletConnectV2Error.sessionConnetionTimeout)
             self?.canEstablishNewSessionSubject.send(true)
         }


### PR DESCRIPTION
Добавил таймер как в первом WC, с тем же интервалом и с тем же текстом ошибки
Поменял причина отказа сессии на более валидную. При старом варианте при жамкании Reject на попытку запустить сессию почему-то дАпп не сбрасывал устаревший и бесполезный QR 