### PR TITLE
IOS-4385 remove schnorr from w1

### DIFF
--- a/Tangem/App/Models/UserWallet/Implementations/GenericConfig.swift
+++ b/Tangem/App/Models/UserWallet/Implementations/GenericConfig.swift
@@ -40,7 +40,7 @@ extension GenericConfig: UserWalletConfig {
     }
 
     var mandatoryCurves: [EllipticCurve] {
-        [.secp256k1, .ed25519, .bip0340, .bls12381_G2_AUG]
+        [.secp256k1, .ed25519, .bls12381_G2_AUG]
     }
 
     var derivationStyle: DerivationStyle? {

--- a/Tangem/App/Models/UserWallet/Implementations/GenericDemoConfig.swift
+++ b/Tangem/App/Models/UserWallet/Implementations/GenericDemoConfig.swift
@@ -32,7 +32,7 @@ extension GenericDemoConfig: UserWalletConfig {
     }
 
     var mandatoryCurves: [EllipticCurve] {
-        [.secp256k1, .ed25519, .bip0340, .bls12381_G2_AUG]
+        [.secp256k1, .ed25519, .bls12381_G2_AUG]
     }
 
     var derivationStyle: DerivationStyle? {

--- a/Tangem/App/Models/UserWallet/Implementations/Wallet2Config.swift
+++ b/Tangem/App/Models/UserWallet/Implementations/Wallet2Config.swift
@@ -41,7 +41,7 @@ extension Wallet2Config: UserWalletConfig {
     }
 
     var mandatoryCurves: [EllipticCurve] {
-        [.secp256k1, .ed25519, .bip0340, .bls12381_G2_AUG, .ed25519_slip0010]
+        [.secp256k1, .ed25519, .bls12381_G2_AUG, .bip0340, .ed25519_slip0010]
     }
 
     var derivationStyle: DerivationStyle? {


### PR DESCRIPTION
Убираем шнор для в1, чтобы у юзеров не было проблем со сбросом к заводским на незабэкапленных катах