### PR TITLE
IOS-4264: Fix crashes in TokenItemViewModel

### DIFF
--- a/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentViewModel.swift
+++ b/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentViewModel.swift
@@ -76,6 +76,9 @@ final class MultiWalletMainContentViewModel: ObservableObject {
     }
 
     private func convertToSections(_ sections: [TokenListSectionInfo]) -> [MultiWalletTokenItemsSection] {
+        // TODO: Need to change recreation logic, to prevent crashes when sections are refreshed
+        // Or need to replace `unowned` references to `TokenItemInfoProvider` with `weak` references
+        // Will be done in IOS-4157
         MultiWalletTokenItemsSectionFactory()
             .makeSections(from: sections, tapAction: tokenItemTapped(_:))
     }

--- a/Tangem/Modules/Main/MultiWalletMainContent/Views/TokenList/GroupedTokenListInfoProvider.swift
+++ b/Tangem/Modules/Main/MultiWalletMainContent/Views/TokenList/GroupedTokenListInfoProvider.swift
@@ -32,7 +32,8 @@ class GroupedTokenListInfoProvider {
 
     private func bind() {
         userTokenListManager.userTokensPublisher
-            .combineLatest(walletModelsManager.walletModelsPublisher)
+            .removeDuplicates()
+            .combineLatest(walletModelsManager.walletModelsPublisher.removeDuplicates())
             .map(convertToSectionInfo(from:and:))
             .assign(to: \.value, on: currentSections)
             .store(in: &bag)

--- a/Tangem/Modules/Main/MultiWalletMainContent/Views/TokenList/GroupedTokenListInfoProvider.swift
+++ b/Tangem/Modules/Main/MultiWalletMainContent/Views/TokenList/GroupedTokenListInfoProvider.swift
@@ -10,6 +10,7 @@ import Foundation
 import Combine
 import CombineExt
 
+// TODO: This class will be removed in IOS-4157
 class GroupedTokenListInfoProvider {
     private let userTokenListManager: UserTokenListManager
     private let walletModelsManager: WalletModelsManager
@@ -32,6 +33,7 @@ class GroupedTokenListInfoProvider {
     }
 
     private func bind() {
+        // FIXME: Removing duplicates is temp solution while waiting sort/group adapter
         userTokenListManager.userTokensPublisher
             .removeDuplicates()
             .combineLatest(walletModelsManager.walletModelsPublisher.removeDuplicates())

--- a/Tangem/Modules/Main/MultiWalletMainContent/Views/TokenList/GroupedTokenListInfoProvider.swift
+++ b/Tangem/Modules/Main/MultiWalletMainContent/Views/TokenList/GroupedTokenListInfoProvider.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import Combine
+import CombineExt
 
 class GroupedTokenListInfoProvider {
     private let userTokenListManager: UserTokenListManager
@@ -35,7 +36,7 @@ class GroupedTokenListInfoProvider {
             .removeDuplicates()
             .combineLatest(walletModelsManager.walletModelsPublisher.removeDuplicates())
             .map(convertToSectionInfo(from:and:))
-            .assign(to: \.value, on: currentSections)
+            .assign(to: \.value, on: currentSections, ownership: .weak)
             .store(in: &bag)
     }
 


### PR DESCRIPTION
Думаю эта проблема ещё всплывет позже. Из-за того что не сразу деаллоцируется объект, а с некоторой задержкой, происходили периодически накладки. Можно, конечно, убрать `unowned` и поставить везде `weak`, чтобы через опционал обращаться к свойствам протокола, но не очень хочется портить код такими штуками. Думаю надо будет обсудить процесс создания/обновления списка моделей в адаптере, который будет использоваться для `Organize Tokens`, для главной и, наверное, как результат `Manage Tokens`. Может имеет смысл не пересоздавать все абсолютно объекты, а досоздавать только нужные...