### PR TITLE
IOS-3821: Network unavailable state for cells on Organize Tokens screen

### DIFF
--- a/Tangem/Modules/OrganizeTokens/ListItem/OrganizeTokensListItemView.swift
+++ b/Tangem/Modules/OrganizeTokens/ListItem/OrganizeTokensListItemView.swift
@@ -20,12 +20,13 @@ struct OrganizeTokensListItemView: View {
                 networkUnreachable: viewModel.networkUnreachable
             )
 
-            TokenItemViewMiddleComponent(
-                name: viewModel.name,
-                balance: viewModel.balance,
-                hasPendingTransactions: viewModel.hasPendingTransactions,
-                networkUnreachable: viewModel.networkUnreachable
-            )
+            // According to the mockups, network unreachable state on the organize tokens screen
+            // looks different than on the main screen
+            if viewModel.networkUnreachable {
+                networkUnreachableMiddleComponent
+            } else {
+                defaultMiddleComponent
+            }
 
             Spacer(minLength: 0.0)
 
@@ -36,6 +37,28 @@ struct OrganizeTokensListItemView: View {
             }
         }
         .padding(14.0)
+    }
+
+    private var networkUnreachableMiddleComponent: some View {
+        VStack(alignment: .leading, spacing: 2.0) {
+            Text(viewModel.name)
+                .style(Fonts.Bold.subheadline, color: Colors.Text.primary1)
+                .lineLimit(2)
+
+            Text(Localization.commonUnreachable)
+                .style(Fonts.Regular.footnote, color: Colors.Text.tertiary)
+                .lineLimit(1)
+        }
+        .padding(.vertical, 2.0)
+    }
+
+    private var defaultMiddleComponent: some View {
+        TokenItemViewMiddleComponent(
+            name: viewModel.name,
+            balance: viewModel.balance,
+            hasPendingTransactions: viewModel.hasPendingTransactions,
+            networkUnreachable: viewModel.networkUnreachable
+        )
     }
 }
 

--- a/Tangem/Preview Content/Mocks/ForComponents/OrganizeTokens/OrganizeTokensPreviewProvider.swift
+++ b/Tangem/Preview Content/Mocks/ForComponents/OrganizeTokens/OrganizeTokensPreviewProvider.swift
@@ -94,12 +94,12 @@ struct OrganizeTokensPreviewProvider {
                     ),
                     .init(
                         tokenIcon: TokenIconInfoBuilder().build(
-                            for: .coin,
+                            for: .token(value: .tetherMock),
                             in: .ethereumClassic(testnet: false)
                         ),
                         balance: .noData,
                         isDraggable: false,
-                        networkUnreachable: false,
+                        networkUnreachable: true,
                         hasPendingTransactions: true
                     ),
                 ]


### PR DESCRIPTION
[IOS-3821](https://tangem.atlassian.net/browse/IOS-3821)

[Figma](https://www.figma.com/file/ZJoUO3kZGCcVgOUbCMQcY4/iOS-%E2%80%93-UI?type=design&node-id=8608-22773&mode=design&t=UFxwZLBELWYvNC5K-4)

Самая последняя ячейка на скринах:

<img width="387" alt="Screenshot 2023-06-22 at 21 16 56" src="https://github.com/tangem/tangem-app-ios/assets/21194149/8c76a4ce-6059-4543-aaa0-ba6787606d8b">

<img width="388" alt="Screenshot 2023-06-22 at 21 17 12" src="https://github.com/tangem/tangem-app-ios/assets/21194149/ee723ccd-0e43-4225-bd49-3731bf37d339">


[IOS-3821]: https://tangem.atlassian.net/browse/IOS-3821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ