### PR TITLE
IOS-4303 main repeating scan requests

### DIFF
--- a/Tangem/App/Services/UserWalletRepository/UserWalletRepository.swift
+++ b/Tangem/App/Services/UserWalletRepository/UserWalletRepository.swift
@@ -20,7 +20,7 @@ protocol UserWalletRepository: Initializable {
     var eventProvider: AnyPublisher<UserWalletRepositoryEvent, Never> { get }
 
     func unlock(with method: UserWalletRepositoryUnlockMethod, completion: @escaping (UserWalletRepositoryResult?) -> Void)
-    func setSelectedUserWalletId(_ userWalletId: Data?, reason: UserWalletRepositorySelectionChangeReason)
+    func setSelectedUserWalletId(_ userWalletId: Data?, unlockIfNeeded: Bool, reason: UserWalletRepositorySelectionChangeReason)
     func updateSelection()
     func logoutIfNeeded()
 
@@ -33,6 +33,13 @@ protocol UserWalletRepository: Initializable {
     func delete(_ userWallet: UserWallet, logoutIfNeeded shouldAutoLogout: Bool)
     func clear()
     func initializeServices(for cardModel: CardViewModel, cardInfo: CardInfo)
+}
+
+extension UserWalletRepository {
+    /// Selecting UserWallet with specified Id and unlocking it if needed
+    func setSelectedUserWalletId(_ userWalletId: Data?, reason: UserWalletRepositorySelectionChangeReason) {
+        setSelectedUserWalletId(userWalletId, unlockIfNeeded: true, reason: reason)
+    }
 }
 
 private struct UserWalletRepositoryKey: InjectionKey {

--- a/Tangem/Modules/Main/MainViewModel.swift
+++ b/Tangem/Modules/Main/MainViewModel.swift
@@ -179,9 +179,7 @@ final class MainViewModel: ObservableObject {
 
     private func removePage(with id: Data) {
         if let index = pages.firstIndex(where: { $0.id.value == id }) {
-            let newIndex = max(0, min(index, pages.count - 2))
             pages.remove(at: index)
-            selectedCardIndex = newIndex
         }
     }
 

--- a/Tangem/Modules/Main/MainViewModel.swift
+++ b/Tangem/Modules/Main/MainViewModel.swift
@@ -178,7 +178,11 @@ final class MainViewModel: ObservableObject {
     }
 
     private func removePage(with id: Data) {
-        // TODO: Removal logic will be added in IOS-4156
+        if let index = pages.firstIndex(where: { $0.id.value == id }) {
+            let newIndex = max(0, min(index, pages.count - 2))
+            pages.remove(at: index)
+            selectedCardIndex = newIndex
+        }
     }
 
     // MARK: - Private functions

--- a/Tangem/Modules/Main/MainViewModel.swift
+++ b/Tangem/Modules/Main/MainViewModel.swift
@@ -185,12 +185,13 @@ final class MainViewModel: ObservableObject {
 
     private func bind() {
         $selectedCardIndex
+            .dropFirst()
             .sink { [weak self] newIndex in
                 guard let userWalletId = self?.pages[newIndex].id else {
                     return
                 }
 
-                self?.userWalletRepository.setSelectedUserWalletId(userWalletId.value, reason: .userSelected)
+                self?.userWalletRepository.setSelectedUserWalletId(userWalletId.value, unlockIfNeeded: false, reason: .userSelected)
             }
             .store(in: &bag)
 

--- a/Tangem/Preview Content/Fakes/FakeUserWalletRepository.swift
+++ b/Tangem/Preview Content/Fakes/FakeUserWalletRepository.swift
@@ -37,7 +37,7 @@ class FakeUserWalletRepository: UserWalletRepository {
 
     func unlock(with method: UserWalletRepositoryUnlockMethod, completion: @escaping (UserWalletRepositoryResult?) -> Void) {}
 
-    func setSelectedUserWalletId(_ userWalletId: Data?, reason: UserWalletRepositorySelectionChangeReason) {}
+    func setSelectedUserWalletId(_ userWalletId: Data?, unlockIfNeeded: Bool, reason: UserWalletRepositorySelectionChangeReason) {}
 
     func updateSelection() {}
 


### PR DESCRIPTION
при переключении на заблокированную карточку вызывался скан карты. Так же пропускаю первое значение, потому что дефолтное значение 0 перезаписывается при разблокировке карточкой
Так же исправил баг: страницы на главной не удалялись после удаления кошелька из хранилища через контекстное меню