### PR TITLE
IOS-4162 locked user wallet UI

### DIFF
--- a/Tangem/App/Factories/NotificationFactory/NotificationSettingsFactory.swift
+++ b/Tangem/App/Factories/NotificationFactory/NotificationSettingsFactory.swift
@@ -19,4 +19,15 @@ struct NotificationSettingsFactory {
             dismissAction: nil
         )
     }
+
+    func lockedWalletNotificationSettings() -> NotificationView.Settings {
+        .init(
+            colorScheme: .gray,
+            icon: .init(image: Assets.lock.image, color: Colors.Icon.primary1),
+            title: Localization.commonUnlockNeeded,
+            description: Localization.unlockWalletDescriptionShort(BiometricAuthorizationUtils.biometryType.name),
+            isDismissable: false,
+            dismissAction: nil
+        )
+    }
 }

--- a/Tangem/App/Services/UserTokensManager/LockedUserTokensManager.swift
+++ b/Tangem/App/Services/UserTokensManager/LockedUserTokensManager.swift
@@ -15,7 +15,7 @@ struct LockedUserTokensManager: UserTokensManager {
     var isInitialSyncPerformed: Bool { false }
 
     var initialSyncPublisher: AnyPublisher<Bool, Never> { .just(output: false) }
-    
+
     var derivationManager: DerivationManager? { nil }
 
     func deriveEntriesWithoutDerivation(_ completion: @escaping () -> Void) {}

--- a/Tangem/Common/TokenActions/TokenActionType.swift
+++ b/Tangem/Common/TokenActions/TokenActionType.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum TokenActionType {
+enum TokenActionType: CaseIterable {
     case buy
     case send
     case receive

--- a/Tangem/Modules/Main/LockedWalletMainContent/LockedWalletMainContentView.swift
+++ b/Tangem/Modules/Main/LockedWalletMainContent/LockedWalletMainContentView.swift
@@ -1,0 +1,157 @@
+//
+//  LockedWalletMainContentView.swift
+//  Tangem
+//
+//  Created by Andrew Son on 16/08/23.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import SwiftUI
+
+struct LockedWalletMainContentView: View {
+    @ObservedObject var viewModel: LockedWalletMainContentViewModel
+
+    var body: some View {
+        VStack(spacing: 14) {
+            NotificationView(input: viewModel.lockedNotificationInput)
+
+            if viewModel.isMultiWallet {
+                multiWalletContent
+            } else {
+                singleWalletContent
+            }
+        }
+        .padding(.horizontal, 16)
+    }
+
+    private var placeholderColor: Color {
+        Colors.Field.primary
+    }
+
+    private var leadingCircle: some View {
+        placeholderColor
+            .frame(size: .init(bothDimensions: 36))
+            .cornerRadiusContinuous(18)
+    }
+
+    private var multiWalletContent: some View {
+        VStack(spacing: 14) {
+            VStack(alignment: .leading, spacing: 0) {
+                Text(Localization.mainTokens)
+                    .style(Fonts.Bold.footnote, color: Colors.Text.tertiary)
+                    .padding(.vertical, 12)
+                    .padding(.horizontal, 14)
+
+                HStack(spacing: 12) {
+                    ZStack(alignment: .topTrailing) {
+                        leadingCircle
+
+                        Colors.Field.primary
+                            .frame(size: .init(bothDimensions: 14))
+                            .cornerRadiusContinuous(7)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 16)
+                                    .stroke(Colors.Background.primary, lineWidth: 2)
+                            )
+                            .offset(x: 4, y: -4)
+                    }
+
+                    tokenPlaceholders
+                }
+                .padding(14)
+            }
+            .background(Colors.Background.primary)
+            .cornerRadiusContinuous(14)
+
+            FixedSizeButtonWithLeadingIcon(
+                title: Localization.organizeTokensTitle,
+                icon: Assets.sliders.image,
+                action: {}
+            )
+            .disabled(true)
+
+            Spacer()
+
+            MainButton(
+                title: Localization.mainManageTokens,
+                isDisabled: true, action: {}
+            )
+            .padding(.bottom, 10)
+        }
+    }
+
+    @ViewBuilder
+    private var singleWalletContent: some View {
+        ScrollableButtonsView(itemsHorizontalOffset: 14, buttonsInfo: viewModel.singleWalletButtonsInfo)
+
+        VStack(spacing: 0) {
+            HStack(spacing: 4) {
+                Text(Localization.transactionHistoryTitle)
+                    .style(Fonts.Bold.footnote, color: Colors.Text.tertiary)
+
+                Spacer()
+
+                Assets.compass.image
+                    .foregroundColor(Colors.Icon.informative)
+
+                Text(Localization.commonExplorer)
+                    .style(Fonts.Regular.footnote, color: Colors.Text.tertiary)
+            }
+            .padding(.vertical, 12)
+            .padding(.horizontal, 16)
+
+            HStack(spacing: 12) {
+                leadingCircle
+
+                tokenPlaceholders
+            }
+            .padding(.vertical, 8)
+            .padding(.horizontal, 14)
+            .padding(.bottom, 8)
+        }
+        .background(Colors.Background.primary)
+        .cornerRadiusContinuous(14)
+
+        Spacer()
+    }
+
+    private var tokenPlaceholders: some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 10) {
+                placeholderColor
+                    .frame(width: 70, height: 12)
+                    .cornerRadiusContinuous(3)
+
+                placeholderColor
+                    .frame(width: 52, height: 12)
+                    .cornerRadiusContinuous(3)
+            }
+
+            Spacer()
+
+            VStack(spacing: 10) {
+                ForEach(0 ... 1) { _ in
+                    placeholderColor
+                        .frame(width: 40, height: 12)
+                        .cornerRadiusContinuous(3)
+                }
+            }
+        }
+    }
+}
+
+struct LockedWalletMainContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        LockedWalletMainContentView(
+            viewModel: .init(userWalletModel: FakeUserWalletModel.wallet3Cards)
+        )
+        .infinityFrame()
+        .background(Colors.Background.secondary.edgesIgnoringSafeArea(.all))
+
+        LockedWalletMainContentView(
+            viewModel: .init(userWalletModel: FakeUserWalletModel.twins)
+        )
+        .infinityFrame()
+        .background(Colors.Background.secondary.edgesIgnoringSafeArea(.all))
+    }
+}

--- a/Tangem/Modules/Main/LockedWalletMainContent/LockedWalletMainContentViewModel.swift
+++ b/Tangem/Modules/Main/LockedWalletMainContent/LockedWalletMainContentViewModel.swift
@@ -1,0 +1,44 @@
+//
+//  LockedWalletMainContentViewModel.swift
+//  Tangem
+//
+//  Created by Andrew Son on 16/08/23.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Combine
+
+class LockedWalletMainContentViewModel: ObservableObject {
+    lazy var lockedNotificationInput: NotificationViewInput = {
+        let factory = NotificationSettingsFactory()
+        return .init(
+            style: .tappable(action: { [weak self] _ in
+                self?.openUnlockSheet()
+            }),
+            settings: factory.lockedWalletNotificationSettings()
+        )
+    }()
+
+    lazy var singleWalletButtonsInfo: [ButtonWithIconInfo] = TokenActionType.allCases.map {
+        ButtonWithIconInfo(
+            title: $0.title,
+            icon: $0.icon,
+            action: {},
+            disabled: true
+        )
+    }
+
+    var isMultiWallet: Bool {
+        userWalletModel.isMultiWallet
+    }
+
+    private let userWalletModel: UserWalletModel
+
+    init(userWalletModel: UserWalletModel) {
+        self.userWalletModel = userWalletModel
+    }
+
+    private func openUnlockSheet() {
+        // TODO: Will be implemented in IOS-4161
+    }
+}

--- a/Tangem/Modules/Main/MainCardPageBuilder/MainUserWalletPageBuilder.swift
+++ b/Tangem/Modules/Main/MainCardPageBuilder/MainUserWalletPageBuilder.swift
@@ -12,6 +12,7 @@ import SwiftUI
 enum MainUserWalletPageBuilder: Identifiable {
     case singleWallet(id: UserWalletId, headerModel: MainHeaderViewModel, bodyModel: SingleWalletMainContentViewModel)
     case multiWallet(id: UserWalletId, headerModel: MainHeaderViewModel, bodyModel: MultiWalletMainContentViewModel)
+    case lockedWallet(id: UserWalletId, headerModel: MainHeaderViewModel, bodyModel: LockedWalletMainContentViewModel)
 
     var id: UserWalletId {
         switch self {
@@ -19,6 +20,15 @@ enum MainUserWalletPageBuilder: Identifiable {
             return id
         case .multiWallet(let id, _, _):
             return id
+        case .lockedWallet(let id, _, _):
+            return id
+        }
+    }
+
+    var isLockedWallet: Bool {
+        switch self {
+        case .lockedWallet: return true
+        case .singleWallet, .multiWallet: return false
         }
     }
 
@@ -28,6 +38,8 @@ enum MainUserWalletPageBuilder: Identifiable {
         case .singleWallet(_, let headerModel, _):
             MainHeaderView(viewModel: headerModel)
         case .multiWallet(_, let headerModel, _):
+            MainHeaderView(viewModel: headerModel)
+        case .lockedWallet(_, let headerModel, _):
             MainHeaderView(viewModel: headerModel)
         }
     }
@@ -41,6 +53,8 @@ enum MainUserWalletPageBuilder: Identifiable {
         case .multiWallet(let id, _, let bodyModel):
             MultiWalletMainContentView(viewModel: bodyModel)
                 .id(id)
+        case .lockedWallet(let id, _, let bodyModel):
+            LockedWalletMainContentView(viewModel: bodyModel)
         }
     }
 }

--- a/Tangem/Modules/Main/MainCardPageBuilder/MainUserWalletPageBuilderFactory.swift
+++ b/Tangem/Modules/Main/MainCardPageBuilder/MainUserWalletPageBuilderFactory.swift
@@ -25,6 +25,10 @@ struct CommonMainUserWalletPageBuilderFactory: MainUserWalletPageBuilderFactory 
             balanceProvider: model
         )
 
+        if model.isUserWalletLocked {
+            return .lockedWallet(id: id, headerModel: headerModel, bodyModel: .init(userWalletModel: model))
+        }
+
         if model.isMultiWallet {
             let viewModel = MultiWalletMainContentViewModel(
                 userWalletModel: model,

--- a/Tangem/Modules/Main/MainHeaderView/MainHeaderView.swift
+++ b/Tangem/Modules/Main/MainHeaderView/MainHeaderView.swift
@@ -22,19 +22,26 @@ struct MainHeaderView: View {
                     Text(viewModel.userWalletName)
                         .style(Fonts.Bold.footnote, color: Colors.Text.tertiary)
 
-                    Text(viewModel.balance)
-                        .multilineTextAlignment(.leading)
-                        .truncationMode(.middle)
-                        .scaledToFit()
-                        .minimumScaleFactor(0.5)
-                        .showSensitiveInformation(viewModel.showSensitiveInformation)
-                        .skeletonable(
-                            isShown: viewModel.isUserWalletLocked || viewModel.isLoadingFiatBalance,
-                            size: .init(width: 102, height: 24),
-                            radius: 6
-                        )
-                        .style(Fonts.Bold.title1, color: Colors.Text.primary1)
-                        .frame(minHeight: 34)
+                    if viewModel.isUserWalletLocked {
+                        Colors.Field.primary
+                            .frame(width: 102, height: 24)
+                            .cornerRadiusContinuous(6)
+                            .padding(.vertical, 5)
+                    } else {
+                        Text(viewModel.balance)
+                            .multilineTextAlignment(.leading)
+                            .truncationMode(.middle)
+                            .scaledToFit()
+                            .minimumScaleFactor(0.5)
+                            .showSensitiveInformation(viewModel.showSensitiveInformation)
+                            .skeletonable(
+                                isShown: viewModel.isLoadingFiatBalance,
+                                size: .init(width: 102, height: 24),
+                                radius: 6
+                            )
+                            .style(Fonts.Bold.title1, color: Colors.Text.primary1)
+                            .frame(minHeight: 34)
+                    }
 
                     if viewModel.isUserWalletLocked {
                         subtitleText

--- a/Tangem/Modules/Main/MainViewModel.swift
+++ b/Tangem/Modules/Main/MainViewModel.swift
@@ -87,6 +87,8 @@ final class MainViewModel: ObservableObject {
             viewModel.onPullToRefresh(completionHandler: completion)
         case .multiWallet(_, _, let viewModel):
             viewModel.onPullToRefresh(completionHandler: completion)
+        case .lockedWallet:
+            completion()
         }
     }
 

--- a/Tangem/Resources/Localizations/de.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/de.lproj/Localizable.strings
@@ -108,6 +108,7 @@
 "common_terms_and_conditions" = "terms and conditions";
 "common_transfer" = "Transfer";
 "common_understand" = "I understand";
+"common_unlock_needed" = "Unlock needed";
 "common_unreachable" = "Unreachable";
 "common_warning" = "Warnung";
 "common_yes" = "Yes";
@@ -427,6 +428,8 @@
 "twins_recreate_toolbar" = "Tangem Twin";
 "twins_recreate_warning" = "This action is irreversible. You will not have access to the old wallet.";
 "twins_scan_twin_with_number" = "Tap the twin card with number %@ and do not remove until the end of the operation";
+"unlock_wallet_description_full" = "Use %@ or scan a card to have an access to your wallet";
+"unlock_wallet_description_short" = "Use %@ or scan a card";
 "user_wallet_list_add_button" = "Add new wallet";
 "user_wallet_list_delete_prompt" = "Are you sure you want to delete this wallet?";
 "user_wallet_list_error_wallet_already_saved" = "This wallet has already been saved, you can add another one";

--- a/Tangem/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/en.lproj/Localizable.strings
@@ -108,6 +108,7 @@
 "common_terms_and_conditions" = "terms and conditions";
 "common_transfer" = "Transfer";
 "common_understand" = "I understand";
+"common_unlock_needed" = "Unlock needed";
 "common_unreachable" = "Unreachable";
 "common_warning" = "Warning";
 "common_yes" = "Yes";
@@ -427,6 +428,8 @@
 "twins_recreate_toolbar" = "Tangem Twin";
 "twins_recreate_warning" = "This action is irreversible. You will not have access to the old wallet.";
 "twins_scan_twin_with_number" = "Tap the twin card with number %@ and do not remove until the end of the operation";
+"unlock_wallet_description_full" = "Use %@ or scan a card to have an access to your wallet";
+"unlock_wallet_description_short" = "Use %@ or scan a card";
 "user_wallet_list_add_button" = "Add new wallet";
 "user_wallet_list_delete_prompt" = "Are you sure you want to delete this wallet?";
 "user_wallet_list_error_wallet_already_saved" = "This wallet has already been saved, you can add another one";

--- a/Tangem/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/fr.lproj/Localizable.strings
@@ -108,6 +108,7 @@
 "common_terms_and_conditions" = "terms and conditions";
 "common_transfer" = "Transfer";
 "common_understand" = "I understand";
+"common_unlock_needed" = "Unlock needed";
 "common_unreachable" = "Unreachable";
 "common_warning" = "Alerte";
 "common_yes" = "Yes";
@@ -427,6 +428,8 @@
 "twins_recreate_toolbar" = "Tangem Twin";
 "twins_recreate_warning" = "This action is irreversible. You will not have access to the old wallet.";
 "twins_scan_twin_with_number" = "Tap the twin card with number %@ and do not remove until the end of the operation";
+"unlock_wallet_description_full" = "Use %@ or scan a card to have an access to your wallet";
+"unlock_wallet_description_short" = "Use %@ or scan a card";
 "user_wallet_list_add_button" = "Add new wallet";
 "user_wallet_list_delete_prompt" = "Are you sure you want to delete this wallet?";
 "user_wallet_list_error_wallet_already_saved" = "This wallet has already been saved, you can add another one";

--- a/Tangem/Resources/Localizations/it.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/it.lproj/Localizable.strings
@@ -108,6 +108,7 @@
 "common_terms_and_conditions" = "terms and conditions";
 "common_transfer" = "Transfer";
 "common_understand" = "I understand";
+"common_unlock_needed" = "Unlock needed";
 "common_unreachable" = "Unreachable";
 "common_warning" = "Avviso";
 "common_yes" = "Yes";
@@ -427,6 +428,8 @@
 "twins_recreate_toolbar" = "Tangem Twin";
 "twins_recreate_warning" = "This action is irreversible. You will not have access to the old wallet.";
 "twins_scan_twin_with_number" = "Tap the twin card with number %@ and do not remove until the end of the operation";
+"unlock_wallet_description_full" = "Use %@ or scan a card to have an access to your wallet";
+"unlock_wallet_description_short" = "Use %@ or scan a card";
 "user_wallet_list_add_button" = "Add new wallet";
 "user_wallet_list_delete_prompt" = "Are you sure you want to delete this wallet?";
 "user_wallet_list_error_wallet_already_saved" = "This wallet has already been saved, you can add another one";

--- a/Tangem/Resources/Localizations/ru.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/ru.lproj/Localizable.strings
@@ -108,6 +108,7 @@
 "common_terms_and_conditions" = "условия участия";
 "common_transfer" = "Перевод";
 "common_understand" = "Я понял";
+"common_unlock_needed" = "Необходима разблокировка";
 "common_unreachable" = "Недоступно";
 "common_warning" = "Предупреждение";
 "common_yes" = "Да";
@@ -427,6 +428,8 @@
 "twins_recreate_toolbar" = "Tangem Twin";
 "twins_recreate_warning" = "Это действие необратимо. У вас не будет доступа к старому кошельку.";
 "twins_scan_twin_with_number" = "Приложите twin-карту с номером %@ и не убирайте до окончания операции";
+"unlock_wallet_description_full" = "Используйте %@ или отсканируйте карту, чтобы получить доступ к своему кошельку";
+"unlock_wallet_description_short" = "Используйте %@ или отсканируйте карту";
 "user_wallet_list_add_button" = "Добавить новый кошелек";
 "user_wallet_list_delete_prompt" = "Вы уверены, что хотите удалить этот кошелек?";
 "user_wallet_list_error_wallet_already_saved" = "Этот кошелек уже был сохранен, вы можете добавить другой";

--- a/Tangem/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "common_terms_and_conditions" = "條款和條件";
 "common_transfer" = "Transfer";
 "common_understand" = "我了解";
+"common_unlock_needed" = "Unlock needed";
 "common_unreachable" = "無法觸達";
 "common_warning" = "警告";
 "common_yes" = "是";
@@ -428,6 +429,8 @@
 "twins_recreate_toolbar" = "Tangem Twin";
 "twins_recreate_warning" = "這個動作是不可逆的。您將無法訪問舊錢包";
 "twins_scan_twin_with_number" = "將您的 iPhone 靠近編號為 %@ 的雙胞胎卡";
+"unlock_wallet_description_full" = "Use %@ or scan a card to have an access to your wallet";
+"unlock_wallet_description_short" = "Use %@ or scan a card";
 "user_wallet_list_add_button" = "添加新錢包";
 "user_wallet_list_delete_prompt" = "您確定要刪除此錢包?";
 "user_wallet_list_error_wallet_already_saved" = "此錢包已保存，您可以再添加一個";

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -188,6 +188,8 @@
 		B02B74B629879F4A006473F2 /* WalletConnectMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02B74B529879F4A006473F2 /* WalletConnectMessageHandler.swift */; };
 		B02B74B82987A628006473F2 /* WalletConnectV2SignTypedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02B74B72987A628006473F2 /* WalletConnectV2SignTypedData.swift */; };
 		B02E11B92A41DB0900776290 /* TokenMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02E11B82A41DB0900776290 /* TokenMocks.swift */; };
+		B030B4DB2A8CE1DA0023DB8B /* LockedWalletMainContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B030B4DA2A8CE1DA0023DB8B /* LockedWalletMainContentView.swift */; };
+		B030B4DD2A8CE20E0023DB8B /* LockedWalletMainContentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B030B4DC2A8CE20E0023DB8B /* LockedWalletMainContentViewModel.swift */; };
 		B03156A82A86369B001D9646 /* DefaultTokenItemInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B03156A72A86369A001D9646 /* DefaultTokenItemInfoProvider.swift */; };
 		B03156AA2A8636CB001D9646 /* TokenItemViewState+WalletModelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B03156A92A8636CB001D9646 /* TokenItemViewState+WalletModelState.swift */; };
 		B031AAB126C1443E00015003 /* Confetti.swift in Sources */ = {isa = PBXBuildFile; fileRef = B031AAB026C1443D00015003 /* Confetti.swift */; };
@@ -1311,6 +1313,8 @@
 		B02B74B529879F4A006473F2 /* WalletConnectMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletConnectMessageHandler.swift; sourceTree = "<group>"; };
 		B02B74B72987A628006473F2 /* WalletConnectV2SignTypedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletConnectV2SignTypedData.swift; sourceTree = "<group>"; };
 		B02E11B82A41DB0900776290 /* TokenMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenMocks.swift; sourceTree = "<group>"; };
+		B030B4DA2A8CE1DA0023DB8B /* LockedWalletMainContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockedWalletMainContentView.swift; sourceTree = "<group>"; };
+		B030B4DC2A8CE20E0023DB8B /* LockedWalletMainContentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockedWalletMainContentViewModel.swift; sourceTree = "<group>"; };
 		B03156A72A86369A001D9646 /* DefaultTokenItemInfoProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTokenItemInfoProvider.swift; sourceTree = "<group>"; };
 		B03156A92A8636CB001D9646 /* TokenItemViewState+WalletModelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TokenItemViewState+WalletModelState.swift"; sourceTree = "<group>"; };
 		B031AAB026C1443D00015003 /* Confetti.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Confetti.swift; sourceTree = "<group>"; };
@@ -2909,6 +2913,15 @@
 			path = SignHandling;
 			sourceTree = "<group>";
 		};
+		B030B4D92A8CE1CA0023DB8B /* LockedWalletMainContent */ = {
+			isa = PBXGroup;
+			children = (
+				B030B4DA2A8CE1DA0023DB8B /* LockedWalletMainContentView.swift */,
+				B030B4DC2A8CE20E0023DB8B /* LockedWalletMainContentViewModel.swift */,
+			);
+			path = LockedWalletMainContent;
+			sourceTree = "<group>";
+		};
 		B031AAAF26C1435E00015003 /* Confetti */ = {
 			isa = PBXGroup;
 			children = (
@@ -3145,6 +3158,7 @@
 		B06C08442A73FB2C00D982BC /* Main */ = {
 			isa = PBXGroup;
 			children = (
+				B030B4D92A8CE1CA0023DB8B /* LockedWalletMainContent */,
 				B09310592A0BC03100F6043A /* MainHeaderView */,
 				B06C085C2A73FC9A00D982BC /* MainCardPageBuilder */,
 				B06C08512A73FC1B00D982BC /* MultiWalletMainContent */,
@@ -6065,6 +6079,7 @@
 				B0B712192A41639200A9479C /* TokenDetailsHeaderView.swift in Sources */,
 				EF808436293F39D6000D91EA /* UserCurrenciesProvider.swift in Sources */,
 				B6ED083A2A7DB99D0090E51F /* OrganizeTokensOptionsConverter.swift in Sources */,
+				B030B4DD2A8CE20E0023DB8B /* LockedWalletMainContentViewModel.swift in Sources */,
 				DCE5C66C28898B7F000C7F67 /* TangemApiService.swift in Sources */,
 				5DDFC2042812B72C005976FE /* Currency.swift in Sources */,
 				EFA6B04029532D520090A92F /* CircleActionButton.swift in Sources */,
@@ -6797,6 +6812,7 @@
 				B09E518A298104670042998A /* DeprecationServicing.swift in Sources */,
 				B0C4A1D32671F3FC00DCB921 /* TestnetBuyCryptoService.swift in Sources */,
 				B6E932C22A2F2D860068D466 /* OrganizeTokensView.swift in Sources */,
+				B030B4DB2A8CE1DA0023DB8B /* LockedWalletMainContentView.swift in Sources */,
 				EFEC653F292E1B9800AE8521 /* SwappingCoordinatorView.swift in Sources */,
 				B0C4F77D26F0BFF90086D815 /* OnboardingMessagesView.swift in Sources */,
 				5D96BD2A27F60B0D000AA797 /* TokenIconView.swift in Sources */,


### PR DESCRIPTION
Сделал отдельную вьюху и вью модель, чтобы не захламлять `MultiWalletContentView` и `SingleWalletContentView` всякими заглушками. В приложении пока что выглядит иначе, потому что нужны доработке в `CardsInfoPagerView` с добавлением неподвижного футера для кнопки
<img width="489" alt="TangemApp — LockedWalletMainContentView swift 2023-08-17 11-38-33" src="https://github.com/tangem/tangem-app-ios/assets/24321494/7dc2979b-50b7-49d4-8ae7-b50828394cf2">
<img width="505" alt="TangemApp — LockedWalletMainContentView swift 2023-08-17 11-38-21" src="https://github.com/tangem/tangem-app-ios/assets/24321494/15ba3daf-4fb5-42b2-b06a-85443d2b6536">
<img width="532" alt="TangemApp — LockedWalletMainContentView swift 2023-08-17 11-38-11" src="https://github.com/tangem/tangem-app-ios/assets/24321494/6149d371-5430-4d11-83e2-1791a1de3d49">
<img width="528" alt="TangemApp — LockedWalletMainContentView swift 2023-08-17 11-37-48" src="https://github.com/tangem/tangem-app-ios/assets/24321494/a00c303a-26cf-4529-954a-c94afa87d258">
