### PR TITLE
IOS-4381: Remove unowned

### DIFF
--- a/Tangem/UIComponents/TokenItemView/TokenItemViewModel.swift
+++ b/Tangem/UIComponents/TokenItemView/TokenItemViewModel.swift
@@ -41,8 +41,8 @@ final class TokenItemViewModel: ObservableObject, Identifiable {
     private let tokenIcon: TokenIconInfo
     private let tokenItem: TokenItem
     private let tokenTapped: (WalletModelId) -> Void
-    private unowned let infoProvider: TokenItemInfoProvider
-    private unowned let priceChangeProvider: PriceChangeProvider
+    private weak var infoProvider: TokenItemInfoProvider?
+    private weak var priceChangeProvider: PriceChangeProvider?
 
     private var bag = Set<AnyCancellable>()
 
@@ -69,7 +69,7 @@ final class TokenItemViewModel: ObservableObject, Identifiable {
     }
 
     private func bind() {
-        infoProvider.tokenItemStatePublisher
+        infoProvider?.tokenItemStatePublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newState in
                 guard let self else { return }
@@ -100,7 +100,7 @@ final class TokenItemViewModel: ObservableObject, Identifiable {
             }
             .store(in: &bag)
 
-        priceChangeProvider.priceChangePublisher
+        priceChangeProvider?.priceChangePublisher
             .receive(on: DispatchQueue.main)
             .compactMap { [weak self] _ -> String? in
                 guard let self else { return nil }
@@ -117,10 +117,14 @@ final class TokenItemViewModel: ObservableObject, Identifiable {
     }
 
     private func updatePendingTransactionsStateIfNeeded() {
+        guard let infoProvider = infoProvider else { return }
+
         hasPendingTransactions = infoProvider.hasPendingTransactions
     }
 
     private func updateBalances() {
+        guard let infoProvider = infoProvider else { return }
+
         balanceCrypto = .loaded(text: infoProvider.balance)
         balanceFiat = .loaded(text: infoProvider.fiatBalance)
     }


### PR DESCRIPTION
Баг из-за того что `infoProvider` - это структура, которая держит ссылку на `WalletModel` в итоге во время удаления токена из `WalletModel` прилетает ещё событие, а структура, которая является `infoProvider` уже уничтожена. Поменял и для `priceChangeProvider`, т.к. скорее всего такая же проблема будет и с ним.