### PR TITLE
IOS-4321: Change buttons order

### DIFF
--- a/Tangem/Modules/Onboarding/Wallet/WalletOnboardingViewModel.swift
+++ b/Tangem/Modules/Onboarding/Wallet/WalletOnboardingViewModel.swift
@@ -799,9 +799,7 @@ class WalletOnboardingViewModel: OnboardingViewModel<WalletOnboardingStep, Onboa
             primaryButton: .destructive(Text(Localization.cardSettingsActionSheetReset), action: { [weak self] in
                 self?.resetCard(with: cardId)
             }),
-            secondaryButton: Alert.Button.cancel {
-                Analytics.log(.backupResetCardNotification, params: [.option: .cancel])
-            }
+            secondaryButton: .default(Text(Localization.commonCancel))
         )
     }
 

--- a/Tangem/Modules/Onboarding/Wallet/WalletOnboardingViewModel.swift
+++ b/Tangem/Modules/Onboarding/Wallet/WalletOnboardingViewModel.swift
@@ -799,7 +799,9 @@ class WalletOnboardingViewModel: OnboardingViewModel<WalletOnboardingStep, Onboa
             primaryButton: .destructive(Text(Localization.cardSettingsActionSheetReset), action: { [weak self] in
                 self?.resetCard(with: cardId)
             }),
-            secondaryButton: .default(Text(Localization.commonCancel))
+            secondaryButton: .default(Text(Localization.commonCancel)) {
+                Analytics.log(.backupResetCardNotification, params: [.option: .cancel])
+            }
         )
     }
 


### PR DESCRIPTION
Теряется жирность на кнопке `Cancel`, обсудили с Лешей что пока этим можно пренебречь. Проблема в том, что на 14 оси это кастомизировать нельзя, а в 15 вроде можно, но надо избавляться от `AlertBinder` и совсем иначе конструировать алерты. Поэтому пока малой кровью решаем проблему
![IMG_4966](https://github.com/tangem/tangem-app-ios/assets/24321494/3479f15f-0c48-4b94-8fc1-5b626c587945)
