### PR TITLE
Ignore unsupported method error

### DIFF
--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
@@ -310,7 +310,9 @@ final class WalletConnectV2Service {
             log("Receive result from user \(result) for \(logSuffix)")
             try await signApi.respond(topic: session.topic, requestId: request.id, response: result)
         } catch let error as WalletConnectV2Error {
-            displayErrorUI(error)
+            if case .unsupportedWCMethod = error {} else {
+                displayErrorUI(error)
+            }
             await respond(with: error)
         } catch {
             let wcError: WalletConnectV2Error = .unknown(error.localizedDescription)


### PR DESCRIPTION
1inch жестко спамит алертами, что eth_getCode не поддерживается. Я пробовал его добавить, но этот метод возвращает из апи 0x и тоже спамит запросами, поэтому я пока просто буду его игнорировать.