### PR TITLE
IOS-4267: Geometry reader performance improvements

### DIFF
--- a/Tangem/Modules/OrganizeTokens/OrganizeTokensView.swift
+++ b/Tangem/Modules/OrganizeTokens/OrganizeTokensView.swift
@@ -128,9 +128,14 @@ struct OrganizeTokensView: View {
                         .padding(.horizontal, Constants.contentHorizontalInset)
                         .coordinateSpace(name: scrollViewContentCoordinateSpaceName)
                         .onTouchesBegan(onTouchesBegan(atLocation:))
-                        .readGeometry(\.frame.maxY, bindTo: $tokenListContentFrameMaxY)
+                        .readGeometry(
+                            \.frame.maxY,
+                            throttleInterval: GeometryInfo.ThrottleInterval.aggressive,
+                            bindTo: $tokenListContentFrameMaxY
+                        )
                         .readContentOffset(
                             inCoordinateSpace: .named(scrollViewFrameCoordinateSpaceName),
+                            throttleInterval: GeometryInfo.ThrottleInterval.aggressive,
                             bindTo: $scrollViewContentOffset
                         )
 

--- a/Tangem/Modules/OrganizeTokens/OrganizeTokensView.swift
+++ b/Tangem/Modules/OrganizeTokens/OrganizeTokensView.swift
@@ -166,9 +166,7 @@ struct OrganizeTokensView: View {
         .onTapGesture {} // allows scroll to work, see https://developer.apple.com/forums/thread/127277 for details
         .gesture(makeDragAndDropGesture())
         .onChange(of: tokenListContentFrameMaxY) { newValue in
-            withAnimation(.easeOut(duration: 0.1)) {
-                isTokenListFooterGradientHidden = newValue < tokenListFooterFrameMinY
-            }
+            isTokenListFooterGradientHidden = newValue < tokenListFooterFrameMinY
         }
         .onChange(of: scrollViewContentOffset) { newValue in
             dragAndDropController.contentOffsetSubject.send(newValue)
@@ -264,6 +262,7 @@ struct OrganizeTokensView: View {
             cornerRadius: Constants.contentCornerRadius,
             horizontalInset: Constants.contentHorizontalInset
         )
+        .animation(.linear(duration: 0.1), value: isTokenListFooterGradientHidden)
         .readGeometry { geometryInfo in
             $tokenListFooterFrameMinY.wrappedValue = geometryInfo.frame.minY
             $scrollViewBottomContentInset.wrappedValue = geometryInfo.size.height + Constants.contentVerticalInset

--- a/Tangem/UIComponents/CardsInfoPagerView/CardsInfoPagerView.swift
+++ b/Tangem/UIComponents/CardsInfoPagerView/CardsInfoPagerView.swift
@@ -295,9 +295,14 @@ struct CardsInfoPagerView<
                         )
                 }
             }
-            .readGeometry(\.size, bindTo: $contentSize)
+            .readGeometry(
+                \.size,
+                throttleInterval: GeometryInfo.ThrottleInterval.aggressive,
+                bindTo: $contentSize
+            )
             .readContentOffset(
                 inCoordinateSpace: .named(scrollViewFrameCoordinateSpaceName),
+                throttleInterval: GeometryInfo.ThrottleInterval.aggressive,
                 bindTo: $verticalContentOffset
             )
 


### PR DESCRIPTION
[IOS-4267](https://tangem.atlassian.net/browse/IOS-4267)

При скролле на главном и organize tokens параметр `frame` в `readGeometry` мог меняться более чем 1 раз за фрейм, что приводило к ворнингам в консоли:
`Bound preference % tried to update multiple times per frame`
и к общему падению производительности.

Для избежания этого добавлен троттлинг частоты апдейтов в `readGeometry`

-----

Я продолбался и прошлый [пулл](https://github.com/tangem/tangem-app-ios/pull/1899) смотрел не на ту ветку.
Черрипикнул все 5 коммитов в новую ветку с девелопа

[IOS-4267]: https://tangem.atlassian.net/browse/IOS-4267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ