### PR TITLE
IOS-4364 Fix card interaction

### DIFF
--- a/Tangem/Modules/ScanCardSettings/ScanCardSettingsViewModel.swift
+++ b/Tangem/Modules/ScanCardSettings/ScanCardSettingsViewModel.swift
@@ -47,6 +47,7 @@ extension ScanCardSettingsViewModel {
 
     private func processSuccessScan(for cardInfo: CardInfo) {
         let config = UserWalletConfigFactory(cardInfo).makeConfig()
+
         guard let userWalletIdSeed = config.userWalletIdSeed else {
             return
         }
@@ -59,11 +60,18 @@ extension ScanCardSettingsViewModel {
         }
 
         // TODO: remove with details refactoring https://tangem.atlassian.net/browse/IOS-4184
-        guard let cardModel = userWalletRepository.models.first(where: { $0.userWalletId == userWalletId }) as? CardViewModel else {
+        guard let existingCardModel = userWalletRepository.models.first(where: { $0.userWalletId == userWalletId }) as? CardViewModel else {
             return
         }
 
-        coordinator.openCardSettings(cardModel: cardModel)
+        var cardInfo = cardInfo
+        cardInfo.name = existingCardModel.name
+
+        guard let newCardViewModel = CardViewModel(cardInfo: cardInfo) else {
+            return
+        }
+
+        coordinator.openCardSettings(cardModel: newCardViewModel)
     }
 }
 


### PR DESCRIPTION
Все же работать мы должны с отсканированной картой, а не UserWallet из репы. Изначальная проблема была в потере имени при пересохранении. 

Я вернул создание CVM и добавил копирование имени. Код с созданием UserWaleltid оставил, понадобится для рефакторинга в девелопе, за который я берусь буквально сразу

Получается что вернул изначальное поведение