### PR TITLE
IOS-3636 Fix check emv custom blockchain remove

### DIFF
--- a/Tangem/App/Services/TokenItemsRepository/CommonTokenItemsRepository.swift
+++ b/Tangem/App/Services/TokenItemsRepository/CommonTokenItemsRepository.swift
@@ -183,6 +183,7 @@ fileprivate extension Array where Element == StorageEntry {
 
     mutating func tryRemove(blockchainNetwork: BlockchainNetwork) -> Bool {
         if let existingIndex = firstIndex(where: {
+            // Need for verify additionally custom derivationPath EVM blockchains
             if $0.blockchainNetwork.blockchain.isEvm {
                 return $0.blockchainNetwork == blockchainNetwork && $0.blockchainNetwork.derivationPath == blockchainNetwork.derivationPath
             } else {

--- a/Tangem/App/Services/TokenItemsRepository/CommonTokenItemsRepository.swift
+++ b/Tangem/App/Services/TokenItemsRepository/CommonTokenItemsRepository.swift
@@ -182,7 +182,13 @@ fileprivate extension Array where Element == StorageEntry {
     }
 
     mutating func tryRemove(blockchainNetwork: BlockchainNetwork) -> Bool {
-        if let existingIndex = firstIndex(where: { $0.blockchainNetwork == blockchainNetwork }) {
+        if let existingIndex = firstIndex(where: {
+            if $0.blockchainNetwork.blockchain.isEvm {
+                return $0.blockchainNetwork == blockchainNetwork && $0.blockchainNetwork.derivationPath == blockchainNetwork.derivationPath
+            } else {
+                return $0.blockchainNetwork == blockchainNetwork
+            }
+        }) {
             remove(at: existingIndex)
             return true
         }


### PR DESCRIPTION
В рамках бага проблема была следующая. Мы добавляем evm блокчейн (например cronos), потом добавляем кастомный (кастом. деривация) evm в той же сети. При удалении основного evm, удалялся и добавленный кастомный. Сделал проверку на уровне расширения, на совпадения деривации. В виду того что логику по остальным сложно проверить, чтобы ничего остальное не сломалось, сделал проверку на evm. По идее, нужно всегда проверять и на деривацию в том числе, но тут как скажешь @tureck1y 

Проверил на кроносе, баг решен. Также проверил работу остальных токенов, удаляется по прежней логике. Посмотрите получше пожалуйста