### PR TITLE
IOS-3406 Close success modal before pop to details

### DIFF
--- a/Tangem/Modules/Swapping/SwappingCoordinator.swift
+++ b/Tangem/Modules/Swapping/SwappingCoordinator.swift
@@ -73,6 +73,11 @@ extension SwappingCoordinator: SwappingRoutable {
         UIApplication.shared.endEditing()
         Analytics.log(.swapSwapInProgressScreenOpened)
 
+        let dismissAction = { [weak self] in
+            self?.swappingSuccessCoordinator = nil
+            self?.dismiss()
+        }
+
         let coordinator = SwappingSuccessCoordinator(
             factory: factory,
             dismissAction: dismissAction,

--- a/Tangem/Modules/Swapping/SwappingCoordinator.swift
+++ b/Tangem/Modules/Swapping/SwappingCoordinator.swift
@@ -75,7 +75,9 @@ extension SwappingCoordinator: SwappingRoutable {
 
         let dismissAction = { [weak self] in
             self?.swappingSuccessCoordinator = nil
-            self?.dismiss()
+            DispatchQueue.main.async {
+                self?.dismiss()
+            }
         }
 
         let coordinator = SwappingSuccessCoordinator(


### PR DESCRIPTION
на iOS 15 есть проблема, если закрывать coordinator, не закрывая модалку, то ничего не происходит
Сейчас чуть поменялось поведение, но выглядит все равно все хорошо