### PR TITLE
IOS-4288 Fix wc walletModel getter

### DIFF
--- a/Tangem/App/Services/WalletConnect/Utilities/WalletConnectWalletModelProvider.swift
+++ b/Tangem/App/Services/WalletConnect/Utilities/WalletConnectWalletModelProvider.swift
@@ -14,10 +14,18 @@ protocol WalletConnectWalletModelProvider {
     // So we need to compare blockchain and address to simulate comparision of derivation path
     // Information about address is encoded in request params and info about blockchain - request chainId
     func getModel(with address: String, blockchainId: String) throws -> WalletModel
+
+    func getModels(with blockchainId: String) -> [WalletModel]
 }
 
 struct CommonWalletConnectWalletModelProvider: WalletConnectWalletModelProvider {
     private let walletModelsManager: WalletModelsManager
+
+    private var mainWalletModels: [WalletModel] {
+        walletModelsManager.walletModels.filter {
+            $0.isMainToken
+        }
+    }
 
     init(walletModelsManager: WalletModelsManager) {
         self.walletModelsManager = walletModelsManager
@@ -25,13 +33,18 @@ struct CommonWalletConnectWalletModelProvider: WalletConnectWalletModelProvider 
 
     func getModel(with address: String, blockchainId: String) throws -> WalletModel {
         guard
-            let model = walletModelsManager.walletModels.first(where: {
-                $0.wallet.blockchain.coinId == blockchainId && $0.wallet.address.caseInsensitiveCompare(address) == .orderedSame
+            let model = mainWalletModels.first(where: {
+                $0.blockchainNetwork.blockchain.coinId == blockchainId
+                    && $0.wallet.address.caseInsensitiveCompare(address) == .orderedSame
             })
         else {
             throw WalletConnectV2Error.walletModelNotFound(blockchainId)
         }
 
         return model
+    }
+
+    func getModels(with blockchainId: String) -> [WalletModel] {
+        return mainWalletModels.filter { $0.blockchainNetwork.blockchain.coinId == blockchainId }
     }
 }

--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/Utilities/WalletConnectV2Utils.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/Utilities/WalletConnectV2Utils.swift
@@ -36,8 +36,8 @@ struct WalletConnectV2Utils {
     /// in an alert with new session connection request
     /// - Returns:
     /// Array of strings with the blockchain names
-    func getBlockchainNamesFromNamespaces(_ namespaces: [String: SessionNamespace], using walletModels: [WalletModel]) -> [String] {
-        let blockchainNetworks = mapBlockchainNetworks(from: namespaces, using: walletModels)
+    func getBlockchainNamesFromNamespaces(_ namespaces: [String: SessionNamespace], walletModelProvider: WalletConnectWalletModelProvider) -> [String] {
+        let blockchainNetworks = mapBlockchainNetworks(from: namespaces, walletModelProvider: walletModelProvider)
 
         return blockchainNetworks.map { $0.blockchain.displayName }
     }
@@ -82,8 +82,7 @@ struct WalletConnectV2Utils {
     /// - Returns:
     /// Dictionary with `chains` (`WalletConnectSwiftV2` terminology) as keys and session settings as values.
     /// - Throws:Error with list of unsupported blockchain names or a list of not added to user token list blockchain names
-    func createSessionNamespaces(from namespaces: [String: ProposalNamespace], optionalNamespaces: [String: ProposalNamespace]?, for wallets: [WalletModel]) throws -> [String: SessionNamespace] {
-        let wallets = wallets.filter { $0.isMainToken }
+    func createSessionNamespaces(from namespaces: [String: ProposalNamespace], optionalNamespaces: [String: ProposalNamespace]?, walletModelProvider: WalletConnectWalletModelProvider) throws -> [String: SessionNamespace] {
         var sessionNamespaces: [String: SessionNamespace] = [:]
         var missingBlockchains: [String] = []
         var unsupportedEVMBlockchains: [String] = []
@@ -101,7 +100,7 @@ struct WalletConnectV2Utils {
                 }
 
                 supportedChains.insert(wcBlockchain)
-                let filteredWallets = wallets.filter { $0.blockchainNetwork.blockchain.coinId == blockchain.id }
+                let filteredWallets = walletModelProvider.getModels(with: blockchain.id)
                 if filteredWallets.isEmpty {
                     missingBlockchains.append(blockchain.displayName)
                     return nil
@@ -131,7 +130,7 @@ struct WalletConnectV2Utils {
                 }
 
                 supportedChains.insert(wcBlockchain)
-                let filteredWallets = wallets.filter { $0.blockchainNetwork.blockchain.coinId == blockchain.id }
+                let filteredWallets = walletModelProvider.getModels(with: blockchain.id)
                 if filteredWallets.isEmpty {
                     return nil
                 }
@@ -215,12 +214,12 @@ struct WalletConnectV2Utils {
         }
     }
 
-    private func mapBlockchainNetworks(from namespaces: [String: SessionNamespace], using wallets: [WalletModel]) -> [BlockchainNetwork] {
+    private func mapBlockchainNetworks(from namespaces: [String: SessionNamespace], walletModelProvider: WalletConnectWalletModelProvider) -> [BlockchainNetwork] {
         return namespaces.values.flatMap {
             let wcBlockchains = $0.accounts.compactMap { ($0.blockchain, $0.address) }
 
             let tangemBlockchains = wcBlockchains.compactMap {
-                createBlockchainNetwork(from: $0.0, with: $0.1, using: wallets)
+                createBlockchainNetwork(from: $0.0, with: $0.1, walletModelProvider: walletModelProvider)
             }
             return tangemBlockchains
         }
@@ -229,13 +228,13 @@ struct WalletConnectV2Utils {
     private func createBlockchainNetwork(
         from wcBlockchain: WalletConnectSwiftV2.Blockchain,
         with address: String,
-        using walletModels: [WalletModel]
+        walletModelProvider: WalletConnectWalletModelProvider
     ) -> BlockchainNetwork? {
         switch wcBlockchain.namespace {
         case evmNamespace:
             guard
                 let blockchain = createBlockchain(for: wcBlockchain),
-                let walletModel = walletModels.first(where: { $0.wallet.blockchain.coinId == blockchain.id && $0.wallet.address == address })
+                let walletModel = try? walletModelProvider.getModel(with: address, blockchainId: blockchain.id)
             else {
                 return nil
             }

--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
@@ -13,8 +13,8 @@ import BlockchainSdk
 
 protocol WalletConnectUserWalletInfoProvider {
     var userWalletId: UserWalletId { get }
-    var walletModels: [WalletModel] { get }
     var signer: TangemSigner { get }
+    var wcWalletModelProvider: WalletConnectWalletModelProvider { get }
 }
 
 final class WalletConnectV2Service {
@@ -251,7 +251,7 @@ final class WalletConnectV2Service {
             let sessionNamespaces = try utils.createSessionNamespaces(
                 from: proposal.requiredNamespaces,
                 optionalNamespaces: proposal.optionalNamespaces,
-                for: infoProvider.walletModels
+                walletModelProvider: infoProvider.wcWalletModelProvider
             )
             displaySessionConnectionUI(for: proposal, namespaces: sessionNamespaces)
         } catch let error as WalletConnectV2Error {
@@ -273,7 +273,7 @@ final class WalletConnectV2Service {
             return
         }
 
-        let blockchains = WalletConnectV2Utils().getBlockchainNamesFromNamespaces(namespaces, using: infoProvider.walletModels)
+        let blockchains = WalletConnectV2Utils().getBlockchainNamesFromNamespaces(namespaces, walletModelProvider: infoProvider.wcWalletModelProvider)
         let message = messageComposer.makeMessage(for: proposal, targetBlockchains: blockchains)
         uiDelegate.showScreen(with: WalletConnectUIRequest(
             event: .establishSession,

--- a/Tangem/App/ViewModels/CardViewModel.swift
+++ b/Tangem/App/ViewModels/CardViewModel.swift
@@ -510,9 +510,8 @@ extension CardViewModel {
 }
 
 extension CardViewModel: WalletConnectUserWalletInfoProvider {
-    // TODO: remove?
-    var walletModels: [WalletModel] {
-        walletModelsManager.walletModels
+    var wcWalletModelProvider: WalletConnectWalletModelProvider {
+        CommonWalletConnectWalletModelProvider(walletModelsManager: walletModelsManager)
     }
 }
 

--- a/Tangem/Modules/Details/DetailsViewModel.swift
+++ b/Tangem/Modules/Details/DetailsViewModel.swift
@@ -89,7 +89,7 @@ extension DetailsViewModel {
         guard let emailConfig = cardModel.emailConfig else { return }
 
         let dataCollector = DetailsFeedbackDataCollector(
-            walletModels: cardModel.walletModels,
+            walletModels: cardModel.walletModelsManager.walletModels,
             userWalletEmailData: cardModel.emailData
         )
 
@@ -119,7 +119,7 @@ extension DetailsViewModel {
         Analytics.log(.settingsButtonChat)
 
         let dataCollector = DetailsFeedbackDataCollector(
-            walletModels: cardModel.walletModels,
+            walletModels: cardModel.walletModelsManager.walletModels,
             userWalletEmailData: cardModel.emailData
         )
 

--- a/Tangem/Modules/LegacyMain/LegacyAddressDetailView.swift
+++ b/Tangem/Modules/LegacyMain/LegacyAddressDetailView.swift
@@ -110,7 +110,7 @@ struct LegacyAddressDetailView_Previews: PreviewProvider {
             Color.tangemBgGray
             LegacyAddressDetailView(
                 selectedAddressIndex: .constant(0),
-                walletModel: PreviewCard.v4.cardModel.walletModels.first!,
+                walletModel: PreviewCard.v4.cardModel.walletModelsManager.walletModels.first!,
                 copyAddress: {},
                 showQr: {},
                 showExplorerURL: { _ in }

--- a/Tangem/Modules/LegacyMain/LegacyMainCoordinator.swift
+++ b/Tangem/Modules/LegacyMain/LegacyMainCoordinator.swift
@@ -210,7 +210,7 @@ extension LegacyMainCoordinator: LegacyMainRoutable {
         }
 
         if FeatureProvider.isAvailable(.tokenDetailsV2) {
-            guard let walletModel = cardModel.walletModels.first(where: { $0.blockchainNetwork == blockchainNetwork }) else {
+            guard let walletModel = cardModel.walletModelsManager.walletModels.first(where: { $0.blockchainNetwork == blockchainNetwork }) else {
                 return
             }
 

--- a/Tangem/Modules/LegacyMain/LegacyMainViewModel.swift
+++ b/Tangem/Modules/LegacyMain/LegacyMainViewModel.swift
@@ -601,13 +601,13 @@ extension LegacyMainViewModel {
     }
 
     func openSend(for amountToSend: Amount) {
-        guard let blockchainNetwork = cardModel.walletModels.first?.blockchainNetwork else { return }
+        guard let blockchainNetwork = cardModel.walletModelsManager.walletModels.first?.blockchainNetwork else { return }
 
         coordinator.openSend(amountToSend: amountToSend, blockchainNetwork: blockchainNetwork, cardViewModel: cardModel)
     }
 
     func openSendToSell(with request: SellCryptoRequest) {
-        guard let blockchainNetwork = cardModel.walletModels.first?.blockchainNetwork else { return }
+        guard let blockchainNetwork = cardModel.walletModelsManager.walletModels.first?.blockchainNetwork else { return }
 
         let amount = Amount(with: blockchainNetwork.blockchain, value: request.amount)
         coordinator.openSendToSell(
@@ -641,7 +641,7 @@ extension LegacyMainViewModel {
             return
         }
 
-        if let walletModel = cardModel.walletModels.first,
+        if let walletModel = cardModel.walletModelsManager.walletModels.first,
            walletModel.wallet.blockchain == .ethereum(testnet: true),
            let token = walletModel.wallet.amounts.keys.compactMap({ $0.token }).first {
             testnetBuyCryptoService.buyCrypto(.erc20Token(token, walletModel: walletModel, signer: cardModel.signer))

--- a/Tangem/Modules/LegacyTokenDetails/BalanceAddressView.swift
+++ b/Tangem/Modules/LegacyTokenDetails/BalanceAddressView.swift
@@ -189,7 +189,7 @@ struct BalanceAddressView: View {
 
 struct BalanceAddressView_Previews: PreviewProvider {
     static var walletModel: WalletModel {
-        let vm = PreviewCard.stellar.cardModel.walletModels.first!
+        let vm = PreviewCard.stellar.cardModel.walletModelsManager.walletModels.first!
         return vm
     }
 

--- a/Tangem/Modules/LegacyTokenDetails/LegacyTokenDetailsViewModel.swift
+++ b/Tangem/Modules/LegacyTokenDetails/LegacyTokenDetailsViewModel.swift
@@ -191,7 +191,7 @@ class LegacyTokenDetailsViewModel: ObservableObject {
         self.amountType = amountType
         self.coordinator = coordinator
 
-        walletModel = card.walletModels.first(where: { $0.amountType == amountType && $0.blockchainNetwork == blockchainNetwork })
+        walletModel = card.walletModelsManager.walletModels.first(where: { $0.amountType == amountType && $0.blockchainNetwork == blockchainNetwork })
 
         bind()
         updateSwapAvailability()

--- a/Tangem/Modules/Onboarding/BaseModels/OnboardingTopupViewModel.swift
+++ b/Tangem/Modules/Onboarding/BaseModels/OnboardingTopupViewModel.swift
@@ -21,7 +21,7 @@ class OnboardingTopupViewModel<Step: OnboardingStep, Coordinator: OnboardingTopu
     var walletModelUpdateCancellable: AnyCancellable?
 
     var buyCryptoURL: URL? {
-        if let wallet = cardModel?.walletModels.first?.wallet {
+        if let wallet = cardModel?.walletModelsManager.walletModels.first?.wallet {
             return exchangeService.getBuyUrl(
                 currencySymbol: wallet.blockchain.currencySymbol,
                 amountType: .coin,
@@ -36,22 +36,22 @@ class OnboardingTopupViewModel<Step: OnboardingStep, Coordinator: OnboardingTopu
     var buyCryptoCloseUrl: String { exchangeService.successCloseUrl.removeLatestSlash() }
 
     private var shareAddress: String {
-        cardModel?.walletModels.first?.shareAddressString(for: 0) ?? ""
+        cardModel?.walletModelsManager.walletModels.first?.shareAddressString(for: 0) ?? ""
     }
 
     private var walletAddress: String {
-        cardModel?.walletModels.first?.displayAddress(for: 0) ?? ""
+        cardModel?.walletModelsManager.walletModels.first?.displayAddress(for: 0) ?? ""
     }
 
     private var qrNoticeMessage: String {
-        cardModel?.walletModels.first?.qrReceiveMessage ?? ""
+        cardModel?.walletModelsManager.walletModels.first?.qrReceiveMessage ?? ""
     }
 
     private var refreshButtonDispatchWork: DispatchWorkItem?
 
     func updateCardBalance(shouldGoToNextStep: Bool = true) {
         guard
-            let walletModel = cardModel?.walletModels.first,
+            let walletModel = cardModel?.walletModelsManager.walletModels.first,
             walletModelUpdateCancellable == nil
         else { return }
 

--- a/Tangem/Modules/Onboarding/BaseModels/OnboardingViewModel.swift
+++ b/Tangem/Modules/Onboarding/BaseModels/OnboardingViewModel.swift
@@ -374,7 +374,7 @@ extension OnboardingViewModel {
         UIApplication.shared.endEditing()
 
         let dataCollector = DetailsFeedbackDataCollector(
-            walletModels: cardModel?.walletModels ?? [],
+            walletModels: cardModel?.walletModelsManager.walletModels ?? [],
             userWalletEmailData: input.cardInput.emailData
         )
 

--- a/Tangem/Modules/Onboarding/Note/SingleCardOnboardingViewModel.swift
+++ b/Tangem/Modules/Onboarding/Note/SingleCardOnboardingViewModel.swift
@@ -27,7 +27,7 @@ class SingleCardOnboardingViewModel: OnboardingTopupViewModel<SingleCardOnboardi
 
     override var subtitle: String? {
         if currentStep == .topup,
-           case .xrp = cardModel?.walletModels.first?.blockchainNetwork.blockchain {
+           case .xrp = cardModel?.walletModelsManager.walletModels.first?.blockchainNetwork.blockchain {
             return Localization.onboardingTopUpBodyNoAccountError("10", "XRP")
         } else {
             return super.subtitle
@@ -94,7 +94,7 @@ class SingleCardOnboardingViewModel: OnboardingTopupViewModel<SingleCardOnboardi
     private var scheduledUpdate: DispatchWorkItem?
 
     private var canBuyCrypto: Bool {
-        if let blockchain = cardModel?.walletModels.first?.blockchainNetwork.blockchain,
+        if let blockchain = cardModel?.walletModelsManager.walletModels.first?.blockchainNetwork.blockchain,
            exchangeService.canBuy(blockchain.currencySymbol, amountType: .coin, blockchain: blockchain) {
             return true
         }
@@ -111,7 +111,7 @@ class SingleCardOnboardingViewModel: OnboardingTopupViewModel<SingleCardOnboardi
             fatalError("Wrong onboarding steps passed to initializer")
         }
 
-        if let walletModel = cardModel?.walletModels.first {
+        if let walletModel = cardModel?.walletModelsManager.walletModels.first {
             updateCardBalanceText(for: walletModel)
         }
 
@@ -138,7 +138,7 @@ class SingleCardOnboardingViewModel: OnboardingTopupViewModel<SingleCardOnboardi
 
                 switch currentStep {
                 case .topup:
-                    if let walletModel = cardModel?.walletModels.first {
+                    if let walletModel = cardModel?.walletModelsManager.walletModels.first {
                         updateCardBalanceText(for: walletModel)
                     }
 

--- a/Tangem/Modules/Onboarding/Twins/TwinsOnboardingViewModel.swift
+++ b/Tangem/Modules/Onboarding/Twins/TwinsOnboardingViewModel.swift
@@ -139,7 +139,7 @@ class TwinsOnboardingViewModel: OnboardingTopupViewModel<TwinsOnboardingStep, On
 
         super.init(input: input, coordinator: coordinator)
 
-        if let walletModel = cardModel?.walletModels.first {
+        if let walletModel = cardModel?.walletModelsManager.walletModels.first {
             updateCardBalanceText(for: walletModel)
         }
 

--- a/Tangem/Modules/PushTx/PushTxViewModel.swift
+++ b/Tangem/Modules/PushTx/PushTxViewModel.swift
@@ -37,7 +37,7 @@ class PushTxViewModel: ObservableObject {
 
     var walletModel: WalletModel {
         let id = WalletModel.Id(blockchainNetwork: blockchainNetwork, amountType: amountToSend.type).id
-        return cardViewModel.walletModels.first(where: { $0.id == id })!
+        return cardViewModel.walletModelsManager.walletModels.first(where: { $0.id == id })!
     }
 
     var previousFeeAmount: Amount { transaction.fee.amount }

--- a/Tangem/Modules/Send/SendViewModel.swift
+++ b/Tangem/Modules/Send/SendViewModel.swift
@@ -120,7 +120,7 @@ class SendViewModel: ObservableObject {
 
     var walletModel: WalletModel {
         let id = WalletModel.Id(blockchainNetwork: blockchainNetwork, amountType: amountToSend.type).id
-        return cardViewModel.walletModels.first(where: { $0.id == id })!
+        return cardViewModel.walletModelsManager.walletModels.first(where: { $0.id == id })!
     }
 
     var bag = Set<AnyCancellable>()


### PR DESCRIPTION
Проблема была в том, что неправильно выбиралась walletModel для WC. Из-за того, что в нашем распоряжении только id блокчейна и адрес, мы не сможем составить WalletModel.Id. Приходится искать по ним через first и в этот критерий попадали как main модели, так и модели токенов.

- Я добавил фильтрацию по isMainToken (она и так была, да не везде)
- Всего код использовался в трех разных местах, поэтому я слегка подрефакторил, чтобы везде ходить за моделями через один интерфейс и не было рассинхрона
- Как бонус удалился геттер walletModels из CardViewModel, что облегчит дальнейший рефакторинг. 
- Большинство изменений вида walletModels -> walletModelsManager.walletModels