### PR TITLE
IOS-4244 single icon source

### DIFF
--- a/Tangem/Common/UI/IconView/IconView.swift
+++ b/Tangem/Common/UI/IconView/IconView.swift
@@ -23,6 +23,10 @@ struct IconView: View {
         self.forceKingfisher = forceKingfisher
     }
 
+    init(url: URL?, sizeSettings: IconViewSizeSettings, forceKingfisher: Bool = false) {
+        self.init(url: url, size: sizeSettings.iconSize, forceKingfisher: forceKingfisher)
+    }
+
     var body: some View {
         if forceKingfisher {
             kfImage

--- a/Tangem/Common/UI/IconView/IconView.swift
+++ b/Tangem/Common/UI/IconView/IconView.swift
@@ -63,11 +63,9 @@ struct IconView: View {
     var kfImage: some View {
         KFImage(url)
             .cancelOnDisappear(true)
-            .setProcessor(DownsamplingImageProcessor(size: size))
             .placeholder { CircleImageTextView(name: "", color: .tangemSkeletonGray) }
             .fade(duration: 0.3)
             .cacheOriginalImage()
-            .scaleFactor(UIScreen.main.scale)
             .resizable()
             .scaledToFit()
             .frame(size: size)

--- a/Tangem/Common/UI/IconView/IconViewSizeSettings.swift
+++ b/Tangem/Common/UI/IconView/IconViewSizeSettings.swift
@@ -1,0 +1,49 @@
+//
+//  IconViewSizeSettings.swift
+//  Tangem
+//
+//  Created by Andrew Son on 21/08/23.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+enum IconViewSizeSettings {
+    case tokenItem
+    case tokenDetails
+    case tokenDetailsToolbar
+    case receive
+
+    var iconSize: CGSize {
+        switch self {
+        case .tokenItem: return .init(width: 40, height: 40)
+        case .tokenDetails: return .init(bothDimensions: 48)
+        case .tokenDetailsToolbar: return .init(bothDimensions: 24)
+        case .receive: return .init(width: 80, height: 80)
+        }
+    }
+
+    var networkIconSize: CGSize {
+        switch self {
+        case .tokenItem: return .init(width: 16, height: 16)
+        case .tokenDetails, .tokenDetailsToolbar: return .zero
+        case .receive: return .init(width: 32, height: 32)
+        }
+    }
+
+    var networkIconBorderWidth: Double {
+        switch self {
+        case .tokenItem: return 2
+        case .tokenDetails, .tokenDetailsToolbar: return 0
+        case .receive: return 4
+        }
+    }
+
+    var networkIconOffset: CGSize {
+        switch self {
+        case .tokenItem: return .init(width: 4, height: -4)
+        case .tokenDetails, .tokenDetailsToolbar: return .zero
+        case .receive: return .init(width: 9, height: -9)
+        }
+    }
+}

--- a/Tangem/Common/UI/TokenIconView/TokenIconView.swift
+++ b/Tangem/Common/UI/TokenIconView/TokenIconView.swift
@@ -10,6 +10,7 @@ import Foundation
 import Kingfisher
 import SwiftUI
 
+@available(*, deprecated, message: "Use `IconView` instead")
 struct TokenIconView: View {
     private let viewModel: TokenIconViewModel
     private let size: CGSize

--- a/Tangem/Common/UI/TokenIconView/TokenIconView.swift
+++ b/Tangem/Common/UI/TokenIconView/TokenIconView.swift
@@ -28,11 +28,9 @@ struct TokenIconView: View {
 
     var body: some View {
         KFImage(viewModel.imageURL)
-            .setProcessor(DownsamplingImageProcessor(size: size))
             .placeholder { placeholder }
             .fade(duration: 0.3)
             .cacheOriginalImage()
-            .scaleFactor(UIScreen.main.scale)
             .resizable()
             .scaledToFit()
             .cornerRadius(5)

--- a/Tangem/Common/UI/TokenIconView/TokenIconView.swift
+++ b/Tangem/Common/UI/TokenIconView/TokenIconView.swift
@@ -18,7 +18,7 @@ struct TokenIconView: View {
     private let networkIconBorderWidth: Double
     private let networkIconOffset: CGSize
 
-    init(viewModel: TokenIconViewModel, sizeSettings: SizeSettings = .tokenItem) {
+    init(viewModel: TokenIconViewModel, sizeSettings: IconViewSizeSettings = .tokenItem) {
         self.viewModel = viewModel
         size = sizeSettings.iconSize
         networkIconSize = sizeSettings.networkIconSize
@@ -33,7 +33,6 @@ struct TokenIconView: View {
             .cacheOriginalImage()
             .resizable()
             .scaledToFit()
-            .cornerRadius(5)
             .frame(size: size)
             .overlay(networkIcon.offset(networkIconOffset), alignment: .topTrailing)
     }
@@ -57,48 +56,6 @@ struct TokenIconView: View {
     @ViewBuilder
     private var placeholder: some View {
         CircleImageTextView(name: viewModel.name, color: Colors.Icon.inactive)
-    }
-}
-
-extension TokenIconView {
-    enum SizeSettings {
-        case tokenItem
-        case tokenDetails
-        case tokenDetailsToolbar
-        case receive
-
-        var iconSize: CGSize {
-            switch self {
-            case .tokenItem: return .init(width: 40, height: 40)
-            case .tokenDetails: return .init(bothDimensions: 48)
-            case .tokenDetailsToolbar: return .init(bothDimensions: 24)
-            case .receive: return .init(width: 80, height: 80)
-            }
-        }
-
-        var networkIconSize: CGSize {
-            switch self {
-            case .tokenItem: return .init(width: 16, height: 16)
-            case .tokenDetails, .tokenDetailsToolbar: return .zero
-            case .receive: return .init(width: 32, height: 32)
-            }
-        }
-
-        var networkIconBorderWidth: Double {
-            switch self {
-            case .tokenItem: return 2
-            case .tokenDetails, .tokenDetailsToolbar: return 0
-            case .receive: return 4
-            }
-        }
-
-        var networkIconOffset: CGSize {
-            switch self {
-            case .tokenItem: return .init(width: 4, height: -4)
-            case .tokenDetails, .tokenDetailsToolbar: return .zero
-            case .receive: return .init(width: 9, height: -9)
-            }
-        }
     }
 }
 

--- a/Tangem/Modules/TokenDetails/TokenDetailsView.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsView.swift
@@ -13,13 +13,9 @@ struct TokenDetailsView: View {
 
     @State private var contentOffset: CGPoint = .zero
 
-    private let tokenIconSizeSettings: TokenIconView.SizeSettings = .tokenDetails
+    private let tokenIconSizeSettings: IconViewSizeSettings = .tokenDetails
     private let headerTopPadding: CGFloat = 14
     private let coorditateSpaceName = "token_details_scroll_space"
-
-    private var tokenIconViewModel: TokenIconViewModel {
-        TokenIconViewModel(id: viewModel.tokenItem.id, name: viewModel.tokenItem.name, style: .blockchain)
-    }
 
     private var toolbarIconOpacity: Double {
         let iconSize = tokenIconSizeSettings.iconSize
@@ -68,7 +64,7 @@ struct TokenDetailsView: View {
         .coordinateSpace(name: coorditateSpaceName)
         .toolbar(content: {
             ToolbarItem(placement: .principal) {
-                TokenIconView(viewModel: tokenIconViewModel, sizeSettings: .tokenDetailsToolbar)
+                IconView(url: viewModel.iconUrl, sizeSettings: .tokenDetailsToolbar)
                     .opacity(toolbarIconOpacity)
             }
 

--- a/Tangem/Modules/TokenDetails/TokenDetailsViewModel.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsViewModel.swift
@@ -31,6 +31,14 @@ final class TokenDetailsViewModel: SingleTokenBaseViewModel, ObservableObject {
         }
     }
 
+    var iconUrl: URL? {
+        guard let id = tokenItem.id else {
+            return nil
+        }
+
+        return TokenIconURLBuilder().iconURL(id: id)
+    }
+
     init(
         cardModel: CardViewModel,
         userTokensManager: UserTokensManager,

--- a/Tangem/Modules/TokenDetails/Views/TokenDetailsHeaderView.swift
+++ b/Tangem/Modules/TokenDetails/Views/TokenDetailsHeaderView.swift
@@ -22,7 +22,7 @@ struct TokenDetailsHeaderView: View {
 
                 Spacer()
 
-                TokenIconView(viewModel: viewModel.tokenIconModel, sizeSettings: .tokenDetails)
+                IconView(url: viewModel.tokenIconModel.imageURL, sizeSettings: .tokenDetails)
             }
 
             HStack(spacing: 6) {

--- a/Tangem/UIComponents/ReceiveBottomSheetView/ReceiveBottomSheetView.swift
+++ b/Tangem/UIComponents/ReceiveBottomSheetView/ReceiveBottomSheetView.swift
@@ -30,8 +30,8 @@ struct ReceiveBottomSheetView: View {
     @ViewBuilder
     private var addressNetworkUnderstandingConfirmationView: some View {
         VStack(spacing: 56) {
-            TokenIconView(
-                viewModel: viewModel.tokenIconViewModel,
+            IconView(
+                url: viewModel.iconURL,
                 sizeSettings: .receive
             )
             .padding(.top, 56)

--- a/Tangem/UIComponents/ReceiveBottomSheetView/ReceiveBottomSheetViewModel.swift
+++ b/Tangem/UIComponents/ReceiveBottomSheetView/ReceiveBottomSheetViewModel.swift
@@ -14,13 +14,13 @@ class ReceiveBottomSheetViewModel: ObservableObject, Identifiable {
     @Published var isUserUnderstandsAddressNetworkRequirements: Bool
     @Published var showToast: Bool = false
 
-    let tokenIconViewModel: TokenIconViewModel
-
     let addressInfos: [ReceiveAddressInfo]
     let networkWarningMessage: String
 
     let id = UUID()
     let addressIndexUpdateNotifier = PassthroughSubject<Int, Never>()
+
+    let iconURL: URL?
 
     private let tokenItem: TokenItem
 
@@ -33,7 +33,7 @@ class ReceiveBottomSheetViewModel: ObservableObject, Identifiable {
 
     init(tokenItem: TokenItem, addressInfos: [ReceiveAddressInfo]) {
         self.tokenItem = tokenItem
-        tokenIconViewModel = .init(tokenItem: tokenItem)
+        iconURL = tokenItem.id != nil ? TokenIconURLBuilder().iconURL(id: tokenItem.id!) : nil
         self.addressInfos = addressInfos
 
         networkWarningMessage = Localization.receiveBottomSheetWarningMessage(

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -378,6 +378,7 @@
 		B0CFD6CB2A027E2E009DF4D5 /* PriceChangeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0CFD6CA2A027E2E009DF4D5 /* PriceChangeProvider.swift */; };
 		B0D1AC322906719300584E6C /* Analytics+Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D1AC312906719300584E6C /* Analytics+Event.swift */; };
 		B0D7F896295EDCBE00497139 /* ReferralErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D7F895295EDCBE00497139 /* ReferralErrors.swift */; };
+		B0D9FDCA2A9336920047A1C0 /* IconViewSizeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D9FDC92A9336920047A1C0 /* IconViewSizeSettings.swift */; };
 		B0DC10CD2927505300BBE854 /* SwiftConcurrency+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0DC10CC2927505300BBE854 /* SwiftConcurrency+.swift */; };
 		B0DC10D1292755BB00BBE854 /* walletWithBackup.json in Resources */ = {isa = PBXBuildFile; fileRef = B0DC10CF292755BA00BBE854 /* walletWithBackup.json */; };
 		B0DC10D42927564000BBE854 /* PreviewCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0DC10D32927564000BBE854 /* PreviewCards.swift */; };
@@ -1513,6 +1514,7 @@
 		B0CFD6CA2A027E2E009DF4D5 /* PriceChangeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceChangeProvider.swift; sourceTree = "<group>"; };
 		B0D1AC312906719300584E6C /* Analytics+Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Analytics+Event.swift"; sourceTree = "<group>"; };
 		B0D7F895295EDCBE00497139 /* ReferralErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralErrors.swift; sourceTree = "<group>"; };
+		B0D9FDC92A9336920047A1C0 /* IconViewSizeSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconViewSizeSettings.swift; sourceTree = "<group>"; };
 		B0DC10CC2927505300BBE854 /* SwiftConcurrency+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SwiftConcurrency+.swift"; sourceTree = "<group>"; };
 		B0DC10CF292755BA00BBE854 /* walletWithBackup.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = walletWithBackup.json; sourceTree = "<group>"; };
 		B0DC10D32927564000BBE854 /* PreviewCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewCards.swift; sourceTree = "<group>"; };
@@ -5598,6 +5600,7 @@
 			children = (
 				EF5A16712937972A00BEC2F4 /* IconView.swift */,
 				EF94A89B29927C4F008F2C3F /* CachedAsyncImage.swift */,
+				B0D9FDC92A9336920047A1C0 /* IconViewSizeSettings.swift */,
 			);
 			path = IconView;
 			sourceTree = "<group>";
@@ -6190,6 +6193,7 @@
 				B06C9B862A3AE65A00875852 /* ExchangeCryptoUtility.swift in Sources */,
 				DC3DCAED2A49C6D900F72554 /* WalletManagersRepository.swift in Sources */,
 				B0C171CE264C173400E4BA5C /* CameraAccessDeniedModifier.swift in Sources */,
+				B0D9FDCA2A9336920047A1C0 /* IconViewSizeSettings.swift in Sources */,
 				EFB4C1322837C51700E991C1 /* TextHint.swift in Sources */,
 				DC7D3A0929E065E3007BCD23 /* BackupHelper.swift in Sources */,
 				DC72548C2A02B97A0003FE1B /* ResetToFactoryViewModelInput.swift in Sources */,
@@ -6647,7 +6651,6 @@
 				DC22535928A4FD9C0094F30C /* UserWalletConfigFactory.swift in Sources */,
 				B0606E122684A946004004ED /* BlinkingModifier.swift in Sources */,
 				DCBC945D299404510050BC35 /* CommonAnalyticsContext.swift in Sources */,
-				EFFC860E28BCE87700F863CE /* LegacyCardMigrator.swift in Sources */,
 				B00371BE2A8A5E5900D77A4B /* FakeUserTokensManager.swift in Sources */,
 				DC261CA9292CF56600875E64 /* AuthCoordinatorView.swift in Sources */,
 				DAA5E30328D21369003C0E80 /* BiometryLogoImage.swift in Sources */,


### PR DESCRIPTION
Мигание иконок и повторные перезагрузки происходили из-за обработки оригинального изображения кингфишером, а в новой оси происходило из-за разницы подходов, где-то был кингфишер, где-то новый `CachedAsyncImage`. Привел к использованию нового `IconView`. Вообще надо бы подтюнить `CachedAsyncImage`, чтобы с анимацией переключение состояний было, но это не относится к этой задаче


https://github.com/tangem/tangem-app-ios/assets/24321494/3f4f1847-08af-470e-8ae3-fdcc25683cd2

https://github.com/tangem/tangem-app-ios/assets/24321494/c36f73ea-e144-4c81-8849-79ad53e20ddb

