### PR TITLE
IOS-4161 main locked card bottom sheet

### DIFF
--- a/Tangem/App/Services/UserWalletRepository/CommonUserWalletRepository.swift
+++ b/Tangem/App/Services/UserWalletRepository/CommonUserWalletRepository.swift
@@ -470,7 +470,7 @@ class CommonUserWalletRepository: UserWalletRepository {
 
                 if let requiredUserWallet,
                    scannedUserWallet.userWalletId != requiredUserWallet.userWalletId {
-                    completion(.error(TangemSdkError.cardError))
+                    completion(.error(UserWalletRepositoryError.cardWithWrongUserWalletIdScanned))
                     return
                 }
 

--- a/Tangem/App/Services/UserWalletRepository/UserWalletRepository.swift
+++ b/Tangem/App/Services/UserWalletRepository/UserWalletRepository.swift
@@ -111,7 +111,7 @@ enum UserWalletRepositoryError: String, Error, LocalizedError, BindableError {
         case .biometricsChanged:
             return .init(title: Localization.commonAttention, message: Localization.keyInvalidatedWarningDescription)
         case .cardWithWrongUserWalletIdScanned:
-            return .init(title: Localization.commonAttention, message: Localization.errorWrongWalletTapped)
+            return .init(title: Localization.commonWarning, message: Localization.errorWrongWalletTapped)
         }
     }
 }

--- a/Tangem/App/Services/UserWalletRepository/UserWalletRepository.swift
+++ b/Tangem/App/Services/UserWalletRepository/UserWalletRepository.swift
@@ -98,6 +98,7 @@ enum UserWalletRepositoryUnlockMethod {
 enum UserWalletRepositoryError: String, Error, LocalizedError, BindableError {
     case duplicateWalletAdded
     case biometricsChanged
+    case cardWithWrongUserWalletIdScanned
 
     var errorDescription: String? {
         rawValue
@@ -109,6 +110,8 @@ enum UserWalletRepositoryError: String, Error, LocalizedError, BindableError {
             return .init(title: "", message: Localization.userWalletListErrorWalletAlreadySaved)
         case .biometricsChanged:
             return .init(title: Localization.commonAttention, message: Localization.keyInvalidatedWarningDescription)
+        case .cardWithWrongUserWalletIdScanned:
+            return .init(title: Localization.commonAttention, message: Localization.errorWrongWalletTapped)
         }
     }
 }

--- a/Tangem/Modules/Main/LockedWalletMainContent/LockedWalletMainContentView.swift
+++ b/Tangem/Modules/Main/LockedWalletMainContent/LockedWalletMainContentView.swift
@@ -143,13 +143,13 @@ struct LockedWalletMainContentView: View {
 struct LockedWalletMainContentView_Previews: PreviewProvider {
     static var previews: some View {
         LockedWalletMainContentView(
-            viewModel: .init(userWalletModel: FakeUserWalletModel.wallet3Cards)
+            viewModel: .init(userWalletModel: FakeUserWalletModel.wallet3Cards, lockedWalletDelegate: nil)
         )
         .infinityFrame()
         .background(Colors.Background.secondary.edgesIgnoringSafeArea(.all))
 
         LockedWalletMainContentView(
-            viewModel: .init(userWalletModel: FakeUserWalletModel.twins)
+            viewModel: .init(userWalletModel: FakeUserWalletModel.twins, lockedWalletDelegate: nil)
         )
         .infinityFrame()
         .background(Colors.Background.secondary.edgesIgnoringSafeArea(.all))

--- a/Tangem/Modules/Main/LockedWalletMainContent/LockedWalletMainContentView.swift
+++ b/Tangem/Modules/Main/LockedWalletMainContent/LockedWalletMainContentView.swift
@@ -143,13 +143,13 @@ struct LockedWalletMainContentView: View {
 struct LockedWalletMainContentView_Previews: PreviewProvider {
     static var previews: some View {
         LockedWalletMainContentView(
-            viewModel: .init(userWalletModel: FakeUserWalletModel.wallet3Cards, lockedWalletDelegate: nil)
+            viewModel: .init(userWalletModel: FakeUserWalletModel.wallet3Cards, lockedUserWalletDelegate: nil)
         )
         .infinityFrame()
         .background(Colors.Background.secondary.edgesIgnoringSafeArea(.all))
 
         LockedWalletMainContentView(
-            viewModel: .init(userWalletModel: FakeUserWalletModel.twins, lockedWalletDelegate: nil)
+            viewModel: .init(userWalletModel: FakeUserWalletModel.twins, lockedUserWalletDelegate: nil)
         )
         .infinityFrame()
         .background(Colors.Background.secondary.edgesIgnoringSafeArea(.all))

--- a/Tangem/Modules/Main/LockedWalletMainContent/LockedWalletMainContentViewModel.swift
+++ b/Tangem/Modules/Main/LockedWalletMainContent/LockedWalletMainContentViewModel.swift
@@ -8,6 +8,10 @@
 
 import Combine
 
+protocol LockedWalletDelegate: AnyObject {
+    func openUnlockSheet(for userWalletModel: UserWalletModel)
+}
+
 class LockedWalletMainContentViewModel: ObservableObject {
     lazy var lockedNotificationInput: NotificationViewInput = {
         let factory = NotificationSettingsFactory()
@@ -33,12 +37,14 @@ class LockedWalletMainContentViewModel: ObservableObject {
     }
 
     private let userWalletModel: UserWalletModel
+    private weak var lockedWalletDelegate: LockedWalletDelegate?
 
-    init(userWalletModel: UserWalletModel) {
+    init(userWalletModel: UserWalletModel, lockedWalletDelegate: LockedWalletDelegate?) {
         self.userWalletModel = userWalletModel
+        self.lockedWalletDelegate = lockedWalletDelegate
     }
 
     private func openUnlockSheet() {
-        // TODO: Will be implemented in IOS-4161
+        lockedWalletDelegate?.openUnlockSheet(for: userWalletModel)
     }
 }

--- a/Tangem/Modules/Main/LockedWalletMainContent/LockedWalletMainContentViewModel.swift
+++ b/Tangem/Modules/Main/LockedWalletMainContent/LockedWalletMainContentViewModel.swift
@@ -8,8 +8,8 @@
 
 import Combine
 
-protocol LockedWalletDelegate: AnyObject {
-    func openUnlockSheet(for userWalletModel: UserWalletModel)
+protocol MainLockedUserWalletDelegate: AnyObject {
+    func openUnlockUserWalletBottomSheet(for userWalletModel: UserWalletModel)
 }
 
 class LockedWalletMainContentViewModel: ObservableObject {
@@ -37,14 +37,14 @@ class LockedWalletMainContentViewModel: ObservableObject {
     }
 
     private let userWalletModel: UserWalletModel
-    private weak var lockedWalletDelegate: LockedWalletDelegate?
+    private weak var lockedUserWalletDelegate: MainLockedUserWalletDelegate?
 
-    init(userWalletModel: UserWalletModel, lockedWalletDelegate: LockedWalletDelegate?) {
+    init(userWalletModel: UserWalletModel, lockedUserWalletDelegate: MainLockedUserWalletDelegate?) {
         self.userWalletModel = userWalletModel
-        self.lockedWalletDelegate = lockedWalletDelegate
+        self.lockedUserWalletDelegate = lockedUserWalletDelegate
     }
 
     private func openUnlockSheet() {
-        lockedWalletDelegate?.openUnlockSheet(for: userWalletModel)
+        lockedUserWalletDelegate?.openUnlockUserWalletBottomSheet(for: userWalletModel)
     }
 }

--- a/Tangem/Modules/Main/MainCardPageBuilder/MainUserWalletPageBuilder.swift
+++ b/Tangem/Modules/Main/MainCardPageBuilder/MainUserWalletPageBuilder.swift
@@ -55,6 +55,7 @@ enum MainUserWalletPageBuilder: Identifiable {
                 .id(id)
         case .lockedWallet(let id, _, let bodyModel):
             LockedWalletMainContentView(viewModel: bodyModel)
+                .id(id)
         }
     }
 }

--- a/Tangem/Modules/Main/MainCardPageBuilder/MainUserWalletPageBuilderFactory.swift
+++ b/Tangem/Modules/Main/MainCardPageBuilder/MainUserWalletPageBuilderFactory.swift
@@ -9,14 +9,14 @@
 import Foundation
 
 protocol MainUserWalletPageBuilderFactory {
-    var unlockUserWalletDelegate: LockedWalletDelegate? { get set }
+    var lockedUserWalletDelegate: MainLockedUserWalletDelegate? { get set }
     func createPage(for model: UserWalletModel) -> MainUserWalletPageBuilder?
     func createPages(from models: [UserWalletModel]) -> [MainUserWalletPageBuilder]
 }
 
 struct CommonMainUserWalletPageBuilderFactory: MainUserWalletPageBuilderFactory {
     let coordinator: MultiWalletMainContentRoutable & SingleWalletMainContentRoutable
-    weak var unlockUserWalletDelegate: LockedWalletDelegate?
+    weak var lockedUserWalletDelegate: MainLockedUserWalletDelegate?
 
     func createPage(for model: UserWalletModel) -> MainUserWalletPageBuilder? {
         let id = model.userWalletId
@@ -33,7 +33,7 @@ struct CommonMainUserWalletPageBuilderFactory: MainUserWalletPageBuilderFactory 
                 headerModel: headerModel,
                 bodyModel: .init(
                     userWalletModel: model,
-                    lockedWalletDelegate: unlockUserWalletDelegate
+                    lockedUserWalletDelegate: lockedUserWalletDelegate
                 )
             )
         }

--- a/Tangem/Modules/Main/MainCardPageBuilder/MainUserWalletPageBuilderFactory.swift
+++ b/Tangem/Modules/Main/MainCardPageBuilder/MainUserWalletPageBuilderFactory.swift
@@ -9,16 +9,14 @@
 import Foundation
 
 protocol MainUserWalletPageBuilderFactory {
-    var lockedUserWalletDelegate: MainLockedUserWalletDelegate? { get set }
-    func createPage(for model: UserWalletModel) -> MainUserWalletPageBuilder?
-    func createPages(from models: [UserWalletModel]) -> [MainUserWalletPageBuilder]
+    func createPage(for model: UserWalletModel, lockedUserWalletDelegate: MainLockedUserWalletDelegate) -> MainUserWalletPageBuilder?
+    func createPages(from models: [UserWalletModel], lockedUserWalletDelegate: MainLockedUserWalletDelegate) -> [MainUserWalletPageBuilder]
 }
 
 struct CommonMainUserWalletPageBuilderFactory: MainUserWalletPageBuilderFactory {
     let coordinator: MultiWalletMainContentRoutable & SingleWalletMainContentRoutable
-    weak var lockedUserWalletDelegate: MainLockedUserWalletDelegate?
 
-    func createPage(for model: UserWalletModel) -> MainUserWalletPageBuilder? {
+    func createPage(for model: UserWalletModel, lockedUserWalletDelegate: MainLockedUserWalletDelegate) -> MainUserWalletPageBuilder? {
         let id = model.userWalletId
         let subtitleProvider = MainHeaderSubtitleProviderFactory().provider(for: model)
         let headerModel = MainHeaderViewModel(
@@ -82,7 +80,7 @@ struct CommonMainUserWalletPageBuilderFactory: MainUserWalletPageBuilderFactory 
         )
     }
 
-    func createPages(from models: [UserWalletModel]) -> [MainUserWalletPageBuilder] {
-        return models.compactMap(createPage(for:))
+    func createPages(from models: [UserWalletModel], lockedUserWalletDelegate: MainLockedUserWalletDelegate) -> [MainUserWalletPageBuilder] {
+        return models.compactMap { createPage(for: $0, lockedUserWalletDelegate: lockedUserWalletDelegate) }
     }
 }

--- a/Tangem/Modules/Main/MainCardPageBuilder/MainUserWalletPageBuilderFactory.swift
+++ b/Tangem/Modules/Main/MainCardPageBuilder/MainUserWalletPageBuilderFactory.swift
@@ -9,12 +9,14 @@
 import Foundation
 
 protocol MainUserWalletPageBuilderFactory {
+    var unlockUserWalletDelegate: LockedWalletDelegate? { get set }
     func createPage(for model: UserWalletModel) -> MainUserWalletPageBuilder?
     func createPages(from models: [UserWalletModel]) -> [MainUserWalletPageBuilder]
 }
 
 struct CommonMainUserWalletPageBuilderFactory: MainUserWalletPageBuilderFactory {
     let coordinator: MultiWalletMainContentRoutable & SingleWalletMainContentRoutable
+    weak var unlockUserWalletDelegate: LockedWalletDelegate?
 
     func createPage(for model: UserWalletModel) -> MainUserWalletPageBuilder? {
         let id = model.userWalletId
@@ -26,7 +28,14 @@ struct CommonMainUserWalletPageBuilderFactory: MainUserWalletPageBuilderFactory 
         )
 
         if model.isUserWalletLocked {
-            return .lockedWallet(id: id, headerModel: headerModel, bodyModel: .init(userWalletModel: model))
+            return .lockedWallet(
+                id: id,
+                headerModel: headerModel,
+                bodyModel: .init(
+                    userWalletModel: model,
+                    lockedWalletDelegate: unlockUserWalletDelegate
+                )
+            )
         }
 
         if model.isMultiWallet {

--- a/Tangem/Modules/Main/MainView.swift
+++ b/Tangem/Modules/Main/MainView.swift
@@ -65,7 +65,10 @@ struct MainView: View {
                 ]
             )
         }
-        .bottomSheet(item: $viewModel.unlockWalletBottomSheetViewModel) { model in
+        .bottomSheet(
+            item: $viewModel.unlockWalletBottomSheetViewModel,
+            settings: .init(backgroundColor: Colors.Background.primary)
+        ) { model in
             UnlockUserWalletBottomSheetView(viewModel: model)
         }
         .background(

--- a/Tangem/Modules/Main/MainView.swift
+++ b/Tangem/Modules/Main/MainView.swift
@@ -55,13 +55,6 @@ struct MainView: View {
                 .offset(x: 10)
             }
         })
-        .background(
-            ScanTroubleshootingView(
-                isPresented: $viewModel.showTroubleshootingView,
-                tryAgainAction: viewModel.scanCardAction,
-                requestSupportAction: viewModel.requestSupport
-            )
-        )
         .alert(item: $viewModel.errorAlert) { $0.alert }
         .actionSheet(isPresented: $viewModel.showingDeleteConfirmation) {
             ActionSheet(
@@ -72,6 +65,16 @@ struct MainView: View {
                 ]
             )
         }
+        .bottomSheet(item: $viewModel.unlockWalletBottomSheetViewModel) { model in
+            UnlockUserWalletBottomSheetView(viewModel: model)
+        }
+        .background(
+            ScanTroubleshootingView(
+                isPresented: $viewModel.showTroubleshootingView,
+                tryAgainAction: viewModel.scanCardAction,
+                requestSupportAction: viewModel.requestSupport
+            )
+        )
     }
 
     var scanCardButton: some View {

--- a/Tangem/Modules/Main/MainViewModel.swift
+++ b/Tangem/Modules/Main/MainViewModel.swift
@@ -42,8 +42,7 @@ final class MainViewModel: ObservableObject {
         self.coordinator = coordinator
         self.mainUserWalletPageBuilderFactory = mainUserWalletPageBuilderFactory
 
-        self.mainUserWalletPageBuilderFactory.lockedUserWalletDelegate = self
-        pages = self.mainUserWalletPageBuilderFactory.createPages(from: userWalletRepository.models)
+        pages = mainUserWalletPageBuilderFactory.createPages(from: userWalletRepository.models, lockedUserWalletDelegate: self)
         bind()
     }
 
@@ -173,7 +172,7 @@ final class MainViewModel: ObservableObject {
             return
         }
 
-        guard let newPage = mainUserWalletPageBuilderFactory.createPage(for: userWalletModel) else {
+        guard let newPage = mainUserWalletPageBuilderFactory.createPage(for: userWalletModel, lockedUserWalletDelegate: self) else {
             return
         }
 
@@ -189,7 +188,7 @@ final class MainViewModel: ObservableObject {
     }
 
     private func recreatePages() {
-        pages = mainUserWalletPageBuilderFactory.createPages(from: userWalletRepository.models)
+        pages = mainUserWalletPageBuilderFactory.createPages(from: userWalletRepository.models, lockedUserWalletDelegate: self)
     }
 
     // MARK: - Private functions
@@ -271,7 +270,7 @@ extension MainViewModel: UnlockUserWalletBottomSheetDelegate {
     func userWalletUnlocked(_ userWalletModel: UserWalletModel) {
         guard
             let index = pages.firstIndex(where: { $0.id == userWalletModel.userWalletId }),
-            let page = mainUserWalletPageBuilderFactory.createPage(for: userWalletModel)
+            let page = mainUserWalletPageBuilderFactory.createPage(for: userWalletModel, lockedUserWalletDelegate: self)
         else {
             return
         }

--- a/Tangem/Modules/Main/MainViewModel.swift
+++ b/Tangem/Modules/Main/MainViewModel.swift
@@ -42,7 +42,7 @@ final class MainViewModel: ObservableObject {
         self.coordinator = coordinator
         self.mainUserWalletPageBuilderFactory = mainUserWalletPageBuilderFactory
 
-        self.mainUserWalletPageBuilderFactory.unlockUserWalletDelegate = self
+        self.mainUserWalletPageBuilderFactory.lockedUserWalletDelegate = self
         pages = self.mainUserWalletPageBuilderFactory.createPages(from: userWalletRepository.models)
         bind()
     }
@@ -188,7 +188,7 @@ final class MainViewModel: ObservableObject {
         }
     }
 
-    private func updateUnlockedPages() {
+    private func recreatePages() {
         pages = mainUserWalletPageBuilderFactory.createPages(from: userWalletRepository.models)
     }
 
@@ -253,8 +253,8 @@ extension MainViewModel {
     }
 }
 
-extension MainViewModel: LockedWalletDelegate {
-    func openUnlockSheet(for userWalletModel: UserWalletModel) {
+extension MainViewModel: MainLockedUserWalletDelegate {
+    func openUnlockUserWalletBottomSheet(for userWalletModel: UserWalletModel) {
         unlockWalletBottomSheetViewModel = .init(
             userWalletModel: userWalletModel,
             delegate: self
@@ -262,10 +262,10 @@ extension MainViewModel: LockedWalletDelegate {
     }
 }
 
-extension MainViewModel: UnlockUserWalletDelegate {
+extension MainViewModel: UnlockUserWalletBottomSheetDelegate {
     func unlockedWithBiometry() {
         unlockWalletBottomSheetViewModel = nil
-        updateUnlockedPages()
+        recreatePages()
     }
 
     func userWalletUnlocked(_ userWalletModel: UserWalletModel) {

--- a/Tangem/Modules/Main/UnlockCardBottomSheet/UnlockUserWalletBottomSheetView.swift
+++ b/Tangem/Modules/Main/UnlockCardBottomSheet/UnlockUserWalletBottomSheetView.swift
@@ -83,7 +83,7 @@ struct UnlockUserWalletBottomSheetView_Previews: PreviewProvider {
                 }
 
                 NavHolder()
-                    .bottomSheet(item: state) { model in
+                    .bottomSheet(item: state, settings: .init(backgroundColor: Colors.Background.primary)) { model in
                         UnlockUserWalletBottomSheetView(viewModel: model)
                     }
             }

--- a/Tangem/Modules/Main/UnlockCardBottomSheet/UnlockUserWalletBottomSheetView.swift
+++ b/Tangem/Modules/Main/UnlockCardBottomSheet/UnlockUserWalletBottomSheetView.swift
@@ -1,0 +1,92 @@
+//
+//  UnlockUserWalletBottomSheetView.swift
+//  Tangem
+//
+//  Created by Andrew Son on 15/08/23.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import SwiftUI
+
+struct UnlockUserWalletBottomSheetView: View {
+    @ObservedObject var viewModel: UnlockUserWalletBottomSheetViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Assets.lockBig.image
+                .foregroundColor(Colors.Icon.primary1)
+                .padding(.top, 46)
+                .padding(.bottom, 30)
+
+            Text(Localization.commonUnlockNeeded)
+                .style(Fonts.Regular.title1, color: Colors.Text.primary1)
+                .padding(.bottom, 14)
+
+            Text(Localization.unlockWalletDescriptionFull(BiometricAuthorizationUtils.biometryType.name))
+                .style(Fonts.Regular.subheadline, color: Colors.Text.secondary)
+                .multilineTextAlignment(.center)
+                .lineSpacing(3)
+                .padding(.bottom, 56)
+                .padding(.horizontal, 34)
+
+            MainButton(
+                title: Localization.userWalletListUnlockAll(BiometricAuthorizationUtils.biometryType.name),
+                action: viewModel.unlockWithBiometry
+            )
+            .padding(.bottom, 10)
+
+            MainButton(
+                title: Localization.scanCardSettingsButton,
+                icon: .trailing(Assets.tangemIcon),
+                style: .secondary,
+                isLoading: viewModel.isScannerBusy,
+                action: viewModel.unlockWithCard
+            )
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, 10)
+        .alert(item: $viewModel.error) { $0.alert }
+    }
+}
+
+struct UnlockUserWalletBottomSheetView_Previews: PreviewProvider {
+    class FakeUnlockUserWalletDelegate: UnlockUserWalletDelegate {
+        func unlockedWithBiometry() {
+            print("Unlocked with biometry")
+        }
+
+        func userWalletUnlocked(_ userWalletModel: UserWalletModel) {
+            print("Unlocked with card: \(userWalletModel.userWalletId.stringValue)")
+        }
+
+        func showTroubleshooting() {
+            print("Request troubleshooting")
+        }
+    }
+
+    static let delegate = FakeUnlockUserWalletDelegate()
+    static var bottomSheetModel: UnlockUserWalletBottomSheetViewModel = {
+        let lockedUserWalletModel = FakeUserWalletModel.twins
+        InjectedValues[\.userWalletRepository] = FakeUserWalletRepository(models: [lockedUserWalletModel])
+
+        return UnlockUserWalletBottomSheetViewModel(
+            userWalletModel: lockedUserWalletModel,
+            delegate: delegate
+        )
+    }()
+
+    static var previews: some View {
+        StatefulPreviewWrapper(UnlockUserWalletBottomSheetViewModel?.none, content: { state in
+            VStack {
+                Button("Open bottom sheet") {
+                    state.wrappedValue = bottomSheetModel
+                }
+
+                NavHolder()
+                    .bottomSheet(item: state) { model in
+                        UnlockUserWalletBottomSheetView(viewModel: model)
+                    }
+            }
+        })
+    }
+}

--- a/Tangem/Modules/Main/UnlockCardBottomSheet/UnlockUserWalletBottomSheetView.swift
+++ b/Tangem/Modules/Main/UnlockCardBottomSheet/UnlockUserWalletBottomSheetView.swift
@@ -50,7 +50,7 @@ struct UnlockUserWalletBottomSheetView: View {
 }
 
 struct UnlockUserWalletBottomSheetView_Previews: PreviewProvider {
-    class FakeUnlockUserWalletDelegate: UnlockUserWalletDelegate {
+    class FakeUnlockUserWalletDelegate: UnlockUserWalletBottomSheetDelegate {
         func unlockedWithBiometry() {
             print("Unlocked with biometry")
         }

--- a/Tangem/Modules/Main/UnlockCardBottomSheet/UnlockUserWalletBottomSheetViewModel.swift
+++ b/Tangem/Modules/Main/UnlockCardBottomSheet/UnlockUserWalletBottomSheetViewModel.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Combine
 
-protocol UnlockUserWalletDelegate: AnyObject {
+protocol UnlockUserWalletBottomSheetDelegate: AnyObject {
     func unlockedWithBiometry()
     func userWalletUnlocked(_ userWalletModel: UserWalletModel)
     func showTroubleshooting()
@@ -22,9 +22,9 @@ class UnlockUserWalletBottomSheetViewModel: ObservableObject, Identifiable {
     @Published var error: AlertBinder? = nil
 
     private let userWalletModel: UserWalletModel
-    private weak var delegate: UnlockUserWalletDelegate?
+    private weak var delegate: UnlockUserWalletBottomSheetDelegate?
 
-    init(userWalletModel: UserWalletModel, delegate: UnlockUserWalletDelegate?) {
+    init(userWalletModel: UserWalletModel, delegate: UnlockUserWalletBottomSheetDelegate?) {
         self.userWalletModel = userWalletModel
         self.delegate = delegate
     }

--- a/Tangem/Modules/Main/UnlockCardBottomSheet/UnlockUserWalletBottomSheetViewModel.swift
+++ b/Tangem/Modules/Main/UnlockCardBottomSheet/UnlockUserWalletBottomSheetViewModel.swift
@@ -1,0 +1,68 @@
+//
+//  UnlockUserWalletBottomSheetViewModel.swift
+//  Tangem
+//
+//  Created by Andrew Son on 16/08/23.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+protocol UnlockUserWalletDelegate: AnyObject {
+    func unlockedWithBiometry()
+    func userWalletUnlocked(_ userWalletModel: UserWalletModel)
+    func showTroubleshooting()
+}
+
+class UnlockUserWalletBottomSheetViewModel: ObservableObject, Identifiable {
+    @Injected(\.userWalletRepository) private var userWalletRepository: UserWalletRepository
+
+    @Published var isScannerBusy = false
+    @Published var error: AlertBinder? = nil
+
+    private let userWalletModel: UserWalletModel
+    private weak var delegate: UnlockUserWalletDelegate?
+
+    init(userWalletModel: UserWalletModel, delegate: UnlockUserWalletDelegate?) {
+        self.userWalletModel = userWalletModel
+        self.delegate = delegate
+    }
+
+    func unlockWithBiometry() {
+        // TODO: Update anal
+        //        Analytics.log(.buttonUnlockAllWithFaceID)
+
+        userWalletRepository.unlock(with: .biometry) { [weak self] result in
+            switch result {
+            case .error(let error), .partial(_, let error):
+                self?.error = error.alertBinder
+            case .success:
+                self?.delegate?.unlockedWithBiometry()
+            default:
+                break
+            }
+        }
+    }
+
+    func unlockWithCard() {
+        // TODO: Update anal
+        Analytics.beginLoggingCardScan(source: .myWalletsUnlock)
+        isScannerBusy = true
+        userWalletRepository.unlock(with: .card(userWallet: userWalletModel.userWallet)) { [weak self] result in
+            DispatchQueue.main.async {
+                self?.isScannerBusy = false
+                switch result {
+                case .success(let unlockedModel):
+                    self?.delegate?.userWalletUnlocked(unlockedModel)
+                case .error(let error), .partial(_, let error):
+                    self?.error = error.alertBinder
+                case .troubleshooting:
+                    self?.delegate?.showTroubleshooting()
+                default:
+                    break
+                }
+            }
+        }
+    }
+}

--- a/Tangem/Preview Content/Fakes/FakeUserWalletRepository.swift
+++ b/Tangem/Preview Content/Fakes/FakeUserWalletRepository.swift
@@ -35,7 +35,26 @@ class FakeUserWalletRepository: UserWalletRepository {
         self.models = models
     }
 
-    func unlock(with method: UserWalletRepositoryUnlockMethod, completion: @escaping (UserWalletRepositoryResult?) -> Void) {}
+    func unlock(with method: UserWalletRepositoryUnlockMethod, completion: @escaping (UserWalletRepositoryResult?) -> Void) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            guard let model = self.models.first else {
+                completion(.error("No models"))
+                return
+            }
+
+            switch method {
+            case .biometry:
+                completion(.troubleshooting)
+            case .card(let userWallet):
+                if let userWallet, let cardViewModel = CardViewModel(userWallet: userWallet) {
+                    completion(.success(cardViewModel))
+                    return
+                }
+
+                completion(.error("Can't create card view model"))
+            }
+        }
+    }
 
     func setSelectedUserWalletId(_ userWalletId: Data?, unlockIfNeeded: Bool, reason: UserWalletRepositorySelectionChangeReason) {}
 

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 		B0BA7BCB26C5684E00D7066F /* AddressQrBottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0BA7BCA26C5684E00D7066F /* AddressQrBottomSheetView.swift */; };
 		B0BDFD1B2A8B685200479F53 /* NotificationView+Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0BDFD1A2A8B685200479F53 /* NotificationView+Settings.swift */; };
 		B0BDFD1D2A8B68B600479F53 /* NotificationViewInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0BDFD1C2A8B68B600479F53 /* NotificationViewInput.swift */; };
+		B0BDFD222A8BAB3600479F53 /* UnlockUserWalletBottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0BDFD212A8BAB3600479F53 /* UnlockUserWalletBottomSheetView.swift */; };
 		B0BE305D2A7B91CC00B3AD13 /* TokenListSectionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0BE305C2A7B91CC00B3AD13 /* TokenListSectionInfo.swift */; };
 		B0BE305F2A7BA4E500B3AD13 /* TokenListInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0BE305E2A7BA4E500B3AD13 /* TokenListInfoProvider.swift */; };
 		B0BE30612A7BA4FB00B3AD13 /* GroupedTokenListInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0BE30602A7BA4FB00B3AD13 /* GroupedTokenListInfoProvider.swift */; };
@@ -378,6 +379,7 @@
 		B0CFD6CB2A027E2E009DF4D5 /* PriceChangeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CFD6CA2A027E2E009DF4D5 /* PriceChangeProvider.swift */; };
 		B0D1AC322906719300584E6C /* Analytics+Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D1AC312906719300584E6C /* Analytics+Event.swift */; };
 		B0D7F896295EDCBE00497139 /* ReferralErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D7F895295EDCBE00497139 /* ReferralErrors.swift */; };
+		B0DB73FC2A8CA28800F6376E /* UnlockUserWalletBottomSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0DB73FB2A8CA28800F6376E /* UnlockUserWalletBottomSheetViewModel.swift */; };
 		B0DC10CD2927505300BBE854 /* SwiftConcurrency+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0DC10CC2927505300BBE854 /* SwiftConcurrency+.swift */; };
 		B0DC10D1292755BB00BBE854 /* walletWithBackup.json in Resources */ = {isa = PBXBuildFile; fileRef = B0DC10CF292755BA00BBE854 /* walletWithBackup.json */; };
 		B0DC10D42927564000BBE854 /* PreviewCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0DC10D32927564000BBE854 /* PreviewCards.swift */; };
@@ -1475,6 +1477,7 @@
 		B0BA7BCA26C5684E00D7066F /* AddressQrBottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressQrBottomSheetView.swift; sourceTree = "<group>"; };
 		B0BDFD1A2A8B685200479F53 /* NotificationView+Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationView+Settings.swift"; sourceTree = "<group>"; };
 		B0BDFD1C2A8B68B600479F53 /* NotificationViewInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationViewInput.swift; sourceTree = "<group>"; };
+		B0BDFD212A8BAB3600479F53 /* UnlockUserWalletBottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockUserWalletBottomSheetView.swift; sourceTree = "<group>"; };
 		B0BE305C2A7B91CC00B3AD13 /* TokenListSectionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenListSectionInfo.swift; sourceTree = "<group>"; };
 		B0BE305E2A7BA4E500B3AD13 /* TokenListInfoProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenListInfoProvider.swift; sourceTree = "<group>"; };
 		B0BE30602A7BA4FB00B3AD13 /* GroupedTokenListInfoProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedTokenListInfoProvider.swift; sourceTree = "<group>"; };
@@ -1513,6 +1516,8 @@
 		B0CFD6CA2A027E2E009DF4D5 /* PriceChangeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceChangeProvider.swift; sourceTree = "<group>"; };
 		B0D1AC312906719300584E6C /* Analytics+Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Analytics+Event.swift"; sourceTree = "<group>"; };
 		B0D7F895295EDCBE00497139 /* ReferralErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralErrors.swift; sourceTree = "<group>"; };
+		B0DB73FB2A8CA28800F6376E /* UnlockUserWalletBottomSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockUserWalletBottomSheetViewModel.swift; sourceTree = "<group>"; };
+		B0DB73FE2A8CBDE400F6376E /* LockedWalletMainContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockedWalletMainContentView.swift; sourceTree = "<group>"; };
 		B0DC10CC2927505300BBE854 /* SwiftConcurrency+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftConcurrency+.swift"; sourceTree = "<group>"; };
 		B0DC10CF292755BA00BBE854 /* walletWithBackup.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = walletWithBackup.json; sourceTree = "<group>"; };
 		B0DC10D32927564000BBE854 /* PreviewCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewCards.swift; sourceTree = "<group>"; };
@@ -2404,6 +2409,7 @@
 				5D3F77C324BF56D800E8695B /* Products */,
 				BBA154748909F0AB4121528D /* Pods */,
 				2E5061A84512B23CCB5F2E17 /* Frameworks */,
+				B0D58E322A8E30E300377D12 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -3171,6 +3177,7 @@
 			isa = PBXGroup;
 			children = (
 				B030B4D92A8CE1CA0023DB8B /* LockedWalletMainContent */,
+				B0BDFD202A8BAB1800479F53 /* UnlockCardBottomSheet */,
 				B09310592A0BC03100F6043A /* MainHeaderView */,
 				B06C085C2A73FC9A00D982BC /* MainCardPageBuilder */,
 				B06C08512A73FC1B00D982BC /* MultiWalletMainContent */,
@@ -3490,6 +3497,15 @@
 			path = Animators;
 			sourceTree = "<group>";
 		};
+		B0BDFD202A8BAB1800479F53 /* UnlockCardBottomSheet */ = {
+			isa = PBXGroup;
+			children = (
+				B0BDFD212A8BAB3600479F53 /* UnlockUserWalletBottomSheetView.swift */,
+				B0DB73FB2A8CA28800F6376E /* UnlockUserWalletBottomSheetViewModel.swift */,
+			);
+			path = UnlockCardBottomSheet;
+			sourceTree = "<group>";
+		};
 		B0C171CC264C171D00E4BA5C /* Modifiers */ = {
 			isa = PBXGroup;
 			children = (
@@ -3596,6 +3612,14 @@
 				DCE402B72A31E69100D40C77 /* Analytics+DestinationAddressSource.swift */,
 			);
 			path = Analytics;
+			sourceTree = "<group>";
+		};
+		B0D58E322A8E30E300377D12 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				B0DB73FE2A8CBDE400F6376E /* LockedWalletMainContentView.swift */,
+			);
+			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 		B0DC10CE292755BA00BBE854 /* Cards */ = {
@@ -6280,6 +6304,7 @@
 				B05F1E66299CB81D00E27E32 /* TransactionViewPlaceholder.swift in Sources */,
 				EF4BEF7F28AB872E00C5D1BE /* UserTokenList.swift in Sources */,
 				DC0A5806282501530031BECC /* KeysManager.swift in Sources */,
+				B0BDFD222A8BAB3600479F53 /* UnlockUserWalletBottomSheetView.swift in Sources */,
 				DC66BBE32858E7A600CDF765 /* WelcomeRoutable.swift in Sources */,
 				EFFE2CEC28B8E1B000B9F279 /* CommonDerivationManager.swift in Sources */,
 				EFE23AC8292CB6F700A3C554 /* SwappingTokenListRoutable.swift in Sources */,
@@ -6647,7 +6672,6 @@
 				DC22535928A4FD9C0094F30C /* UserWalletConfigFactory.swift in Sources */,
 				B0606E122684A946004004ED /* BlinkingModifier.swift in Sources */,
 				DCBC945D299404510050BC35 /* CommonAnalyticsContext.swift in Sources */,
-				EFFC860E28BCE87700F863CE /* LegacyCardMigrator.swift in Sources */,
 				B00371BE2A8A5E5900D77A4B /* FakeUserTokensManager.swift in Sources */,
 				DC261CA9292CF56600875E64 /* AuthCoordinatorView.swift in Sources */,
 				DAA5E30328D21369003C0E80 /* BiometryLogoImage.swift in Sources */,
@@ -6767,6 +6791,7 @@
 				B0FE0B3A297140D10046EE2C /* WalletConnectV2Error.swift in Sources */,
 				B0E1564D26B941AF005B33E4 /* SingleCardOnboardingViewModel.swift in Sources */,
 				B09BB85F259A075600B92000 /* TangemButton.swift in Sources */,
+				B0DB73FC2A8CA28800F6376E /* UnlockUserWalletBottomSheetViewModel.swift in Sources */,
 				DA5CD0992A25F4F2008FD876 /* PromotionCoordinatorView.swift in Sources */,
 				DA2D04D327BB9B07006F1E69 /* ShopOrderProgressView.swift in Sources */,
 				DCF2369129924C0900FE1855 /* AnalyticsContext.swift in Sources */,


### PR DESCRIPTION
Пришлось немного доработать репозиторий, добавил ещё один вид ошибки, т.к. текущая ошибка некорректная, когда сканируется карточка с и `UserWalletId` не соответствует.
Боттом щит вызывается на главном экране, чтобы проще было потом его же скрывать программно.
<img width="484" src="https://github.com/tangem/tangem-app-ios/assets/24321494/d8d683a3-b736-4bb9-85e1-c7faafcc79cc">
<img width="484" src="https://github.com/tangem/tangem-app-ios/assets/24321494/65422a4e-7839-4219-a44d-59ec8ee1e265">
<img width="484" src="https://github.com/tangem/tangem-app-ios/assets/24321494/b20d471f-3bf1-440b-ae8c-eb9bb5a3e234">
