### PR TITLE
IOS-4384: Hide Organize tokens when tokens count is less than 2

### DIFF
--- a/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentView.swift
+++ b/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentView.swift
@@ -41,12 +41,14 @@ struct MultiWalletMainContentView: View {
 
             tokensContent
 
-            FixedSizeButtonWithLeadingIcon(
-                title: Localization.organizeTokensTitle,
-                icon: Assets.OrganizeTokens.filterIcon.image,
-                action: viewModel.openOrganizeTokens
-            )
-            .infinityFrame(axis: .horizontal)
+            if viewModel.isOrganizeTokensVisible {
+                FixedSizeButtonWithLeadingIcon(
+                    title: Localization.organizeTokensTitle,
+                    icon: Assets.OrganizeTokens.filterIcon.image,
+                    action: viewModel.openOrganizeTokens
+                )
+                .infinityFrame(axis: .horizontal)
+            }
         }
         .animation(.default, value: viewModel.missingDerivationNotificationSettings)
         .padding(.horizontal, 16)

--- a/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentViewModel.swift
+++ b/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentViewModel.swift
@@ -21,6 +21,17 @@ final class MultiWalletMainContentViewModel: ObservableObject {
 
     @Published var isScannerBusy = false
 
+    var isOrganizeTokensVisible: Bool {
+        if sections.isEmpty {
+            return false
+        }
+
+        let numberOfTokens = sections.reduce(0) { $0 + $1.tokenItemModels.count }
+        let requiredNumberOfTokens = 2
+
+        return numberOfTokens >= requiredNumberOfTokens
+    }
+
     // MARK: - Dependencies
 
     private let userWalletModel: UserWalletModel


### PR DESCRIPTION
Когда количество токенов на главном экране меньше двух необходимо скрывать кнопку `Organize tokens`

https://github.com/tangem/tangem-app-ios/assets/24321494/f42c73ef-8856-4c18-9985-7ccbb298ee80

