### PR TITLE
IOS-4073 learn2earn allow to claim tokens after promotion is finished if the user bought the wallet

### DIFF
--- a/Tangem/App/Services/PromotionService/PromotionService.swift
+++ b/Tangem/App/Services/PromotionService/PromotionService.swift
@@ -84,14 +84,14 @@ extension PromotionService: PromotionServiceProtocol {
                     // Regardless of whether or not promotion has finished or not
                     let hasPromoCodePurchase = await hasPurchaseForPromoCode(promoCode, userWalletId: userWalletId)
 
-                    madePromotionalPurchase = hasPromoCodePurchase
                     madePurchase = hasPromoCodePurchase
+                    madePromotionalPurchase = hasPromoCodePurchase
                 } else {
                     // Old user
                     // They have already made the purchase, albeit not as part of the promotion
                     // Thus they can only claim while the promotion lasts
-                    madePromotionalPurchase = false
                     madePurchase = true
+                    madePromotionalPurchase = false
                 }
 
                 promotionAvailable = (promotionActive || madePromotionalPurchase) && !alreadyClaimedAward && madePurchase

--- a/Tangem/App/Services/PromotionService/PromotionService.swift
+++ b/Tangem/App/Services/PromotionService/PromotionService.swift
@@ -20,7 +20,10 @@ class PromotionService {
 
     let currentProgramName = "1inch"
     private let promoCodeStorageKey = "promo_code"
-    private let finishedPromotionNamesStorageKey = "finished_promotion_names"
+
+    // "491" -- hack to reset the storage in 4.9.1 due to the change in the way we record finished promotions.
+    // Worst case the users will send one more network request per device.
+    private let finishedPromotionNamesStorageKey = "finished_promotion_names_491"
     private let awardedPromotionNamesStorageKey = "awarded_promotion_names"
 
     var awardAmount: Int?


### PR DESCRIPTION
Поменял ключ для сохранения данных чтобы можно было заново начать. Иначе у пользователей 4.9.0 промоакция "завершится" и больше не появится.