### PR TITLE
IOS-4583 Add delays to fix pending derivations

### DIFF
--- a/Tangem/App/Services/DerivationManager/CommonDerivationManager.swift
+++ b/Tangem/App/Services/DerivationManager/CommonDerivationManager.swift
@@ -118,7 +118,11 @@ extension CommonDerivationManager: DerivationManager {
                 // TODO: refactor storage to single source
                 keysRepository.update(keys: keys)
                 delegate?.onDerived(response)
-                completion(.success(()))
+
+                // delay to get more time to updaеe ui and hide generate addresses shit under thе hood
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                    completion(.success(()))
+                }
             case .failure(let error):
                 completion(.failure(error))
             }

--- a/Tangem/App/Services/UserTokensManager/CommonUserTokensManager.swift
+++ b/Tangem/App/Services/UserTokensManager/CommonUserTokensManager.swift
@@ -80,7 +80,10 @@ extension CommonUserTokensManager: UserTokensManager {
             return
         }
 
-        derivationManager.deriveKeys(cardInteractor: interactor, completion: completion)
+        // Delay to update derivations in derivationManager
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            derivationManager.deriveKeys(cardInteractor: interactor, completion: completion)
+        }
     }
 
     func contains(_ tokenItem: TokenItem, derivationPath: DerivationPath?) -> Bool {


### PR DESCRIPTION
Бажок был в том, что derivationManager не успевал получить обновления.

Из-за смеси реактивщины и completion handlers приходится вставлять задержки вот так. 

Заодно добавил задержку, чтобы уменьшить гличи анимации после генерации адресов 