### PR TITLE
IOS-4252 Fix derivations

### DIFF
--- a/Tangem/App/Models/UserWallet/Implementations/Wallet2Config.swift
+++ b/Tangem/App/Models/UserWallet/Implementations/Wallet2Config.swift
@@ -45,13 +45,6 @@ extension Wallet2Config: UserWalletConfig {
     }
 
     var derivationStyle: DerivationStyle? {
-        assert(hasFeature(.hdWallets))
-
-        // Keep in mind, that cards with hasImportedWallets == false must have old derivations
-        if !card.hasImportedWallets {
-            return .v2
-        }
-
         return .v3
     }
 

--- a/Tangem/App/ViewModels/CardViewModel.swift
+++ b/Tangem/App/ViewModels/CardViewModel.swift
@@ -462,7 +462,10 @@ class CardViewModel: Identifiable, ObservableObject {
         config = UserWalletConfigFactory(cardInfo).makeConfig()
         _signer = config.tangemSigner
         updateModel()
-        userWalletRepository.save(userWallet)
+        // prevent save until onboarding completed
+        if userWalletRepository.contains(userWallet) {
+            userWalletRepository.save(userWallet)
+        }
         _updatePublisher.send()
     }
 


### PR DESCRIPTION
- Забыл убрать заглушку для импортированных кошельков, что приводило непосредственно к багу
- Еще заметил, что при создании бэкапа вызывался OnDerived, где происходило преждевременное сохранение в репозиторий, пересоздание модели и апдейты. Это еще предстоит рефакторить, пока просто костыль.