### PR TITLE
IOS-4325 onboarding not highlighted wrong words

### DIFF
--- a/Tangem/Modules/Onboarding/Views/SeedPhrase/SeedPhraseInputProcessor.swift
+++ b/Tangem/Modules/Onboarding/Views/SeedPhrase/SeedPhraseInputProcessor.swift
@@ -57,11 +57,13 @@ class SeedPhraseInputProcessor {
     }
 
     func prepare(copiedText: String) -> NSAttributedString {
+        // Replace all new lines before trying to create mnemonic, because new line is not a valid separator
+        let textToParse = copiedText.replacingOccurrences(of: "\n", with: " ")
         do {
-            let mnemonic = try Mnemonic(with: copiedText)
+            let mnemonic = try Mnemonic(with: textToParse)
             return processInput(words: mnemonic.mnemonicComponents).attributedText
         } catch {
-            let parsed = parse(input: copiedText)
+            let parsed = parse(input: textToParse)
             return processInput(words: parsed).attributedText
         }
     }

--- a/Tangem/Modules/Onboarding/Views/SeedPhrase/SeedPhraseInputProcessor.swift
+++ b/Tangem/Modules/Onboarding/Views/SeedPhrase/SeedPhraseInputProcessor.swift
@@ -58,7 +58,7 @@ class SeedPhraseInputProcessor {
 
     func prepare(copiedText: String) -> NSAttributedString {
         // Replace all new lines before trying to create mnemonic, because new line is not a valid separator
-        let textToParse = copiedText.replacingOccurrences(of: "\n", with: " ")
+        let textToParse = copiedText.components(separatedBy: CharacterSet.newlines).joined(separator: " ")
         do {
             let mnemonic = try Mnemonic(with: textToParse)
             return processInput(words: mnemonic.mnemonicComponents).attributedText

--- a/Tangem/Modules/Onboarding/Views/SeedPhrase/SeedPhraseTextView.swift
+++ b/Tangem/Modules/Onboarding/Views/SeedPhrase/SeedPhraseTextView.swift
@@ -120,6 +120,9 @@ extension SeedPhraseTextView {
             // If user typed or pasted something we can safely invalidate all previous results
             inputProcessor.resetValidation()
 
+            let isNewLine = text == "\n"
+            let text = isNewLine ? " " : text
+
             let oldText = textView.text ?? ""
             guard let oldTextRange = Range(range, in: oldText) else {
                 return true
@@ -140,6 +143,9 @@ extension SeedPhraseTextView {
                 return false
             }
 
+            let oldCaretPosition = textView.selectedRange
+            let newCaretPosition = NSRange(location: oldCaretPosition.location + (text.isEmpty ? -1 : text.count), length: 0)
+
             // If removing characters or if it is a letter we should check for suggestion
             // Text will be empty if user removes characters
             var needToClearSuggestions = true
@@ -147,11 +153,9 @@ extension SeedPhraseTextView {
                 // Save caret position and attributed text before inserting new character
                 // to give system ability to manually replace characters and do validation
                 // with debounce after text update.
-                let oldCaretPosition = textView.selectedRange
-                let oldAttributedText = textView.attributedText
 
+                let oldAttributedText = textView.attributedText
                 let textWithNewInput = textView.text.replacingCharacters(in: oldTextRange, with: text)
-                let newCaretPosition = NSRange(location: oldCaretPosition.location + (text.isEmpty ? -1 : text.count), length: 0)
 
                 textView.text = textWithNewInput
                 textView.selectedRange = newCaretPosition
@@ -193,6 +197,14 @@ extension SeedPhraseTextView {
                     .foregroundColor: inputProcessor.defaultTextColor,
                     .font: inputProcessor.defaultTextFont,
                 ]
+            }
+
+            if isNewLine {
+                let mutableAttrString = NSMutableAttributedString(attributedString: textView.attributedText)
+                mutableAttrString.mutableString.replaceCharacters(in: range, with: text)
+                textView.attributedText = mutableAttrString
+                textView.selectedRange = newCaretPosition
+                return false
             }
 
             return true

--- a/Tangem/Modules/Onboarding/Views/SeedPhrase/SeedPhraseTextView.swift
+++ b/Tangem/Modules/Onboarding/Views/SeedPhrase/SeedPhraseTextView.swift
@@ -120,7 +120,7 @@ extension SeedPhraseTextView {
             // If user typed or pasted something we can safely invalidate all previous results
             inputProcessor.resetValidation()
 
-            let isNewLine = text == "\n"
+            let isNewLine = text.rangeOfCharacter(from: CharacterSet.newlines) != nil
             let text = isNewLine ? " " : text
 
             let oldText = textView.text ?? ""

--- a/Tangem/Modules/Onboarding/Views/SeedPhrase/SeedPhraseTextView.swift
+++ b/Tangem/Modules/Onboarding/Views/SeedPhrase/SeedPhraseTextView.swift
@@ -199,6 +199,7 @@ extension SeedPhraseTextView {
                 ]
             }
 
+            // This need to prevent inserting new lines in text view and saving correct text coloring
             if isNewLine {
                 let mutableAttrString = NSMutableAttributedString(attributedString: textView.attributedText)
                 mutableAttrString.mutableString.replaceCharacters(in: range, with: text)


### PR DESCRIPTION
* Привел к тому же виду что и в андроиде: переход на новую строку заменяется на пробел.
* Добавил несколько комментов
* Добавил очистку скопированный строки от переходов на новую строку, это надо было, т.к. парсер внутри СДК не хочет парсить, если неправильное количество слов в скопированном тексте. Поэтому лучше очистить скопированный текст в любом случае от новых строк, а потом уже обрабатывать его в сдк.

https://github.com/tangem/tangem-app-ios/assets/24321494/d6d5c192-5a87-4cad-83ac-fce1f072d752

