### PR TITLE
IOS-4118 Fixed spelling error

### DIFF
--- a/Tangem/App/ViewModels/CardViewModel.swift
+++ b/Tangem/App/ViewModels/CardViewModel.swift
@@ -281,7 +281,7 @@ class CardViewModel: Identifiable, ObservableObject {
     }
 
     private let _updatePublisher: PassthroughSubject<Void, Never> = .init()
-    private let _userWalletNamePubliher: CurrentValueSubject<String, Never>
+    private let _userWalletNamePublisher: CurrentValueSubject<String, Never>
     private var bag = Set<AnyCancellable>()
     private var signSubscription: AnyCancellable?
 
@@ -329,7 +329,7 @@ class CardViewModel: Identifiable, ObservableObject {
 
         _signer = config.tangemSigner
         accessCodeRecoveryEnabled = cardInfo.card.userSettings.isUserCodeRecoveryAllowed
-        _userWalletNamePubliher = .init(cardInfo.name)
+        _userWalletNamePublisher = .init(cardInfo.name)
         updateCurrentSecurityOption()
         appendPersistentBlockchains()
         bind()
@@ -568,7 +568,7 @@ extension CardViewModel: UserWalletModel {
 
     func updateWalletName(_ name: String) {
         cardInfo.name = name
-        _userWalletNamePubliher.send(name)
+        _userWalletNamePublisher.send(name)
     }
 }
 
@@ -577,7 +577,7 @@ extension CardViewModel: MainHeaderInfoProvider {
 
     var isUserWalletLocked: Bool { userWallet.isLocked }
 
-    var userWalletNamePublisher: AnyPublisher<String, Never> { _userWalletNamePubliher.eraseToAnyPublisher() }
+    var userWalletNamePublisher: AnyPublisher<String, Never> { _userWalletNamePublisher.eraseToAnyPublisher() }
 }
 
 // TODO: refactor storage to single source


### PR DESCRIPTION
Не мог пройти мимо

Используется в связке userWalletNamePublisher / _userWalletNamePublisher, одно без другого не ищется