### PR TITLE
IOS-4611: Inverse `isToggled` appearance for the sort-by-balance button

### DIFF
--- a/Tangem/Modules/OrganizeTokens/ListHeader/OrganizeTokensHeaderView.swift
+++ b/Tangem/Modules/OrganizeTokens/ListHeader/OrganizeTokensHeaderView.swift
@@ -23,7 +23,7 @@ struct OrganizeTokensHeaderView: View {
                 FlexySizeButtonWithLeadingIcon(
                     title: viewModel.sortByBalanceButtonTitle,
                     icon: Assets.OrganizeTokens.byBalanceSortIcon.image,
-                    isToggled: !viewModel.isSortByBalanceEnabled,
+                    isToggled: viewModel.isSortByBalanceEnabled,
                     action: viewModel.toggleSortState
                 )
                 .shadow(color: Colors.Icon.inactive.opacity(sortByBalanceButtonShadowOpacity), radius: 4.0)
@@ -45,7 +45,7 @@ struct OrganizeTokensHeaderView: View {
     }
 
     private var sortByBalanceButtonShadowOpacity: CGFloat {
-        return buttonShadowOpacity / (viewModel.isSortByBalanceEnabled ? 1.0 : 3.0)
+        return buttonShadowOpacity / (viewModel.isSortByBalanceEnabled ? 3.0 : 1.0)
     }
 
     private var groupingButtonShadowOpacity: CGFloat {


### PR DESCRIPTION
[IOS-4611](https://tangem.atlassian.net/browse/IOS-4611)

Reverts changes made in f5382a7d09ae03cf8ba81b41e9b8e85cf3492ef9

[IOS-4611]: https://tangem.atlassian.net/browse/IOS-4611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ