### PR TITLE
IOS-3634: Fix testnet tokens mapping

### DIFF
--- a/Tangem/App/Services/Common/TestnetTokensRepository.swift
+++ b/Tangem/App/Services/Common/TestnetTokensRepository.swift
@@ -25,11 +25,16 @@ class TestnetTokensRepository {
     private func readTestnetList() -> AnyPublisher<CoinsResponse, Error> {
         Just(())
             .receive(on: DispatchQueue.global())
-            .tryMap { testnet in
-                try JsonUtils.readBundleFile(
-                    with: Constants.testFilename,
-                    type: CoinsResponse.self
-                )
+            .tryMap { _ in
+                do {
+                    return try JsonUtils.readBundleFile(
+                        with: Constants.testFilename,
+                        type: CoinsResponse.self
+                    )
+                } catch {
+                    Log.error("Unable to read testnet mock file due to error: \"\(error)\"")
+                    throw error
+                }
             }
             .eraseToAnyPublisher()
     }

--- a/Tangem/Resources/testnet_tokens.json
+++ b/Tangem/Resources/testnet_tokens.json
@@ -8,7 +8,8 @@
             "networks":
             [
                 {
-                    "networkId": "bitcoin/test"
+                    "networkId": "bitcoin/test",
+                    "exchangeable": false
                 }
             ]
         },
@@ -19,8 +20,9 @@
             "networks":
             [
                 {
-                    "networkId": "ethereum/test"
-                }
+                    "networkId": "ethereum/test",
+                    "exchangeable": false
+                }  
             ]
         },
         {
@@ -30,7 +32,8 @@
             "networks":
             [
                 {
-                    "networkId": "ethereum-classic/test"
+                    "networkId": "ethereum-classic/test",
+                    "exchangeable": false
                 }
             ]
         },
@@ -41,7 +44,8 @@
             "networks":
             [
                 {
-                    "networkId": "ethereum-pow-iou/test"
+                    "networkId": "ethereum-pow-iou/test",
+                    "exchangeable": false
                 }
             ]
         },
@@ -52,10 +56,12 @@
             "networks":
             [
                 {
-                    "networkId": "binancecoin/test"
+                    "networkId": "binancecoin/test",
+                    "exchangeable": false
                 },
                 {
-                    "networkId": "binance-smart-chain/test"
+                    "networkId": "binance-smart-chain/test",
+                    "exchangeable": false
                 }
             ]
         },
@@ -66,7 +72,8 @@
             "networks":
             [
                 {
-                    "networkId": "avalanche/test"
+                    "networkId": "avalanche/test",
+                    "exchangeable": false
                 }
             ]
         },
@@ -77,7 +84,8 @@
             "networks":
             [
                 {
-                    "networkId": "fantom/test"
+                    "networkId": "fantom/test",
+                    "exchangeable": false
                 }
             ]
         },
@@ -88,7 +96,8 @@
             "networks":
             [
                 {
-                    "networkId": "arbitrum-one/test"
+                    "networkId": "arbitrum-one/test",
+                    "exchangeable": false
                 }
             ]
         },
@@ -99,7 +108,8 @@
             "networks":
             [
                 {
-                    "networkId": "stellar/test"
+                    "networkId": "stellar/test",
+                    "exchangeable": false
                 }
             ]
         },
@@ -110,7 +120,8 @@
             "networks":
             [
                 {
-                    "networkId": "solana/test"
+                    "networkId": "solana/test",
+                    "exchangeable": false
                 }
             ]
         },
@@ -121,7 +132,8 @@
             "networks":
             [
                 {
-                    "networkId": "tron/test"
+                    "networkId": "tron/test",
+                    "exchangeable": false
                 }
             ]
         },
@@ -132,7 +144,8 @@
             "networks":
             [
                 {
-                    "networkId": "polkadot/test"
+                    "networkId": "polkadot/test",
+                    "exchangeable": false
                 }
             ]
         },
@@ -143,7 +156,8 @@
             "networks":
             [
                 {
-                    "networkId": "optimistic-ethereum/test"
+                    "networkId": "optimistic-ethereum/test",
+                    "exchangeable": false
                 }
             ]
         },
@@ -154,7 +168,8 @@
             "networks":
             [
                 {
-                    "networkId": "the-open-network/test"
+                    "networkId": "the-open-network/test",
+                    "exchangeable": false
                 }
             ]
         },
@@ -165,7 +180,8 @@
             "networks":
             [
                 {
-                    "networkId": "cosmos/test"
+                    "networkId": "cosmos/test",
+                    "exchangeable": false
                 }
             ]
         },
@@ -177,21 +193,25 @@
             [
                 {
                     "networkId": "polygon-pos/test",
+                    "exchangeable": false,
                     "contractAddress": "0x3813e82e6f7098b9583FC0F33a962D02018B6803",
                     "decimalCount": 6
                 },
                 {
                     "networkId": "binance-smart-chain/test",
+                    "exchangeable": false,
                     "contractAddress": "0x337610d27c682e347c9cd60bd4b3b107c9d34ddd",
                     "decimalCount": 18
                 },
                 {
                     "networkId": "tron/test",
+                    "exchangeable": false,
                     "contractAddress": "TXLAQ63Xg1NAzckPwKHvzw7CSEmLMEqcdj",
                     "decimalCount": 6
                 },
                 {
                     "networkId": "binance-smart-chain/test",
+                    "exchangeable": false,
                     "contractAddress": "0x7ef95a0fee0dd31b22626fa2e10ee6a223f8a684",
                     "decimalCount": 18
                 }
@@ -205,6 +225,7 @@
             [
                 {
                     "networkId": "tron/test",
+                    "exchangeable": false,
                     "contractAddress": "TF17BgPaZYbz8oxbjhriubPDsA7ArKoLX3",
                     "decimalCount": 18
                 }
@@ -218,6 +239,7 @@
             [
                 {
                     "networkId": "solana/test",
+                    "exchangeable": false,
                     "contractAddress": "22PTNbX31Zuztd6nD82fC8nQdT2hUfWv9XWXKuDkrFqR",
                     "decimalCount": 9
                 }
@@ -231,6 +253,7 @@
             [
                 {
                     "networkId": "solana/test",
+                    "exchangeable": false,
                     "contractAddress": "HmSghNPg6KCk711YJA92aPejt8auyFkvmaED6jbHfUs4",
                     "decimalCount": 9
                 }
@@ -244,6 +267,7 @@
             [
                 {
                     "networkId": "polygon-pos/test",
+                    "exchangeable": false,
                     "contractAddress": "0x0000000000000000000000000000000000001010",
                     "decimalCount": 18
                 }
@@ -257,16 +281,19 @@
             [
                 {
                     "networkId": "polygon-pos/test",
+                    "exchangeable": false,
                     "contractAddress": "0xcB1e72786A6eb3b44C2a2429e317c8a2462CFeb1",
                     "decimalCount": 18
                 },
                 {
                     "networkId": "binance-smart-chain/test",
+                    "exchangeable": false,
                     "contractAddress": "0xec5dcb5dbf4b114c9d0f65bccab49ec54f6a0867",
                     "decimalCount": 18
                 },
                 {
                     "networkId": "binance-smart-chain/test",
+                    "exchangeable": false,
                     "contractAddress": "0x8a9424745056eb399fd19a0ec26a14316684e274",
                     "decimalCount": 18
                 }
@@ -280,6 +307,7 @@
             [
                 {
                     "networkId": "polygon-pos/test",
+                    "exchangeable": false,
                     "contractAddress": "0xfe4F5145f6e09952a5ba9e956ED0C25e3Fa4c7F1",
                     "decimalCount": 18
                 }
@@ -293,11 +321,13 @@
             [
                 {
                     "networkId": "polygon-pos/test",
+                    "exchangeable": false,
                     "contractAddress": "0x714550C2C1Ea08688607D86ed8EeF4f5E4F22323",
                     "decimalCount": 18
                 },
                 {
                     "networkId": "binance-smart-chain/test",
+                    "exchangeable": false,
                     "contractAddress": "0xd66c6b4f0be8ce5b39d52e0fd1344c389929b378",
                     "decimalCount": 18
                 }
@@ -311,6 +341,7 @@
             [
                 {
                     "networkId": "polygon-pos/test",
+                    "exchangeable": false,
                     "contractAddress": "0x2d7882bedcbfddce29ba99965dd3cdf7fcb10a1e",
                     "decimalCount": 18
                 }
@@ -324,6 +355,7 @@
             [
                 {
                     "networkId": "polygon-pos/test",
+                    "exchangeable": false,
                     "contractAddress": "0xA6FA4fB5f76172d178d61B04b0ecd319C5d1C0aa",
                     "decimalCount": 18
                 }
@@ -337,6 +369,7 @@
             [
                 {
                     "networkId": "polygon-pos/test",
+                    "exchangeable": false,
                     "contractAddress": "0xd0A1E359811322d97991E03f863a0C30C2cF029C",
                     "decimalCount": 18
                 }
@@ -350,6 +383,7 @@
             [
                 {
                     "networkId": "binancecoin/test",
+                    "exchangeable": false,
                     "contractAddress": "HEM-452",
                     "decimalCount": 8
                 }
@@ -363,6 +397,7 @@
             [
                 {
                     "networkId": "binance-smart-chain/test",
+                    "exchangeable": false,
                     "contractAddress": "0x6ce8da28e2f864420840cf74474eff5fd80e65b8",
                     "decimalCount": 18
                 }
@@ -376,6 +411,7 @@
             [
                 {
                     "networkId": "binance-smart-chain/test",
+                    "exchangeable": false,
                     "contractAddress": "0xed24fc36d5ee211ea25a80239fb8c4cfd80f12ee",
                     "decimalCount": 18
                 }
@@ -389,6 +425,7 @@
             [
                 {
                     "networkId": "binance-smart-chain/test",
+                    "exchangeable": false,
                     "contractAddress": "0x64544969ed7ebf5f083679233325356ebe738930",
                     "decimalCount": 18
                 }
@@ -402,6 +439,7 @@
             [
                 {
                     "networkId": "binance-smart-chain/test",
+                    "exchangeable": false,
                     "contractAddress": "0xa83575490d7df4e2f47b7d38ef351a2722ca45b9",
                     "decimalCount": 18
                 }
@@ -415,6 +453,7 @@
             [
                 {
                     "networkId": "ethereum/test",
+                    "exchangeable": false,
                     "contractAddress": "0xaFF4481D10270F50f203E0763e2597776068CBc5",
                     "decimalCount": 18
                 }
@@ -428,6 +467,7 @@
             [
                 {
                     "networkId": "ethereum/test",
+                    "exchangeable": false,
                     "contractAddress": "0x022E292b44B5a146F2e8ee36Ff44D3dd863C915c",
                     "decimalCount": 18
                 }
@@ -441,6 +481,7 @@
             [
                 {
                     "networkId": "ethereum/test",
+                    "exchangeable": false,
                     "contractAddress": "0xc6fDe3FD2Cc2b173aEC24cc3f267cb3Cd78a26B7",
                     "decimalCount": 8
                 }
@@ -454,6 +495,7 @@
             [
                 {
                     "networkId": "ethereum/test",
+                    "exchangeable": false,
                     "contractAddress": "0x1f9061B953bBa0E36BF50F21876132DcF276fC6e",
                     "decimalCount": 0
                 }
@@ -467,6 +509,7 @@
             [
                 {
                     "networkId": "avalanche/test",
+                    "exchangeable": false,
                     "contractAddress": "0x2058ec2791dD28b6f67DB836ddf87534F4Bbdf22",
                     "decimalCount": 6
                 }
@@ -480,6 +523,7 @@
             [
                 {
                     "networkId": "avalanche/test",
+                    "exchangeable": false,
                     "contractAddress": "0x97132C109c6816525F7f338DCb7435E1412A7668",
                     "decimalCount": 9
                 }
@@ -493,6 +537,7 @@
             [
                 {
                     "networkId": "fantom/test",
+                    "exchangeable": false,
                     "contractAddress": "0x91ea991bd52EE3C40EdA2509701d905e1Ee54074",
                     "decimalCount": 18
                 }
@@ -506,6 +551,7 @@
             [
                 {
                     "networkId": "fantom/test",
+                    "exchangeable": false,
                     "contractAddress": "0xf1277d1Ed8AD466beddF92ef448A132661956621",
                     "decimalCount": 18
                 }
@@ -518,7 +564,8 @@
             "networks":
             [
                 {
-                    "networkId": "kava/test"
+                    "networkId": "kava/test",
+                    "exchangeable": false
                 }
             ]
         },
@@ -529,7 +576,8 @@
             "networks":
             [
                 {
-                    "networkId": "ravencoin/test"
+                    "networkId": "ravencoin/test",
+                    "exchangeable": false
                 }
             ]
         },


### PR DESCRIPTION
1. Обсудили с @Balashov152 что захардкодить `"exchangeable": false` это норма, т.к. для тестнета свапалка все равно не будет работать
2. Добавил логгинг чтобы в следующий раз не искать опять проблему

IOS-3634