### PR TITLE
IOS-4122: Update the order of Stellar APIs for 4.9.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,7 @@ def tangem_sdk_pod
 end
 
 def blockchain_sdk_pods
- pod 'BlockchainSdk', :git => 'https://github.com/tangem/blockchain-sdk-swift.git', :tag => 'develop-330-hotfix-1'
+  pod 'BlockchainSdk', :git => 'https://github.com/tangem/blockchain-sdk-swift.git', :tag => 'develop-330-hotfix-2'
   # pod 'BlockchainSdk', :path => '../blockchain-sdk-swift'
   
   pod 'TangemWalletCore', :git => 'https://github.com/tangem/wallet-core-binaries-ios.git', :tag => '3.2.1-tangem2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -253,7 +253,7 @@ DEPENDENCIES:
   - AppsFlyerFramework
   - BinanceChain (from `https://github.com/tangem/swiftbinancechain.git`, tag `0.0.9`)
   - BitcoinCore.swift (from `https://github.com/tangem/bitcoincore.git`, tag `0.0.19`)
-  - BlockchainSdk (from `https://github.com/tangem/blockchain-sdk-swift.git`, tag `develop-330-hotfix-1`)
+  - BlockchainSdk (from `https://github.com/tangem/blockchain-sdk-swift.git`, tag `develop-330-hotfix-2`)
   - Firebase/Analytics
   - Firebase/Crashlytics
   - HDWalletKit (from `https://github.com/tangem/hdwallet.git`, tag `0.3.12`)
@@ -329,7 +329,7 @@ EXTERNAL SOURCES:
     :tag: 0.0.19
   BlockchainSdk:
     :git: https://github.com/tangem/blockchain-sdk-swift.git
-    :tag: develop-330-hotfix-1
+    :tag: develop-330-hotfix-2
   HDWalletKit:
     :git: https://github.com/tangem/hdwallet.git
     :tag: 0.3.12
@@ -367,7 +367,7 @@ CHECKOUT OPTIONS:
     :tag: 0.0.19
   BlockchainSdk:
     :git: https://github.com/tangem/blockchain-sdk-swift.git
-    :tag: develop-330-hotfix-1
+    :tag: develop-330-hotfix-2
   HDWalletKit:
     :git: https://github.com/tangem/hdwallet.git
     :tag: 0.3.12
@@ -452,6 +452,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 77a62fe6bacc05bb10ff20edce75612fa109fd61
   ZendeskSupportSDK: ba72e90e327635b5fde3d023a3de33242a6ee8ab
 
-PODFILE CHECKSUM: 71895486de8c4156539327c46c3212f4c89e7ff7
+PODFILE CHECKSUM: 9fc0bbeb417fee108bdcc71555f36861fe0f3c38
 
 COCOAPODS: 1.12.1


### PR DESCRIPTION
[IOS-4122](https://tangem.atlassian.net/browse/IOS-4122)

[diff](https://github.com/tangem/blockchain-sdk-swift/compare/develop-330-hotfix-1...develop-330-hotfix-2)


[IOS-4122]: https://tangem.atlassian.net/browse/IOS-4122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ