### PR TITLE
IOS-3711 header token details

### DIFF
--- a/Tangem/Common/UI/TokenIconView/TokenIconView.swift
+++ b/Tangem/Common/UI/TokenIconView/TokenIconView.swift
@@ -65,11 +65,15 @@ struct TokenIconView: View {
 extension TokenIconView {
     enum SizeSettings {
         case tokenItem
+        case tokenDetails
+        case tokenDetailsToolbar
         case receive
 
         var iconSize: CGSize {
             switch self {
             case .tokenItem: return .init(width: 40, height: 40)
+            case .tokenDetails: return .init(bothDimensions: 48)
+            case .tokenDetailsToolbar: return .init(bothDimensions: 24)
             case .receive: return .init(width: 80, height: 80)
             }
         }
@@ -77,6 +81,7 @@ extension TokenIconView {
         var networkIconSize: CGSize {
             switch self {
             case .tokenItem: return .init(width: 16, height: 16)
+            case .tokenDetails, .tokenDetailsToolbar: return .zero
             case .receive: return .init(width: 32, height: 32)
             }
         }
@@ -84,6 +89,7 @@ extension TokenIconView {
         var networkIconBorderWidth: Double {
             switch self {
             case .tokenItem: return 2
+            case .tokenDetails, .tokenDetailsToolbar: return 0
             case .receive: return 4
             }
         }
@@ -91,6 +97,7 @@ extension TokenIconView {
         var networkIconOffset: CGSize {
             switch self {
             case .tokenItem: return .init(width: 4, height: -4)
+            case .tokenDetails, .tokenDetailsToolbar: return .zero
             case .receive: return .init(width: 9, height: -9)
             }
         }
@@ -103,6 +110,8 @@ struct TokenIconView_Preview: PreviewProvider {
     static var previews: some View {
         VStack(spacing: 16) {
             TokenIconView(viewModel: viewModel)
+
+            TokenIconView(viewModel: tokenViewModel, sizeSettings: .tokenDetails)
 
             TokenIconView(
                 viewModel: tokenViewModel,

--- a/Tangem/Common/Utilities/LocalizationIconParser.swift
+++ b/Tangem/Common/Utilities/LocalizationIconParser.swift
@@ -17,7 +17,9 @@ struct LocalizationIconParser {
             throw "Not supported localized string"
         }
 
-        return (components[0].trimmingCharacters(in: .whitespaces),
-                components[1].trimmingCharacters(in: .whitespaces))
+        return (
+            components[0].trimmingCharacters(in: .whitespaces),
+            components[1].trimmingCharacters(in: .whitespaces)
+        )
     }
 }

--- a/Tangem/Common/Utilities/LocalizationIconParser.swift
+++ b/Tangem/Common/Utilities/LocalizationIconParser.swift
@@ -1,0 +1,23 @@
+//
+//  LocalizationIconParser.swift
+//  Tangem
+//
+//  Created by Andrew Son on 21/06/23.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+struct LocalizationIconParser {
+    private let imageSeparator = "%image%"
+
+    func parse(_ localizedString: String) throws -> (prefix: String, suffix: String) {
+        let components = localizedString.components(separatedBy: imageSeparator)
+        if components.count != 2 {
+            throw "Not supported localized string"
+        }
+
+        return (components[0].trimmingCharacters(in: .whitespaces),
+                components[1].trimmingCharacters(in: .whitespaces))
+    }
+}

--- a/Tangem/Modules/TokenDetails/TokenDetailsView.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsView.swift
@@ -25,20 +25,14 @@ struct TokenDetailsView: View {
         let iconSize = tokenIconSizeSettings.iconSize
         let startAppearingOffset = headerTopPadding + iconSize.height
 
-        if contentOffset.y < startAppearingOffset {
-            return 0
-        }
-
         let fullAppearanceDistance = iconSize.height / 2
         let fullAppearanceOffset = startAppearingOffset + fullAppearanceDistance
 
-        if fullAppearanceOffset < contentOffset.y {
-            return 1
-        }
-
-        let reducedOffset = contentOffset.y - startAppearingOffset
-        let currentOpacity = reducedOffset / fullAppearanceDistance
-        return currentOpacity
+        return clamp(
+            (contentOffset.y - startAppearingOffset) / (fullAppearanceOffset - startAppearingOffset),
+            min: 0,
+            max: 1
+        )
     }
 
     var body: some View {

--- a/Tangem/Modules/TokenDetails/TokenDetailsViewModel.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsViewModel.swift
@@ -22,6 +22,7 @@ final class TokenDetailsViewModel: ObservableObject {
     @Published private var actionButtons: [ButtonWithIconInfo] = []
 
     private(set) var balanceWithButtonsModel: BalanceWithButtonsViewModel!
+    private(set) lazy var tokenDetailsHeaderModel: TokenDetailsHeaderViewModel = .init(tokenItem: tokenItem)
 
     private unowned let coordinator: TokenDetailsRoutable
     private let swappingUtils = SwappingAvailableUtils()
@@ -37,6 +38,15 @@ final class TokenDetailsViewModel: ObservableObject {
     private var availableActions: [TokenActionType] = []
     private var bag = Set<AnyCancellable>()
     private var refreshCancellable: AnyCancellable?
+
+    var tokenItem: TokenItem {
+        switch amountType {
+        case .token(let token):
+            return .token(token, blockchain)
+        default:
+            return .blockchain(blockchain)
+        }
+    }
 
     private var canSend: Bool {
         guard cardModel.canSend else {

--- a/Tangem/Modules/TokenDetails/Views/TokenDetailsHeaderView.swift
+++ b/Tangem/Modules/TokenDetails/Views/TokenDetailsHeaderView.swift
@@ -1,0 +1,57 @@
+//
+//  TokenDetailsHeaderView.swift
+//  Tangem
+//
+//  Created by Andrew Son on 20/06/23.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import SwiftUI
+
+struct TokenDetailsHeaderView: View {
+    let viewModel: TokenDetailsHeaderViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .top) {
+                Text(viewModel.tokenName)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.5)
+                    .multilineTextAlignment(.leading)
+                    .style(Fonts.Bold.largeTitle, color: Colors.Text.primary1)
+
+                Spacer()
+
+                TokenIconView(viewModel: viewModel.tokenIconModel, sizeSettings: .tokenDetails)
+            }
+
+            HStack(spacing: 6) {
+                Text(viewModel.networkPrefix)
+                    .style(Fonts.Regular.footnote, color: Colors.Text.tertiary)
+
+                if let networkIconName = viewModel.networkIconName {
+                    Image(networkIconName)
+                        .resizable()
+                        .frame(size: .init(bothDimensions: 18))
+                }
+
+                if let networkSuffix = viewModel.networkSuffix {
+                    Text(networkSuffix)
+                        .style(Fonts.Bold.footnote, color: Colors.Text.primary1)
+                }
+            }
+        }
+    }
+}
+
+struct SwiftUIView_Previews: PreviewProvider {
+    private static var tokenItem: TokenItem {
+        .token(.inverseBTCBlaBlaBlaMock, .polygon(testnet: false))
+        //        .blockchain(.avalanche(testnet: false))
+        //        .token(.sushiMock, .ethereum(testnet: false))
+    }
+
+    static var previews: some View {
+        TokenDetailsHeaderView(viewModel: .init(tokenItem: tokenItem))
+    }
+}

--- a/Tangem/Modules/TokenDetails/Views/TokenDetailsHeaderViewModel.swift
+++ b/Tangem/Modules/TokenDetails/Views/TokenDetailsHeaderViewModel.swift
@@ -49,11 +49,11 @@ class TokenDetailsHeaderViewModel {
             let components = try parser.parse(localizedString)
 
             if tokenTypePrefix.isEmpty {
-                networkPrefix = components.prefix.trimmingCharacters(in: .whitespaces).capitalizingFirstLetter()
+                networkPrefix = components.prefix.capitalizingFirstLetter()
             } else {
                 networkPrefix = components.prefix
             }
-            networkSuffix = components.suffix.trimmingCharacters(in: .whitespaces)
+            networkSuffix = components.suffix
         } catch {
             networkPrefix = localizedString
             networkSuffix = nil

--- a/Tangem/Modules/TokenDetails/Views/TokenDetailsHeaderViewModel.swift
+++ b/Tangem/Modules/TokenDetails/Views/TokenDetailsHeaderViewModel.swift
@@ -1,0 +1,64 @@
+//
+//  TokenDetailsHeaderViewModel.swift
+//  Tangem
+//
+//  Created by Andrew Son on 21/06/23.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+class TokenDetailsHeaderViewModel {
+    let tokenName: String
+    let tokenIconModel: TokenIconViewModel
+    var networkPrefix: String = ""
+    var networkIconName: String?
+    var networkSuffix: String?
+
+    private let tokenItem: TokenItem
+
+    init(tokenItem: TokenItem) {
+        self.tokenItem = tokenItem
+        tokenIconModel = .init(tokenItem: tokenItem)
+        tokenName = tokenItem.name
+
+        prepare()
+    }
+
+    private func prepare() {
+        if tokenItem.isToken {
+            prepareTokenComponents()
+        } else {
+            prepareCoinComponents()
+        }
+    }
+
+    private func prepareCoinComponents() {
+        networkPrefix = Localization.commonMainNetwork
+        networkIconName = nil
+        networkSuffix = nil
+    }
+
+    private func prepareTokenComponents() {
+        let tokenTypePrefix = tokenItem.blockchain.tokenTypeName ?? ""
+        let networkNameSuffix = tokenItem.blockchain.displayName
+
+        let localizedString = Localization.tokenDetailsTokenTypeSubtitle(tokenTypePrefix, networkNameSuffix)
+        do {
+            let parser = LocalizationIconParser()
+            let components = try parser.parse(localizedString)
+
+            if tokenTypePrefix.isEmpty {
+                networkPrefix = components.prefix.trimmingCharacters(in: .whitespaces).capitalizingFirstLetter()
+            } else {
+                networkPrefix = components.prefix
+            }
+            networkSuffix = components.suffix.trimmingCharacters(in: .whitespaces)
+        } catch {
+            networkPrefix = localizedString
+            networkSuffix = nil
+        }
+
+        networkIconName = tokenItem.blockchain.iconNameFilled
+    }
+}

--- a/Tangem/Preview Content/Mocks/Common/TokenMocks.swift
+++ b/Tangem/Preview Content/Mocks/Common/TokenMocks.swift
@@ -29,4 +29,14 @@ extension Token {
             id: "sushi"
         )
     }
+
+    static var inverseBTCBlaBlaBlaMock: Token {
+        Token(
+            name: "Inverse BTC Flexible Leverage Index",
+            symbol: "IBTC-FLI-P",
+            contractAddress: "0x130ce4e4f76c2265f94a961d70618562de0bb8d2",
+            decimalCount: 18,
+            id: "inverse-btc-flexible-leverage-index"
+        )
+    }
 }

--- a/Tangem/Resources/Localizations/de.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/de.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "common_explorer_format" = "%@ explorer";
 "common_import" = "Import";
 "common_like" = "Like";
+"common_main_network" = "Main network";
 "common_no" = "No";
 "common_no_data" = "No data";
 "common_ok" = "OK";
@@ -405,6 +406,7 @@
 "token_details_hide_token" = "Hide token";
 "token_details_send_blocked_fee_format" = "%1$@ is a token in the %2$@ network. To make a %3$@ transaction you need to deposit some %4$@ (%5$@) to cover the network fee.";
 "token_details_send_blocked_tx_format" = "Please wait for %@ transaction to complete to be able to send funds";
+"token_details_token_type_subtitle" = "%1$@ token in %%image%% %2$@ network";
 "token_details_transaction_length_warning" = "iPhone 7/7+ cannot sign a transaction on this network due to system restrictions. Please use a different phone to complete this operation";
 "token_details_unable_hide_alert_message" = "The %1$@ token is the main currency on the %2$@ network and cannot be hidden as long as you have other tokens on this network in the list.";
 "token_details_unable_hide_alert_title" = "Unable to hide %@";

--- a/Tangem/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/en.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "common_explorer_format" = "%@ explorer";
 "common_import" = "Import";
 "common_like" = "Like";
+"common_main_network" = "Main network";
 "common_no" = "No";
 "common_no_data" = "No data";
 "common_ok" = "OK";
@@ -405,6 +406,7 @@
 "token_details_hide_token" = "Hide token";
 "token_details_send_blocked_fee_format" = "%1$@ is a token in the %2$@ network. To make a %3$@ transaction you need to deposit some %4$@ (%5$@) to cover the network fee.";
 "token_details_send_blocked_tx_format" = "Please wait for %@ transaction to complete to be able to send funds";
+"token_details_token_type_subtitle" = "%1$@ token in %%image%% %2$@ network";
 "token_details_transaction_length_warning" = "iPhone 7/7+ cannot sign a transaction on this network due to system restrictions. Please use a different phone to complete this operation";
 "token_details_unable_hide_alert_message" = "The %1$@ token is the main currency on the %2$@ network and cannot be hidden as long as you have other tokens on this network in the list.";
 "token_details_unable_hide_alert_title" = "Unable to hide %@";

--- a/Tangem/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/fr.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "common_explorer_format" = "%@ explorer";
 "common_import" = "Import";
 "common_like" = "Like";
+"common_main_network" = "Main network";
 "common_no" = "No";
 "common_no_data" = "No data";
 "common_ok" = "OK";
@@ -405,6 +406,7 @@
 "token_details_hide_token" = "Hide token";
 "token_details_send_blocked_fee_format" = "%1$@ is a token in the %2$@ network. To make a %3$@ transaction you need to deposit some %4$@ (%5$@) to cover the network fee.";
 "token_details_send_blocked_tx_format" = "Please wait for %@ transaction to complete to be able to send funds";
+"token_details_token_type_subtitle" = "%1$@ token in %%image%% %2$@ network";
 "token_details_transaction_length_warning" = "iPhone 7/7+ cannot sign a transaction on this network due to system restrictions. Please use a different phone to complete this operation";
 "token_details_unable_hide_alert_message" = "The %1$@ token is the main currency on the %2$@ network and cannot be hidden as long as you have other tokens on this network in the list.";
 "token_details_unable_hide_alert_title" = "Unable to hide %@";

--- a/Tangem/Resources/Localizations/it.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/it.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "common_explorer_format" = "%@ explorer";
 "common_import" = "Import";
 "common_like" = "Like";
+"common_main_network" = "Main network";
 "common_no" = "No";
 "common_no_data" = "No data";
 "common_ok" = "OK";
@@ -405,6 +406,7 @@
 "token_details_hide_token" = "Hide token";
 "token_details_send_blocked_fee_format" = "%1$@ is a token in the %2$@ network. To make a %3$@ transaction you need to deposit some %4$@ (%5$@) to cover the network fee.";
 "token_details_send_blocked_tx_format" = "Please wait for %@ transaction to complete to be able to send funds";
+"token_details_token_type_subtitle" = "%1$@ token in %%image%% %2$@ network";
 "token_details_transaction_length_warning" = "iPhone 7/7+ cannot sign a transaction on this network due to system restrictions. Please use a different phone to complete this operation";
 "token_details_unable_hide_alert_message" = "The %1$@ token is the main currency on the %2$@ network and cannot be hidden as long as you have other tokens on this network in the list.";
 "token_details_unable_hide_alert_title" = "Unable to hide %@";

--- a/Tangem/Resources/Localizations/ru.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/ru.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "common_explorer_format" = "%@ обозреватель";
 "common_import" = "Импортировать";
 "common_like" = "Нравится";
+"common_main_network" = "Основная сеть";
 "common_no" = "Нет";
 "common_no_data" = "Нет данных";
 "common_ok" = "Ок";
@@ -405,6 +406,7 @@
 "token_details_hide_token" = "Скрыть токен";
 "token_details_send_blocked_fee_format" = "%1$@ — это токен в сети %2$@. Чтобы отправить транзакцию %3$@, необходимо пополнить баланс %4$@ (%5$@) для оплаты комиссии сети.";
 "token_details_send_blocked_tx_format" = "Пожалуйста, дождитесь завершения транзакции %@, чтобы иметь возможность отправить средства";
+"token_details_token_type_subtitle" = "%1$@ токен в сети %%image%% %2$@";
 "token_details_transaction_length_warning" = "iPhone 7/7+ не может подписать транзакцию в данной сети из-за системных ограничений. Пожалуйста, используйте другой телефон для выполнения этой операции.";
 "token_details_unable_hide_alert_message" = "Токен %1$@ является основной валютой в сети %2$@ и не может быть скрыт до тех пор, пока у вас в списке есть другие токены этой сети.";
 "token_details_unable_hide_alert_title" = "Невозможно скрыть %@";

--- a/Tangem/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "common_explorer_format" = "%@ explorer";
 "common_import" = "導入";
 "common_like" = "喜歡";
+"common_main_network" = "Main network";
 "common_no" = "否";
 "common_no_data" = "No data";
 "common_ok" = "OK";
@@ -405,6 +406,7 @@
 "token_details_hide_token" = "隱藏代幣";
 "token_details_send_blocked_fee_format" = "%1$@ 是 %2$@ 網絡中的代幣， 要進行 %3$@ 交易，您需要存入一些 %4$@ (%5$@) 以支付網絡費用";
 "token_details_send_blocked_tx_format" = "請等待 %@ 交易完成才能發送資金";
+"token_details_token_type_subtitle" = "%1$@ token in %%image%% %2$@ network";
 "token_details_transaction_length_warning" = "由於系統限制，iPhone 7/7+ 無法在此網絡上簽署交易。 請使用不同的手機完成此操作";
 "token_details_unable_hide_alert_message" = "%1$@ 代幣是 %2$@ 網絡上的主要貨幣，只要列表中還有該網絡上的其他代幣，它就無法被隱藏。";
 "token_details_unable_hide_alert_title" = "無法隱藏 %@";

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -299,6 +299,7 @@
 		B0A0910C26D3628200F46DF5 /* AnimatableGradient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0910B26D3628200F46DF5 /* AnimatableGradient.swift */; };
 		B0A0910E26D362A600F46DF5 /* OnboardingProgressCircle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0910D26D362A600F46DF5 /* OnboardingProgressCircle.swift */; };
 		B0A0911026D3636F00F46DF5 /* AnimationCompletionObserverModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A0910F26D3636F00F46DF5 /* AnimationCompletionObserverModifier.swift */; };
+		B0A1B4802A42C78300376FCC /* TokenDetailsHeaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A1B47F2A42C78300376FCC /* TokenDetailsHeaderViewModel.swift */; };
 		B0A2B3E925D6B5BD0001EEB4 /* TokenBalanceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A2B3E825D6B5BD0001EEB4 /* TokenBalanceViewModel.swift */; };
 		B0A4C4A02A270F5B0060E039 /* BalanceWithButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A4C49F2A270F5B0060E039 /* BalanceWithButtonsView.swift */; };
 		B0A4C4A22A271CD20060E039 /* BalanceWithButtonsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A4C4A12A271CD20060E039 /* BalanceWithButtonsViewModel.swift */; };
@@ -319,6 +320,7 @@
 		B0B335DE29FA959B00E2082E /* TokenIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B335DD29FA959B00E2082E /* TokenIcon.swift */; };
 		B0B335E329FA9EB800E2082E /* BalanceFormattingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B335E229FA9EB800E2082E /* BalanceFormattingOptions.swift */; };
 		B0B4556925E0E63000D7572F /* FailedCardScanTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B4556825E0E63000D7572F /* FailedCardScanTracker.swift */; };
+		B0B712192A41639200A9479C /* TokenDetailsHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B712182A41639200A9479C /* TokenDetailsHeaderView.swift */; };
 		B0B8670326DF5AE1008DAA67 /* ModalSheetPreferenceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B8670226DF5AE1008DAA67 /* ModalSheetPreferenceKey.swift */; };
 		B0B8670626DF60E7008DAA67 /* CardStackAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B8670526DF60E7008DAA67 /* CardStackAnimator.swift */; };
 		B0B86CFF2A1B594000AB1475 /* MultiWalletCardHeaderInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B86CFE2A1B594000AB1475 /* MultiWalletCardHeaderInfoProvider.swift */; };
@@ -370,6 +372,7 @@
 		B0DD162A2A331C2100CB23AA /* TokenDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0DD16252A331C2100CB23AA /* TokenDetailsView.swift */; };
 		B0DD162B2A331C2100CB23AA /* TokenDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0DD16262A331C2100CB23AA /* TokenDetailsViewModel.swift */; };
 		B0DD162C2A331C2100CB23AA /* TokenDetailsRoutable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0DD16272A331C2100CB23AA /* TokenDetailsRoutable.swift */; };
+		B0DE006C2A431BA6005A77D4 /* LocalizationIconParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0DE006B2A431BA6005A77D4 /* LocalizationIconParser.swift */; };
 		B0E0AF5D2996488100E52F7B /* TransactionHistoryMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E0AF5C2996488100E52F7B /* TransactionHistoryMapper.swift */; };
 		B0E1564B26B941A4005B33E4 /* SingleCardOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E1564A26B941A4005B33E4 /* SingleCardOnboardingView.swift */; };
 		B0E1564D26B941AF005B33E4 /* SingleCardOnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E1564C26B941AF005B33E4 /* SingleCardOnboardingViewModel.swift */; };
@@ -1328,6 +1331,7 @@
 		B0A0910B26D3628200F46DF5 /* AnimatableGradient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatableGradient.swift; sourceTree = "<group>"; };
 		B0A0910D26D362A600F46DF5 /* OnboardingProgressCircle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingProgressCircle.swift; sourceTree = "<group>"; };
 		B0A0910F26D3636F00F46DF5 /* AnimationCompletionObserverModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationCompletionObserverModifier.swift; sourceTree = "<group>"; };
+		B0A1B47F2A42C78300376FCC /* TokenDetailsHeaderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenDetailsHeaderViewModel.swift; sourceTree = "<group>"; };
 		B0A2B3E825D6B5BD0001EEB4 /* TokenBalanceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenBalanceViewModel.swift; sourceTree = "<group>"; };
 		B0A4C49F2A270F5B0060E039 /* BalanceWithButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceWithButtonsView.swift; sourceTree = "<group>"; };
 		B0A4C4A12A271CD20060E039 /* BalanceWithButtonsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceWithButtonsViewModel.swift; sourceTree = "<group>"; };
@@ -1348,6 +1352,7 @@
 		B0B335DD29FA959B00E2082E /* TokenIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenIcon.swift; sourceTree = "<group>"; };
 		B0B335E229FA9EB800E2082E /* BalanceFormattingOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceFormattingOptions.swift; sourceTree = "<group>"; };
 		B0B4556825E0E63000D7572F /* FailedCardScanTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailedCardScanTracker.swift; sourceTree = "<group>"; };
+		B0B712182A41639200A9479C /* TokenDetailsHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenDetailsHeaderView.swift; sourceTree = "<group>"; };
 		B0B8670226DF5AE1008DAA67 /* ModalSheetPreferenceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalSheetPreferenceKey.swift; sourceTree = "<group>"; };
 		B0B8670526DF60E7008DAA67 /* CardStackAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardStackAnimator.swift; sourceTree = "<group>"; };
 		B0B86CFE2A1B594000AB1475 /* MultiWalletCardHeaderInfoProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiWalletCardHeaderInfoProvider.swift; sourceTree = "<group>"; };
@@ -1400,6 +1405,7 @@
 		B0DD16252A331C2100CB23AA /* TokenDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenDetailsView.swift; sourceTree = "<group>"; };
 		B0DD16262A331C2100CB23AA /* TokenDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenDetailsViewModel.swift; sourceTree = "<group>"; };
 		B0DD16272A331C2100CB23AA /* TokenDetailsRoutable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenDetailsRoutable.swift; sourceTree = "<group>"; };
+		B0DE006B2A431BA6005A77D4 /* LocalizationIconParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationIconParser.swift; sourceTree = "<group>"; };
 		B0E0AF5C2996488100E52F7B /* TransactionHistoryMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistoryMapper.swift; sourceTree = "<group>"; };
 		B0E1564A26B941A4005B33E4 /* SingleCardOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleCardOnboardingView.swift; sourceTree = "<group>"; };
 		B0E1564C26B941AF005B33E4 /* SingleCardOnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleCardOnboardingViewModel.swift; sourceTree = "<group>"; };
@@ -3100,6 +3106,15 @@
 			path = DeprecationService;
 			sourceTree = "<group>";
 		};
+		B0A1B47E2A42C71200376FCC /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				B0B712182A41639200A9479C /* TokenDetailsHeaderView.swift */,
+				B0A1B47F2A42C78300376FCC /* TokenDetailsHeaderViewModel.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		B0A4C49E2A270F490060E039 /* BalanceWithButtonsView */ = {
 			isa = PBXGroup;
 			children = (
@@ -3343,6 +3358,7 @@
 		B0DD16182A331BF300CB23AA /* TokenDetails */ = {
 			isa = PBXGroup;
 			children = (
+				B0A1B47E2A42C71200376FCC /* Views */,
 				B0DD16232A331C2100CB23AA /* TokenDetailsCoordinator.swift */,
 				B0DD16242A331C2100CB23AA /* TokenDetailsCoordinatorView.swift */,
 				B0DD16252A331C2100CB23AA /* TokenDetailsView.swift */,
@@ -3425,6 +3441,7 @@
 			isa = PBXGroup;
 			children = (
 				B0F7D75B2A40487E007FEB2E /* TokenInfoExtractor.swift */,
+				B0DE006B2A431BA6005A77D4 /* LocalizationIconParser.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -5615,6 +5632,7 @@
 			files = (
 				EF9CFC12288FECE100329BE0 /* ScanCardSettingsView.swift in Sources */,
 				EFE23ABB292B8D1800A3C554 /* SwappingPermissionRoutable.swift in Sources */,
+				B0B712192A41639200A9479C /* TokenDetailsHeaderView.swift in Sources */,
 				EF808436293F39D6000D91EA /* UserCurrenciesProvider.swift in Sources */,
 				DCE5C66C28898B7F000C7F67 /* TangemApiService.swift in Sources */,
 				5DDFC2042812B72C005976FE /* Currency.swift in Sources */,
@@ -5902,6 +5920,7 @@
 				EF4662302924DF0300346B6C /* DefaultWarningRow.swift in Sources */,
 				65B4DED828835BE4001524CF /* BottomSheetViewController.swift in Sources */,
 				B018F304259204A200D8F89A /* WarningEvent.swift in Sources */,
+				B0DE006C2A431BA6005A77D4 /* LocalizationIconParser.swift in Sources */,
 				B04CD33E29122C64001EA84A /* ReferralViewModel.swift in Sources */,
 				DCBC944B2993F3420050BC35 /* AnalyticsStorageKey.swift in Sources */,
 				65B4DED6288357DC001524CF /* BottomSheetBaseController.swift in Sources */,
@@ -6106,6 +6125,7 @@
 				B0406BB62A402462006452C2 /* PagerWithDots.swift in Sources */,
 				EFBA1801298900B600C23955 /* ExplorerURLProvider.swift in Sources */,
 				5D49034F27BE84B20072C642 /* ExploreButton.swift in Sources */,
+				B0A1B4802A42C78300376FCC /* TokenDetailsHeaderViewModel.swift in Sources */,
 				DA4C84CD27DA2D6D00B76F91 /* AnimatableModifiers.swift in Sources */,
 				EF053DF32938D4BC006FD13A /* UserWalletListOutput.swift in Sources */,
 				65B435FE2844BF7200DEAE1B /* AttributedTextView.swift in Sources */,


### PR DESCRIPTION
Пока что добавил размеры в `TokenIconView`, думаю стоит отрефакторить эту вьюху и вынести оттуда загрузку картинки, чтобы они не были связаны с иконкой сети.
`LocalizationIconParser` - небольшой парсер локализованных строк, в котором внутри есть тег с изображением. Это из-за требования не разбивать строки на префиксы, суффиксы и прочее. Пока что сделал самым простым и очевидным способом, т.к. времени на проработку детальной системы кодировки и парсинга строк из локалайза пока что нет... 

Первые два видосика в темной теме на демо превьюхе, которую убрал, т.к. много бесполезного кода. Последняя с девайса уже

https://github.com/tangem/tangem-app-ios/assets/24321494/d8dae9b7-9079-4379-a8e0-9b5b6af873e1

https://github.com/tangem/tangem-app-ios/assets/24321494/97ebfc1d-6fdf-4799-9a62-b131f7a52591

https://github.com/tangem/tangem-app-ios/assets/24321494/83f7e344-17a3-4c23-8c78-f8cf2f419c22


