### PR TITLE
IOS-4144 adapt token item to new design

### DIFF
--- a/Tangem/App/ViewModels/WalletModel.swift
+++ b/Tangem/App/ViewModels/WalletModel.swift
@@ -751,3 +751,9 @@ extension WalletModel {
         walletManager as? EthereumTransactionProcessor
     }
 }
+
+extension WalletModel: TokenItemInfoProvider {
+    var hasPendingTransactions: Bool {
+        !incomingPendingTransactions.isEmpty || !outgoingPendingTransactions.isEmpty
+    }
+}

--- a/Tangem/Preview Content/Fakes/FakeWalletManager.swift
+++ b/Tangem/Preview Content/Fakes/FakeWalletManager.swift
@@ -100,8 +100,8 @@ class FakeWalletManager: WalletManager {
 extension FakeWalletManager {
     static let ethWithTokensManager: FakeWalletManager = {
         var wallet = Wallet.ethereumWalletStub
-        wallet.add(coinValue: 15.929003000000354389)
-        wallet.add(tokenValue: 1242.298278546, for: .sushiMock)
+        wallet.add(coinValue: 15.929021455553232400354389)
+        wallet.add(tokenValue: 124245648213146521.298278546, for: .sushiMock)
         wallet.add(tokenValue: 864, for: .tetherMock)
         wallet.add(tokenValue: 0.9991239124323274832932535, for: .inverseBTCBlaBlaBlaMock)
         return FakeWalletManager(wallet: wallet)
@@ -116,6 +116,15 @@ extension FakeWalletManager {
         return FakeWalletManager(wallet: wallet)
     }()
 
-    static let btcManager = FakeWalletManager(wallet: .btcWalletStub)
-    static let xrpManager = FakeWalletManager(wallet: .xrpWalletStub)
+    static let btcManager: FakeWalletManager = {
+        var wallet = Wallet.btcWalletStub
+        wallet.add(coinValue: 1423)
+        return FakeWalletManager(wallet: wallet)
+    }()
+
+    static let xrpManager: FakeWalletManager = {
+        var wallet = Wallet.xrpWalletStub
+        wallet.add(coinValue: 5828830)
+        return FakeWalletManager(wallet: wallet)
+    }()
 }

--- a/Tangem/Preview Content/Mocks/Common/TokenMocks.swift
+++ b/Tangem/Preview Content/Mocks/Common/TokenMocks.swift
@@ -39,4 +39,26 @@ extension Token {
             id: "inverse-btc-flexible-leverage-index"
         )
     }
+
+    static var shibaInuMock: Token {
+        Token(
+            name: "Shiba Inu",
+            symbol: "SHIB",
+            contractAddress: "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
+            decimalCount: 18,
+            id: "shiba-inu",
+            exchangeable: true
+        )
+    }
+
+    static var cosmosMock: Token {
+        Token(
+            name: "Cosmos Hub",
+            symbol: "ATOM",
+            contractAddress: "0xac51C4c48Dc3116487eD4BC16542e27B5694Da1b",
+            decimalCount: 6,
+            id: "cosmos",
+            exchangeable: false
+        )
+    }
 }

--- a/Tangem/Preview Content/Mocks/ForComponents/FakeTokenItemInfoProvider.swift
+++ b/Tangem/Preview Content/Mocks/ForComponents/FakeTokenItemInfoProvider.swift
@@ -51,7 +51,7 @@ class FakeTokenItemInfoProvider: PriceChangeProvider, ObservableObject {
         }
         print("Tapped wallet model: \(tappedWalletManager)")
         var updateSubscription: AnyCancellable?
-        updateSubscription = tappedWalletManager.update(silent: false)
+        updateSubscription = tappedWalletManager.update(silent: true)
             .sink { newState in
                 print("Receive new state \(newState) for \(tappedWalletManager)")
                 withExtendedLifetime(updateSubscription) {}

--- a/Tangem/Preview Content/Mocks/ForComponents/FakeTokenItemInfoProvider.swift
+++ b/Tangem/Preview Content/Mocks/ForComponents/FakeTokenItemInfoProvider.swift
@@ -10,90 +10,35 @@ import Foundation
 import Combine
 import BlockchainSdk
 
-class FakeTokenItemInfoProvider: TokenItemInfoProvider, PriceChangeProvider, ObservableObject {
-    var walletStatePublisher: AnyPublisher<WalletModel.State, Never> { walletStateSubject.eraseToAnyPublisher() }
+class FakeTokenItemInfoProvider: PriceChangeProvider, ObservableObject {
     var priceChangePublisher: AnyPublisher<Void, Never> { priceChangedSubject.eraseToAnyPublisher() }
-    var pendingTransactionPublisher: AnyPublisher<(WalletModelId, Bool), Never> { pendingTransactionNotifier.eraseToAnyPublisher() }
 
-    let walletStateSubject = CurrentValueSubject<WalletModel.State, Never>(.created)
     let pendingTransactionNotifier = PassthroughSubject<(WalletModelId, Bool), Never>()
 
     let priceChangedSubject = PassthroughSubject<Void, Never>()
-    let blockchain = Blockchain.ethereum(testnet: false)
 
     private var amountsIndex = 0
     private var previouslyTappedModelId: Int?
     private var bag = Set<AnyCancellable>()
 
-    private(set) lazy var viewModels: [TokenItemViewModel] = {
-        [
-            .init(
-                id: makeId(for: amounts[amountsIndex][.coin]!),
-                tokenIcon: coinInfo,
-                tokenItem: .blockchain(blockchain),
+    var hasPendingTransactions: Bool { false }
+
+    private(set) var viewModels: [TokenItemViewModel] = []
+
+    private var walletModels: [WalletModel] = []
+
+    init(walletManagers: [FakeWalletManager]) {
+        walletModels = walletManagers.flatMap { $0.walletModels }
+        viewModels = walletModels.map {
+            TokenItemViewModel(
+                id: $0.id,
+                tokenIcon: makeTokenIconInfo(for: $0),
+                tokenItem: makeTokenItem(for: $0),
                 tokenTapped: modelTapped(with:),
-                infoProvider: self,
+                infoProvider: $0,
                 priceChangeProvider: self
-            ),
-            .init(
-                id: makeId(for: amounts[amountsIndex][.token(value: wxDaiToken)]!),
-                tokenIcon: makeTokenIconInfo(for: wxDaiToken),
-                tokenItem: .token(wxDaiToken, blockchain),
-                tokenTapped: modelTapped(with:),
-                infoProvider: self,
-                priceChangeProvider: self
-            ),
-            .init(
-                id: makeId(for: amounts[amountsIndex][.token(value: tetherToken)]!),
-                tokenIcon: makeTokenIconInfo(for: tetherToken),
-                tokenItem: .token(tetherToken, blockchain),
-                tokenTapped: modelTapped(with:),
-                infoProvider: self,
-                priceChangeProvider: self
-            ),
-        ]
-    }()
-
-    private var coinInfo: TokenIconInfo {
-        TokenIconInfoBuilder()
-            .build(for: .coin, in: blockchain)
-    }
-
-    private var wxDaiToken: Token {
-        Token(
-            name: "Wrapped XDAI",
-            symbol: "WXDAI",
-            contractAddress: "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
-            decimalCount: 18,
-            id: "wrapped-xdai"
-        )
-    }
-
-    private var tetherToken: Token {
-        Token(
-            name: "Tether",
-            symbol: "USDT",
-            contractAddress: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
-            decimalCount: 18,
-            id: "tether"
-        )
-    }
-
-    private lazy var amounts: [[Amount.AmountType: Amount]] = [
-        [
-            .coin: .init(with: .ethereum(testnet: false), value: 5),
-            .token(value: wxDaiToken): .init(with: wxDaiToken, value: 150),
-            .token(value: tetherToken): .init(with: tetherToken, value: 0.000005),
-        ],
-        [
-            .coin: .init(with: .ethereum(testnet: false), value: 59),
-            .token(value: wxDaiToken): .init(with: wxDaiToken, value: 10),
-            .token(value: tetherToken): .init(with: tetherToken, value: 6.0000000005),
-        ],
-    ]
-
-    func balance(for amountType: BlockchainSdk.Amount.AmountType) -> Decimal {
-        amounts[amountsIndex][amountType]?.value ?? 0
+            )
+        }
     }
 
     func change(for currencyCode: String, in blockchain: BlockchainSdk.Blockchain) -> Double {
@@ -101,52 +46,31 @@ class FakeTokenItemInfoProvider: TokenItemInfoProvider, PriceChangeProvider, Obs
     }
 
     func modelTapped(with id: Int) {
-        if let previouslyTappedModelId = previouslyTappedModelId {
-            pendingTransactionNotifier.send((previouslyTappedModelId, false))
+        guard let tappedWalletManager = walletModels.first(where: { $0.id == id }) else {
+            return
         }
-
-        if previouslyTappedModelId != id {
-            previouslyTappedModelId = id
-            pendingTransactionNotifier.send((id, true))
-        } else {
-            previouslyTappedModelId = nil
-            walletStateSubject.send(.loading)
-        }
-
-        switch walletStateSubject.value {
-        case .created:
-            walletStateSubject.send(.loading)
-        case .loading:
-            let index = viewModels.firstIndex(where: { $0.id == id })
-            switch index {
-            case 0:
-                amountsIndex = amountsIndex == 0 ? 1 : 0
-                walletStateSubject.send(.idle)
-            case 1:
-                walletStateSubject.send(.failed(error: "Failed i failed, che eshe tut skazat?.."))
-            default:
-                walletStateSubject.send(.noDerivation)
+        print("Tapped wallet model: \(tappedWalletManager)")
+        var updateSubscription: AnyCancellable?
+        updateSubscription = tappedWalletManager.update(silent: false)
+            .sink { newState in
+                print("Receive new state \(newState) for \(tappedWalletManager)")
+                withExtendedLifetime(updateSubscription) {}
             }
-        case .idle:
-            walletStateSubject.send(.loading)
-        case .noDerivation:
-            walletStateSubject.send(.noAccount(message: "You need to topup account to use it"))
-        case .noAccount:
-            walletStateSubject.send(.created)
-        case .failed:
-            walletStateSubject.send(.loading)
-        }
     }
 
-    private func makeTokenIconInfo(for token: Token) -> TokenIconInfo {
+    private func makeTokenIconInfo(for walletModel: WalletModel) -> TokenIconInfo {
         return TokenIconInfoBuilder()
-            .build(for: .token(value: token), in: blockchain)
+            .build(
+                for: walletModel.tokenItem.amountType,
+                in: walletModel.blockchainNetwork.blockchain
+            )
     }
 
-    private func makeId(for amount: Amount) -> Int {
-        var hasher = Hasher()
-        hasher.combine(amount.type)
-        hasher.combine(amount.currencySymbol)
-        return hasher.finalize()
+    private func makeTokenItem(for walletModel: WalletModel) -> TokenItem {
+        let blockchain = walletModel.blockchainNetwork.blockchain
+        switch walletModel.amountType {
+        case .coin, .reserve: return .blockchain(blockchain)
+        case .token(let value): return .token(value, blockchain)
+        }
     }
 }

--- a/Tangem/Preview Content/Stubs/WalletStubs.swift
+++ b/Tangem/Preview Content/Stubs/WalletStubs.swift
@@ -14,7 +14,21 @@ extension Wallet {
         blockchain: .ethereum(testnet: false),
         addresses: [
             .default: PlainAddress(
-                value: "0x1213012890acc67bd6f731",
+                value: "0x27a716A260892C789D4E09719BEa1f526eDFc9E9",
+                publicKey: .init(
+                    seedKey: Data.randomData(count: 32),
+                    derivation: .ethDerivationStub
+                ),
+                type: .default
+            ),
+        ]
+    )
+
+    static let polygonWalletStub = Wallet(
+        blockchain: .polygon(testnet: false),
+        addresses: [
+            .default: PlainAddress(
+                value: "0x27a716A260892C789D4E09719BEa1f526eDFc9E9",
                 publicKey: .init(
                     seedKey: Data.randomData(count: 32),
                     derivation: .ethDerivationStub

--- a/Tangem/UIComponents/TokenItemView/TokenItemInfoProvider.swift
+++ b/Tangem/UIComponents/TokenItemView/TokenItemInfoProvider.swift
@@ -10,8 +10,8 @@ import Combine
 import BlockchainSdk
 
 protocol TokenItemInfoProvider: AnyObject {
-    var walletStatePublisher: AnyPublisher<WalletModel.State, Never> { get }
-    var pendingTransactionPublisher: AnyPublisher<(WalletModelId, Bool), Never> { get }
-
-    func balance(for amountType: Amount.AmountType) -> Decimal
+    var walletDidChangePublisher: AnyPublisher<WalletModel.State, Never> { get }
+    var hasPendingTransactions: Bool { get }
+    var balance: String { get }
+    var fiatBalance: String { get }
 }

--- a/Tangem/UIComponents/TokenItemView/TokenItemView.swift
+++ b/Tangem/UIComponents/TokenItemView/TokenItemView.swift
@@ -42,7 +42,7 @@ struct TokenItemView: View {
 }
 
 struct TokenItemView_Previews: PreviewProvider {
-    static let infoProvider = FakeTokenItemInfoProvider()
+    static let infoProvider = FakeTokenItemInfoProvider(walletManagers: [.ethWithTokensManager, .btcManager, .polygonWithTokensManager, .xrpManager])
 
     static var previews: some View {
         VStack(spacing: 0) {

--- a/Tangem/UIComponents/TokenItemView/TokenItemViewModel.swift
+++ b/Tangem/UIComponents/TokenItemView/TokenItemViewModel.swift
@@ -32,7 +32,6 @@ final class TokenItemViewModel: ObservableObject, Identifiable {
     private unowned let priceChangeProvider: PriceChangeProvider
 
     private var bag = Set<AnyCancellable>()
-    private var balanceUpdateTask: Task<Void, Error>?
 
     init(
         id: Int,
@@ -57,7 +56,7 @@ final class TokenItemViewModel: ObservableObject, Identifiable {
     }
 
     private func bind() {
-        infoProvider.walletStatePublisher
+        infoProvider.walletDidChangePublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newState in
                 guard let self else { return }
@@ -82,17 +81,8 @@ final class TokenItemViewModel: ObservableObject, Identifiable {
                 case .loading:
                     break
                 }
-            }
-            .store(in: &bag)
 
-        infoProvider.pendingTransactionPublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] id, hasPendingTransactions in
-                guard self?.id == id else {
-                    return
-                }
-
-                self?.hasPendingTransactions = hasPendingTransactions
+                updatePendingTransactionsStateIfNeeded()
             }
             .store(in: &bag)
 
@@ -112,32 +102,13 @@ final class TokenItemViewModel: ObservableObject, Identifiable {
             .store(in: &bag)
     }
 
+    private func updatePendingTransactionsStateIfNeeded() {
+        hasPendingTransactions = infoProvider.hasPendingTransactions
+    }
+
     // TODO: remove update from here! Get it from walletModel
     private func updateBalances() {
-        let formatter = BalanceFormatter()
-        let balance = infoProvider.balance(for: tokenItem.amountType)
-        let formattedBalance = formatter.formatCryptoBalance(balance, currencyCode: tokenItem.currencySymbol)
-        balanceCrypto = .loaded(text: formattedBalance)
-
-        balanceUpdateTask?.cancel()
-        balanceUpdateTask = Task { [weak self] in
-            guard let self else { return }
-
-            let formattedFiat: String
-            do {
-                let fiatBalance = try await BalanceConverter().convertToFiat(
-                    value: balance,
-                    from: tokenItem.currencyId ?? ""
-                )
-                formattedFiat = formatter.formatFiatBalance(fiatBalance)
-            } catch {
-                formattedFiat = "-"
-            }
-
-            try Task.checkCancellation()
-            await MainActor.run {
-                self.balanceFiat = .loaded(text: formattedFiat)
-            }
-        }
+        balanceCrypto = .loaded(text: infoProvider.balance)
+        balanceFiat = .loaded(text: infoProvider.fiatBalance)
     }
 }

--- a/Tangem/UIComponents/TokenItemView/TokenItemViewModel.swift
+++ b/Tangem/UIComponents/TokenItemView/TokenItemViewModel.swift
@@ -106,7 +106,6 @@ final class TokenItemViewModel: ObservableObject, Identifiable {
         hasPendingTransactions = infoProvider.hasPendingTransactions
     }
 
-    // TODO: remove update from here! Get it from walletModel
     private func updateBalances() {
         balanceCrypto = .loaded(text: infoProvider.balance)
         balanceFiat = .loaded(text: infoProvider.fiatBalance)


### PR DESCRIPTION
Удалил старую логику конвертации баланса и загрузки внутри `TokenItemViewModel`, т.к. теперь это все делается внутри `WalletModel`. Так же добавил несколько фейковых воллет менеджеров, которые имеют баланс и могут имитировать загрузку баланса