### PR TITLE
IOS-3870: Dark theme support for BottomSheetContainer

### DIFF
--- a/Tangem/UIComponents/BottomSheet/BottomSheetContainer.swift
+++ b/Tangem/UIComponents/BottomSheet/BottomSheetContainer.swift
@@ -189,7 +189,7 @@ struct BottomSheetContainer_Previews: PreviewProvider {
 
         var body: some View {
             ZStack {
-                Color.green
+                Colors.Background.primary
                     .edgesIgnoringSafeArea(.all)
 
                 Button("Bottom sheet isShowing \((coordinator.item != nil).description)") {
@@ -253,5 +253,6 @@ struct BottomSheetContainer_Previews: PreviewProvider {
 
     static var previews: some View {
         StatableContainer()
+            .preferredColorScheme(.dark)
     }
 }

--- a/Tangem/UIComponents/BottomSheet/BottomSheetModifier.swift
+++ b/Tangem/UIComponents/BottomSheet/BottomSheetModifier.swift
@@ -64,6 +64,7 @@ struct BottomSheetModifier<Item: Identifiable, ContentView: View>: ViewModifier 
 
         let controller = UIHostingController<Sheet>(rootView: sheet)
         controller.modalPresentationStyle = .overFullScreen
+        controller.overrideUserInterfaceStyle = UIApplication.topViewController?.overrideUserInterfaceStyle ?? .unspecified
         controller.view.backgroundColor = .clear
 
         stateObject.viewDidHidden = {


### PR DESCRIPTION
<img width="422" alt="image" src="https://github.com/tangem/tangem-app-ios/assets/24321494/4e5ed966-762f-48c8-b5f5-b98c8a8200b3">
