### PR TITLE
Bugfix/ios 3626 rename operator chat to agent

### DIFF
--- a/Tangem/Modules/SupportChat/Zendesk/ZendeskSupportChatViewModel.swift
+++ b/Tangem/Modules/SupportChat/Zendesk/ZendeskSupportChatViewModel.swift
@@ -131,7 +131,7 @@ final class ZendeskSupportChatViewModel {
         })
 
         let sheet = ActionSheet(
-            title: Text(Localization.chatUserRateOperatorTitle),
+            title: Text(Localization.chatUserRateAgentTitle),
             buttons: [buttonLike, buttonDislike, buttonCancel]
         )
 

--- a/Tangem/Resources/Localizations/de.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/de.lproj/Localizable.strings
@@ -46,10 +46,10 @@
 "card_settings_security_mode_footer" = "Selected application protection method";
 "card_settings_title" = "Card Settings";
 "chat_button_title" = "Support";
-"chat_user_action_rate_user" = "Rate operator";
+"chat_user_action_rate_user" = "Rate agent";
 "chat_user_action_send_log" = "Send logs";
 "chat_user_actions_title" = "Please select an action";
-"chat_user_rate_operator_title" = "Please, rate the work of the operator";
+"chat_user_rate_agent_title" = "Please, rate the work of the agent";
 "common_accept" = "Akzeptieren";
 "common_attention" = "Attention";
 "common_back" = "Back";

--- a/Tangem/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/en.lproj/Localizable.strings
@@ -46,10 +46,10 @@
 "card_settings_security_mode_footer" = "Selected application protection method";
 "card_settings_title" = "Card Settings";
 "chat_button_title" = "Support";
-"chat_user_action_rate_user" = "Rate operator";
+"chat_user_action_rate_user" = "Rate agent";
 "chat_user_action_send_log" = "Send logs";
 "chat_user_actions_title" = "Please select an action";
-"chat_user_rate_operator_title" = "Please, rate the work of the operator";
+"chat_user_rate_agent_title" = "Please, rate the work of the agent";
 "common_accept" = "Accept";
 "common_attention" = "Attention";
 "common_back" = "Back";

--- a/Tangem/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/fr.lproj/Localizable.strings
@@ -46,10 +46,10 @@
 "card_settings_security_mode_footer" = "Selected application protection method";
 "card_settings_title" = "Card Settings";
 "chat_button_title" = "Support";
-"chat_user_action_rate_user" = "Rate operator";
+"chat_user_action_rate_user" = "Rate agent";
 "chat_user_action_send_log" = "Send logs";
 "chat_user_actions_title" = "Please select an action";
-"chat_user_rate_operator_title" = "Please, rate the work of the operator";
+"chat_user_rate_agent_title" = "Please, rate the work of the agent";
 "common_accept" = "J'accepte";
 "common_attention" = "Attention";
 "common_back" = "Back";

--- a/Tangem/Resources/Localizations/it.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/it.lproj/Localizable.strings
@@ -46,10 +46,10 @@
 "card_settings_security_mode_footer" = "Selected application protection method";
 "card_settings_title" = "Card Settings";
 "chat_button_title" = "Support";
-"chat_user_action_rate_user" = "Rate operator";
+"chat_user_action_rate_user" = "Rate agent";
 "chat_user_action_send_log" = "Send logs";
 "chat_user_actions_title" = "Please select an action";
-"chat_user_rate_operator_title" = "Please, rate the work of the operator";
+"chat_user_rate_agent_title" = "Please, rate the work of the agent";
 "common_accept" = "Accetta";
 "common_attention" = "Attention";
 "common_back" = "Back";

--- a/Tangem/Resources/Localizations/ru.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/ru.lproj/Localizable.strings
@@ -46,10 +46,10 @@
 "card_settings_security_mode_footer" = "Выбранный способ защиты приложения";
 "card_settings_title" = "Настройки карты";
 "chat_button_title" = "Чат";
-"chat_user_action_rate_user" = "Оценить оператора";
+"chat_user_action_rate_user" = "Оценить агента";
 "chat_user_action_send_log" = "Отправить логи";
 "chat_user_actions_title" = "Пожалуйста, выберите действие";
-"chat_user_rate_operator_title" = "Пожалуйста, оцените работу оператора";
+"chat_user_rate_agent_title" = "Пожалуйста, оцените работу агента";
 "common_accept" = "Принять";
 "common_attention" = "Внимание";
 "common_back" = "Назад";
@@ -90,7 +90,7 @@
 "common_share" = "Поделиться";
 "common_sign" = "Подписать";
 "common_sign_and_send" = "Подписать и отправить";
-"common_stake" = "Stake";
+"common_stake" = "Стейкинг";
 "common_start" = "Начать";
 "common_submit" = "Отправить";
 "common_success" = "Успешно";

--- a/Tangem/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -49,7 +49,7 @@
 "chat_user_action_rate_user" = "請評價";
 "chat_user_action_send_log" = "發送logs";
 "chat_user_actions_title" = "請選擇一個操作";
-"chat_user_rate_operator_title" = "請評價我們的服務";
+"chat_user_rate_agent_title" = "請評價我們的服務";
 "common_accept" = "接受";
 "common_attention" = "注意";
 "common_back" = "返回";


### PR DESCRIPTION
По итогу обсуждания, нужно привести сущность оператор / агент к одному виду. Согласовал с саппортом, что у них оператор нигде не используется, только агенты, переименовал локолайз на "**агента**"