### PR TITLE
IOS-4426 Move to ids

### DIFF
--- a/Tangem/App/Services/WalletModelsManager/CommonWalletModelsManager.swift
+++ b/Tangem/App/Services/WalletModelsManager/CommonWalletModelsManager.swift
@@ -47,9 +47,9 @@ class CommonWalletModelsManager {
         })
 
         let walletModelIdsToDelete = existingWalletModelIds.subtracting(newWalletModelIds)
-        let walletModelIdsToAdd = newWalletModelIds.subtracting(existingWalletModelIds)
+        let walletModelIdsToAdd = Set(newWalletModelIds.subtracting(existingWalletModelIds)
 
-        guard !walletModelIdsToAdd.isEmpty || !walletModelIdsToDelete.isEmpty else {
+        if walletModelIdsToAdd.isEmpty && walletModelIdsToDelete.isEmpty {
             return
         }
 

--- a/Tangem/App/Services/WalletModelsManager/CommonWalletModelsManager.swift
+++ b/Tangem/App/Services/WalletModelsManager/CommonWalletModelsManager.swift
@@ -46,8 +46,8 @@ class CommonWalletModelsManager {
             return [mainId] + tokenIds
         })
 
-        let walletModelIdsToDelete = Set(existingWalletModelIds).subtracting(newWalletModelIds)
-        let walletModelIdsToAdd = Set(newWalletModelIds).subtracting(existingWalletModelIds)
+        let walletModelIdsToDelete = existingWalletModelIds.subtracting(newWalletModelIds)
+        let walletModelIdsToAdd = newWalletModelIds.subtracting(existingWalletModelIds)
 
         guard !walletModelIdsToAdd.isEmpty || !walletModelIdsToDelete.isEmpty else {
             return

--- a/Tangem/App/Services/WalletModelsManager/CommonWalletModelsManager.swift
+++ b/Tangem/App/Services/WalletModelsManager/CommonWalletModelsManager.swift
@@ -47,7 +47,7 @@ class CommonWalletModelsManager {
         })
 
         let walletModelIdsToDelete = existingWalletModelIds.subtracting(newWalletModelIds)
-        let walletModelIdsToAdd = Set(newWalletModelIds.subtracting(existingWalletModelIds)
+        let walletModelIdsToAdd = newWalletModelIds.subtracting(existingWalletModelIds)
 
         if walletModelIdsToAdd.isEmpty && walletModelIdsToDelete.isEmpty {
             return

--- a/Tangem/App/ViewModels/WalletModel.swift
+++ b/Tangem/App/ViewModels/WalletModel.swift
@@ -13,6 +13,10 @@ import BlockchainSdk
 class WalletModel {
     @Injected(\.ratesRepository) private var ratesRepository: RatesRepository
 
+    var walletModelId: WalletModel.Id {
+        .init(blockchainNetwork: blockchainNetwork, amountType: amountType)
+    }
+
     /// Listen for fiat and balance changes. This publisher will not be called if the is nothing changed. Use `update(silent:)` for waiting for update
     var walletDidChangePublisher: AnyPublisher<WalletModel.State, Never> {
         _walletDidChangePublisher.eraseToAnyPublisher()


### PR DESCRIPTION
Из-за того, что создавались всегда все walletModel, могли происходить лишние апдейты. перешел на работу с айдишниками. Я уже и так планировал в этом месте это сделать, чтобы убрать Hashable у WalletModel.  Потестил добавление/удаление сетей и токенов