### PR TITLE
IOS-3592 move balance format to formatter

### DIFF
--- a/Tangem/App/Services/TotalBalanceProvider/TotalBalanceProvider.swift
+++ b/Tangem/App/Services/TotalBalanceProvider/TotalBalanceProvider.swift
@@ -149,13 +149,5 @@ extension TotalBalanceProvider {
         let balance: Decimal?
         let currencyCode: String
         let hasError: Bool
-
-        var balanceFormatted: String {
-            if let balance {
-                return balance.currencyFormatted(code: currencyCode)
-            } else {
-                return "–"
-            }
-        }
     }
 }

--- a/Tangem/App/Utilities/BalanceFormatter/BalanceFormatter.swift
+++ b/Tangem/App/Utilities/BalanceFormatter/BalanceFormatter.swift
@@ -58,6 +58,11 @@ struct BalanceFormatter {
         return formatter.string(from: valueToFormat as NSDecimalNumber) ?? "\(valueToFormat) \(code)"
     }
 
+    /// Format fiat balance string for main page with different font for integer and fractional parts
+    /// - Parameters:
+    ///   - fiatBalance: Fiat balance should be formatted and with currency symbol. Use `formatFiatBalance(Decimal, BalanceFormattingOptions)
+    ///   - formattingOptions: Fonts for integer and fractional parts
+    /// - Returns: Formatted string for main screen
     func formatTotalBalanceForMain(fiatBalance: String, formattingOptions: TotalBalanceFormattingOptions) -> NSAttributedString {
         let attributedString = NSMutableAttributedString(string: fiatBalance)
         let allStringRange = NSRange(location: 0, length: attributedString.length)

--- a/Tangem/App/Utilities/BalanceFormatter/TotalBalanceFormattingOptions.swift
+++ b/Tangem/App/Utilities/BalanceFormatter/TotalBalanceFormattingOptions.swift
@@ -1,0 +1,21 @@
+//
+//  TotalBalanceFormattingOptions.swift
+//  Tangem
+//
+//  Created by Andrew Son on 11/05/23.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import UIKit
+
+struct TotalBalanceFormattingOptions {
+    let integerPartFont: UIFont
+    let fractionalPartFont: UIFont
+
+    static var defaultOptions: TotalBalanceFormattingOptions {
+        TotalBalanceFormattingOptions(
+            integerPartFont: UIFont.systemFont(ofSize: 28, weight: .semibold),
+            fractionalPartFont: UIFont.systemFont(ofSize: 20, weight: .semibold)
+        )
+    }
+}

--- a/Tangem/Common/Extensions/Decimal+.swift
+++ b/Tangem/Common/Extensions/Decimal+.swift
@@ -28,11 +28,4 @@ extension Decimal {
         let formatter = DecimalNumberFormatter(maximumFractionDigits: maximumFractionDigits)
         return formatter.format(value: self)
     }
-
-    static func decimalSeparator() -> String {
-        let formatter = NumberFormatter()
-        formatter.locale = Locale.current
-        formatter.numberStyle = .currency
-        return formatter.decimalSeparator
-    }
 }

--- a/Tangem/Common/TangemSdk/CardInteractor.swift
+++ b/Tangem/Common/TangemSdk/CardInteractor.swift
@@ -74,7 +74,7 @@ extension CardInteractor: CardResettable {
             completion(.failure(CardInteractionError.emptyCard.toTangemSdkError()))
             return
         }
-        
+
         let initialMessage = Message(header: nil, body: Localization.initialMessagePurgeWalletBody)
         let task = ResetToFactorySettingsTask()
         runnableBag = task

--- a/Tangem/Modules/Main/TotalSumBalance/TotalSumBalanceViewModel.swift
+++ b/Tangem/Modules/Main/TotalSumBalance/TotalSumBalanceViewModel.swift
@@ -77,26 +77,9 @@ class TotalSumBalanceViewModel: ObservableObject {
     }
 
     private func addAttributeForBalance(_ totalValue: TotalBalanceProvider.TotalBalance) -> NSAttributedString {
-        let formattedTotalFiatValue = totalValue.balanceFormatted
-
-        guard totalValue.balance != nil else {
-            return .init(string: formattedTotalFiatValue, attributes: [.font: UIFont.systemFont(ofSize: 28, weight: .semibold)])
-        }
-
-        let attributedString = NSMutableAttributedString(string: formattedTotalFiatValue)
-        let allStringRange = NSRange(location: 0, length: attributedString.length)
-        attributedString.addAttribute(.font, value: UIFont.systemFont(ofSize: 28, weight: .semibold), range: allStringRange)
-
-        let decimalLocation = NSString(string: formattedTotalFiatValue).range(of: Decimal.decimalSeparator()).location
-        if decimalLocation < (formattedTotalFiatValue.count - 1) {
-            let locationAfterDecimal = decimalLocation + 1
-            let symbolsAfterDecimal = formattedTotalFiatValue.count - locationAfterDecimal
-            let rangeAfterDecimal = NSRange(location: locationAfterDecimal, length: symbolsAfterDecimal)
-
-            attributedString.addAttribute(.font, value: UIFont.systemFont(ofSize: 20, weight: .semibold), range: rangeAfterDecimal)
-        }
-
-        return attributedString
+        let balanceFormatter = BalanceFormatter()
+        let formattedTotalFiatValue = balanceFormatter.formatFiatBalance(totalValue.balance, formattingOptions: .defaultFiatFormattingOptions)
+        return balanceFormatter.formatTotalBalanceForMain(fiatBalance: formattedTotalFiatValue, formattingOptions: .defaultOptions)
     }
 
     private func checkPositiveBalance() {

--- a/Tangem/Modules/UserWalletList/UserWalletListCellViewModel.swift
+++ b/Tangem/Modules/UserWalletList/UserWalletListCellViewModel.swift
@@ -86,7 +86,8 @@ class UserWalletListCellViewModel: ObservableObject {
                     self.hasError = false
                 case .loaded(let value):
                     self.isBalanceLoading = false
-                    self.balance = value.balanceFormatted
+                    let balanceFormatter = BalanceFormatter()
+                    self.balance = balanceFormatter.formatFiatBalance(value.balance, formattingOptions: .defaultFiatFormattingOptions)
                     self.hasError = value.hasError
                 }
             }

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -309,6 +309,7 @@
 		B0BA7BC526C4F96B00D7066F /* NonDismissableModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0BA7BC426C4F96B00D7066F /* NonDismissableModalView.swift */; };
 		B0BA7BC726C4F9A300D7066F /* OnboardingCircleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0BA7BC626C4F9A300D7066F /* OnboardingCircleButton.swift */; };
 		B0BA7BCB26C5684E00D7066F /* AddressQrBottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0BA7BCA26C5684E00D7066F /* AddressQrBottomSheetView.swift */; };
+		B0BF631B2A0D1C6F009EB975 /* TotalBalanceFormattingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0BF631A2A0D1C6F009EB975 /* TotalBalanceFormattingOptions.swift */; };
 		B0C171CE264C173400E4BA5C /* CameraAccessDeniedModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C171CD264C173400E4BA5C /* CameraAccessDeniedModifier.swift */; };
 		B0C4A1D32671F3FC00DCB921 /* TestnetBuyCryptoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C4A1D22671F3FB00DCB921 /* TestnetBuyCryptoService.swift */; };
 		B0C4F76B26F0896E0086D815 /* SingleCardOnboardingCardsLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C4F76A26F0896E0086D815 /* SingleCardOnboardingCardsLayout.swift */; };
@@ -552,9 +553,9 @@
 		DC7127AF2897ECBB00F60F71 /* NoteConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7127AE2897ECBB00F60F71 /* NoteConfig.swift */; };
 		DC7127B12897ECDF00F60F71 /* LegacyConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7127B02897ECDF00F60F71 /* LegacyConfig.swift */; };
 		DC7127B32897ECEE00F60F71 /* GenericConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7127B22897ECEE00F60F71 /* GenericConfig.swift */; };
-		DC7254922A050C200003FE1B /* NoteOnboardingStepsBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7254912A050C200003FE1B /* NoteOnboardingStepsBuilder.swift */; };
 		DC72548C2A02B97A0003FE1B /* ResetToFactoryViewModelInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC72548B2A02B97A0003FE1B /* ResetToFactoryViewModelInput.swift */; };
 		DC72548E2A02BB810003FE1B /* CardInteractorMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC72548D2A02BB810003FE1B /* CardInteractorMocks.swift */; };
+		DC7254922A050C200003FE1B /* NoteOnboardingStepsBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7254912A050C200003FE1B /* NoteOnboardingStepsBuilder.swift */; };
 		DC74BC2F28EF060600B49850 /* UserWalletId.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC74BC2E28EF060600B49850 /* UserWalletId.swift */; };
 		DC7AC968292BD64D00580668 /* config_alpha.json in Resources */ = {isa = PBXBuildFile; fileRef = DC7AC967292BD64D00580668 /* config_alpha.json */; };
 		DC7AC96A292BE2C900580668 /* TangemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D3F77DC24BF56DC00E8695B /* TangemTests.swift */; };
@@ -1259,6 +1260,7 @@
 		B0BA7BC426C4F96B00D7066F /* NonDismissableModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonDismissableModalView.swift; sourceTree = "<group>"; };
 		B0BA7BC626C4F9A300D7066F /* OnboardingCircleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCircleButton.swift; sourceTree = "<group>"; };
 		B0BA7BCA26C5684E00D7066F /* AddressQrBottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressQrBottomSheetView.swift; sourceTree = "<group>"; };
+		B0BF631A2A0D1C6F009EB975 /* TotalBalanceFormattingOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalBalanceFormattingOptions.swift; sourceTree = "<group>"; };
 		B0C171CD264C173400E4BA5C /* CameraAccessDeniedModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraAccessDeniedModifier.swift; sourceTree = "<group>"; };
 		B0C4A1D22671F3FB00DCB921 /* TestnetBuyCryptoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestnetBuyCryptoService.swift; sourceTree = "<group>"; };
 		B0C4F76A26F0896E0086D815 /* SingleCardOnboardingCardsLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleCardOnboardingCardsLayout.swift; sourceTree = "<group>"; };
@@ -1509,9 +1511,9 @@
 		DC7127AE2897ECBB00F60F71 /* NoteConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteConfig.swift; sourceTree = "<group>"; };
 		DC7127B02897ECDF00F60F71 /* LegacyConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyConfig.swift; sourceTree = "<group>"; };
 		DC7127B22897ECEE00F60F71 /* GenericConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericConfig.swift; sourceTree = "<group>"; };
-		DC7254912A050C200003FE1B /* NoteOnboardingStepsBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteOnboardingStepsBuilder.swift; sourceTree = "<group>"; };
 		DC72548B2A02B97A0003FE1B /* ResetToFactoryViewModelInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetToFactoryViewModelInput.swift; sourceTree = "<group>"; };
 		DC72548D2A02BB810003FE1B /* CardInteractorMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardInteractorMocks.swift; sourceTree = "<group>"; };
+		DC7254912A050C200003FE1B /* NoteOnboardingStepsBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteOnboardingStepsBuilder.swift; sourceTree = "<group>"; };
 		DC74BC2E28EF060600B49850 /* UserWalletId.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserWalletId.swift; sourceTree = "<group>"; };
 		DC7AC967292BD64D00580668 /* config_alpha.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = config_alpha.json; path = "tangem-app-config/config_alpha.json"; sourceTree = SOURCE_ROOT; };
 		DC7D39EE29DFFBDC007BCD23 /* OnboardingStepsBuilderFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingStepsBuilderFactory.swift; sourceTree = "<group>"; };
@@ -2894,6 +2896,7 @@
 			children = (
 				B0B335D129FA89EE00E2082E /* BalanceFormatter.swift */,
 				B0B335E229FA9EB800E2082E /* BalanceFormattingOptions.swift */,
+				B0BF631A2A0D1C6F009EB975 /* TotalBalanceFormattingOptions.swift */,
 			);
 			path = BalanceFormatter;
 			sourceTree = "<group>";
@@ -5449,6 +5452,7 @@
 				5DFCCB7624C381A70014A293 /* SendViewModel.swift in Sources */,
 				DCE5C66E28898BB6000C7F67 /* CommonTangemApiService.swift in Sources */,
 				5DF2522724F914E30015B429 /* AppScanTask.swift in Sources */,
+				B0BF631B2A0D1C6F009EB975 /* TotalBalanceFormattingOptions.swift in Sources */,
 				DC3B49F42893E50700C207EA /* UserWallet.swift in Sources */,
 				5DD6DF21251E018A00F2693E /* AlertCardView.swift in Sources */,
 				DC66BC06285B6C7300CDF765 /* SendCoordinatorView.swift in Sources */,


### PR DESCRIPTION
Перенес форматирование в `BalanceFormatter` чтобы можно было использовать в новом дизайне. Убрал из расширений лишние функции.
<img src="https://github.com/tangem/tangem-app-ios/assets/24321494/18459562-e203-49f0-b6b3-51186575c284" width="300" />
<img src="https://github.com/tangem/tangem-app-ios/assets/24321494/bea12ac9-ad50-4a9f-ac3d-9451e3ea1a50" width="300" />
