### PR TITLE
IOS-4602: Fix buttons for locked SingleWallet cards

### DIFF
--- a/Tangem/Common/TokenActions/TokenActionListBuilder.swift
+++ b/Tangem/Common/TokenActions/TokenActionListBuilder.swift
@@ -43,4 +43,13 @@ struct TokenActionListBuilder {
 
         return availableActions
     }
+
+    func buildActionsForLockedSingleWallet() -> [TokenActionType] {
+        [
+            .buy,
+            .send,
+            .receive,
+            .sell,
+        ]
+    }
 }

--- a/Tangem/Common/TokenActions/TokenActionType.swift
+++ b/Tangem/Common/TokenActions/TokenActionType.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum TokenActionType: CaseIterable {
+enum TokenActionType {
     case buy
     case send
     case receive

--- a/Tangem/Modules/Main/LockedWalletMainContent/LockedWalletMainContentViewModel.swift
+++ b/Tangem/Modules/Main/LockedWalletMainContent/LockedWalletMainContentViewModel.swift
@@ -23,14 +23,16 @@ class LockedWalletMainContentViewModel: ObservableObject {
         )
     }()
 
-    lazy var singleWalletButtonsInfo: [ButtonWithIconInfo] = TokenActionType.allCases.map {
-        ButtonWithIconInfo(
-            title: $0.title,
-            icon: $0.icon,
-            action: {},
-            disabled: true
-        )
-    }
+    lazy var singleWalletButtonsInfo: [ButtonWithIconInfo] = TokenActionListBuilder()
+        .buildActionsForLockedSingleWallet()
+        .map {
+            ButtonWithIconInfo(
+                title: $0.title,
+                icon: $0.icon,
+                action: {},
+                disabled: true
+            )
+        }
 
     var footerViewModel: MainFooterViewModel? {
         guard canManageTokens else { return nil }


### PR DESCRIPTION
`CaseIterable` сыграло злую шутку, когда добавили 2 новых действия. Убрал и сделал явную генерацию для заблокированной карточки

<img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/d05a997e-5649-487b-ad37-da1f95334c36">
