### PR TITLE
Refactor walletModels getters

### DIFF
--- a/Tangem/App/Services/UserWalletModel/UserWalletModel.swift
+++ b/Tangem/App/Services/UserWalletModel/UserWalletModel.swift
@@ -12,11 +12,11 @@ import Combine
 protocol UserWalletModel: AnyObject {
     var isMultiWallet: Bool { get }
     var userWalletId: UserWalletId { get }
+    var walletModels: [WalletModel] { get }
     var userTokenListManager: UserTokenListManager { get }
     var totalBalanceProvider: TotalBalanceProviding { get }
     var userWallet: UserWallet { get }
 
-    func getWalletModels() -> [WalletModel]
     func subscribeToWalletModels() -> AnyPublisher<[WalletModel], Never>
 
     func getSavedEntries() -> [StorageEntry]

--- a/Tangem/App/Services/UserWalletRepository/LockedUserWallet.swift
+++ b/Tangem/App/Services/UserWalletRepository/LockedUserWallet.swift
@@ -24,11 +24,11 @@ class LockedUserWallet: UserWalletModel {
 
     var userWalletId: UserWalletId { .init(value: userWallet.userWalletId) }
 
+    var walletModels: [WalletModel] { [] }
+
     var userTokenListManager: UserTokenListManager { DummyUserTokenListManager() }
 
     var totalBalanceProvider: TotalBalanceProviding { DummyTotalBalanceProvider() }
-
-    func getWalletModels() -> [WalletModel] { [] }
 
     func subscribeToWalletModels() -> AnyPublisher<[WalletModel], Never> { .just(output: []) }
 

--- a/Tangem/App/ViewModels/CardViewModel.swift
+++ b/Tangem/App/ViewModels/CardViewModel.swift
@@ -183,11 +183,7 @@ class CardViewModel: Identifiable, ObservableObject {
     }
 
     var walletModels: [WalletModel] {
-        getWalletModels()
-    }
-
-    var wallets: [Wallet] {
-        walletModels.map { $0.wallet }
+        walletListManager.getWalletModels()
     }
 
     var canSetLongTap: Bool {
@@ -516,7 +512,7 @@ class CardViewModel: Identifiable, ObservableObject {
 
         searchBlockchainsCancellable = nil
 
-        let currentBlockhains = wallets.map { $0.blockchain }
+        let currentBlockhains = walletModels.map { $0.blockchainNetwork.blockchain }
         let unused: [StorageEntry] = config.supportedBlockchains
             .subtracting(currentBlockhains)
             .map { StorageEntry(blockchainNetwork: .init($0, derivationPath: nil), tokens: []) }
@@ -719,10 +715,6 @@ extension CardViewModel: TangemSdkFactory {
 extension CardViewModel: UserWalletModel {
     func getSavedEntries() -> [StorageEntry] {
         userTokenListManager.getEntriesFromRepository()
-    }
-
-    func getWalletModels() -> [WalletModel] {
-        walletListManager.getWalletModels()
     }
 
     func subscribeToWalletModels() -> AnyPublisher<[WalletModel], Never> {

--- a/Tangem/Modules/LegacyMain/LegacyMultiWalletContentView/LegacyMultiWalletContentViewModel.swift
+++ b/Tangem/Modules/LegacyMain/LegacyMultiWalletContentView/LegacyMultiWalletContentViewModel.swift
@@ -126,7 +126,7 @@ private extension LegacyMultiWalletContentViewModel {
 
     func collectTokenItemViewModels() -> [LegacyTokenItemViewModel] {
         let entries = cardModel.getSavedEntries()
-        let walletModels = cardModel.getWalletModels()
+        let walletModels = cardModel.walletModels
         return entries.reduce([]) { result, entry in
             if let walletModel = walletModels.first(where: { $0.blockchainNetwork == entry.blockchainNetwork }) {
                 return result + walletModel.allTokenItemViewModels()

--- a/Tangem/Modules/LegacyMain/LegacySingleWalletContentView/LegacySingleWalletContentViewModel.swift
+++ b/Tangem/Modules/LegacyMain/LegacySingleWalletContentView/LegacySingleWalletContentViewModel.swift
@@ -82,7 +82,7 @@ class LegacySingleWalletContentViewModel: ObservableObject {
         self.output = output
 
         /// Initial set to `singleWalletModel`
-        singleWalletModel = cardModel.getWalletModels().first
+        singleWalletModel = cardModel.walletModels.first
 
         makeActionButtons()
         bind()

--- a/Tangem/Modules/LegacyMain/TotalSumBalance/TotalSumBalanceViewModel.swift
+++ b/Tangem/Modules/LegacyMain/TotalSumBalance/TotalSumBalanceViewModel.swift
@@ -43,9 +43,8 @@ class TotalSumBalanceViewModel: ObservableObject {
 
     func updateForSingleCoinCard() {
         guard let cardAmountType = cardAmountType else { return }
-        let walletModels = userWalletModel.getWalletModels()
 
-        singleWalletBalance = walletModels.first?.allTokenItemViewModels().first(where: { $0.amountType == cardAmountType })?.balance
+        singleWalletBalance = userWalletModel.walletModels.first?.allTokenItemViewModels().first(where: { $0.amountType == cardAmountType })?.balance
     }
 
     func didTapOnCurrencySymbol() {
@@ -85,7 +84,7 @@ class TotalSumBalanceViewModel: ObservableObject {
     private func checkPositiveBalance() {
         guard rateAppService.shouldCheckBalanceForRateApp else { return }
 
-        guard userWalletModel.getWalletModels().contains(where: { !$0.wallet.isEmpty }) else { return }
+        guard userWalletModel.walletModels.contains(where: { !$0.wallet.isEmpty }) else { return }
 
         rateAppService.registerPositiveBalanceDate()
     }

--- a/Tangem/Modules/Onboarding/BaseModels/OnboardingTopupViewModel.swift
+++ b/Tangem/Modules/Onboarding/BaseModels/OnboardingTopupViewModel.swift
@@ -21,7 +21,7 @@ class OnboardingTopupViewModel<Step: OnboardingStep, Coordinator: OnboardingTopu
     var walletModelUpdateCancellable: AnyCancellable?
 
     var buyCryptoURL: URL? {
-        if let wallet = cardModel?.wallets.first {
+        if let wallet = cardModel?.walletModels.first?.wallet {
             return exchangeService.getBuyUrl(
                 currencySymbol: wallet.blockchain.currencySymbol,
                 amountType: .coin,

--- a/Tangem/Modules/Onboarding/Note/SingleCardOnboardingViewModel.swift
+++ b/Tangem/Modules/Onboarding/Note/SingleCardOnboardingViewModel.swift
@@ -94,7 +94,7 @@ class SingleCardOnboardingViewModel: OnboardingTopupViewModel<SingleCardOnboardi
     private var scheduledUpdate: DispatchWorkItem?
 
     private var canBuyCrypto: Bool {
-        if let blockchain = cardModel?.wallets.first?.blockchain,
+        if let blockchain = cardModel?.walletModels.first?.blockchainNetwork.blockchain,
            exchangeService.canBuy(blockchain.currencySymbol, amountType: .coin, blockchain: blockchain) {
             return true
         }

--- a/Tangem/Modules/Referral/ReferralViewModel.swift
+++ b/Tangem/Modules/Referral/ReferralViewModel.swift
@@ -63,7 +63,7 @@ class ReferralViewModel: ObservableObject {
 
         let token = award.token
 
-        guard let address = cardModel.wallets.first(where: { $0.blockchain == blockchain })?.address else {
+        guard let address = cardModel.walletModels.first(where: { $0.blockchainNetwork.blockchain == blockchain })?.wallet.address else {
             requestDerivation(for: blockchain, with: token)
             return
         }

--- a/Tangem/Preview Content/Mocks/UserWalletModelMock.swift
+++ b/Tangem/Preview Content/Mocks/UserWalletModelMock.swift
@@ -14,6 +14,8 @@ class UserWalletModelMock: UserWalletModel {
 
     var userWalletId: UserWalletId { .init(with: Data()) }
 
+    var walletModels: [WalletModel] { [] }
+
     var userTokenListManager: UserTokenListManager { UserTokenListManagerMock() }
 
     var userWallet: UserWallet {
@@ -21,8 +23,6 @@ class UserWalletModelMock: UserWalletModel {
     }
 
     var totalBalanceProvider: TotalBalanceProviding { TotalBalanceProviderMock() }
-
-    func getWalletModels() -> [WalletModel] { [] }
 
     func subscribeToWalletModels() -> AnyPublisher<[WalletModel], Never> { .just(output: []) }
 


### PR DESCRIPTION
Буду бить рефакторинг WalletModel на маленькие кусочки по возможности. Первый шаг направлен на унификацию поиска нужного wallet, чтобы поиск всегда шел по блокчейну и деривации, а не только по блокчейну. Оставил один способ, вместо трех (wallet, getWalletModels, walletModels).