### PR TITLE
IOS-3791: WC 2.0 move projectId to config file

### DIFF
--- a/Tangem/App/Services/KeysManager/CommonKeysManager.swift
+++ b/Tangem/App/Services/KeysManager/CommonKeysManager.swift
@@ -76,6 +76,10 @@ extension CommonKeysManager: KeysManager {
     var swapReferrerAccount: SwapReferrerAccount? {
         keys.swapReferrerAccount
     }
+
+    var walletConnectProjectId: String {
+        keys.walletConnectProjectId
+    }
 }
 
 extension CommonKeysManager {
@@ -101,5 +105,6 @@ extension CommonKeysManager {
         let shopifyShop: ShopifyShop
         let zendesk: ZendeskConfig
         let swapReferrerAccount: SwapReferrerAccount?
+        let walletConnectProjectId: String
     }
 }

--- a/Tangem/App/Services/KeysManager/KeysManager.swift
+++ b/Tangem/App/Services/KeysManager/KeysManager.swift
@@ -20,6 +20,7 @@ protocol KeysManager {
     var infuraProjectId: String { get }
     var swapReferrerAccount: SwapReferrerAccount? { get }
     var utorgSID: String { get }
+    var walletConnectProjectId: String { get }
 }
 
 private struct KeysManagerKey: InjectionKey {

--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
@@ -24,13 +24,12 @@ protocol WalletConnectV2WalletModelProvider: AnyObject {
 
 final class WalletConnectV2Service {
     @Injected(\.walletConnectSessionsStorage) private var sessionsStorage: WalletConnectSessionsStorage
+    @Injected(\.keysManager) private var keysManager: KeysManager
 
     private let factory = WalletConnectV2DefaultSocketFactory()
     private let uiDelegate: WalletConnectUIDelegate
     private let messageComposer: WalletConnectV2MessageComposable
     private let wcHandlersService: WalletConnectV2HandlersServicing
-    private let pairApi: PairingInteracting
-    private let signApi: SignClient
     private let infoProvider: WalletConnectUserWalletInfoProvider
 
     private var canEstablishNewSessionSubject: CurrentValueSubject<Bool, Never> = .init(true)
@@ -53,6 +52,9 @@ final class WalletConnectV2Service {
         }
     }
 
+    private lazy var pairApi: PairingInteracting = Pair.instance
+    private lazy var signApi: SignClient = Sign.instance
+
     init(
         with infoProvider: WalletConnectUserWalletInfoProvider,
         uiDelegate: WalletConnectUIDelegate,
@@ -65,21 +67,17 @@ final class WalletConnectV2Service {
         self.wcHandlersService = wcHandlersService
 
         Networking.configure(
-            // TODO: Update to production id. Should be saved to config file.
-            projectId: "c0e14e9fac0113e872980f2aae3354de",
+            projectId: keysManager.walletConnectProjectId,
             socketFactory: factory,
             socketConnectionType: .automatic
         )
         Pair.configure(metadata: AppMetadata(
             // Not sure that we really need this name, but currently it is hard to recognize what card is connected in dApp
             name: "Tangem \(infoProvider.name)",
-            description: "NFC crypto wallet",
+            description: "Tangem is a card-shaped self-custodial cold hardware wallet",
             url: "tangem.com",
             icons: ["https://user-images.githubusercontent.com/24321494/124071202-72a00900-da58-11eb-935a-dcdab21de52b.png"]
         ))
-
-        pairApi = Pair.instance
-        signApi = Sign.instance
 
         loadSessions(for: infoProvider.userWalletId.value)
         setupSessionSubscriptions()


### PR DESCRIPTION
Пришлось немного изменить порядок инициализации, т.к. внутри либы есть требования по инициализации в начале Networking, потом Pair, а потом уже можно обращаться к синглтонам