### PR TITLE
IOS-4515: Fix dots position, update offset value

### DIFF
--- a/Tangem/Modules/Main/MainView.swift
+++ b/Tangem/Modules/Main/MainView.swift
@@ -52,9 +52,13 @@ struct MainView: View {
 
             ToolbarItem(placement: .navigationBarTrailing) {
                 HStack(spacing: 0) {
+                    if #unavailable(iOS 15) {
+                        // Offset didn't work for iOS 14 if there are no other view in toolbar
+                        Spacer()
+                            .frame(width: 10)
+                    }
                     detailsNavigationButton
                 }
-                .offset(x: 10)
             }
         })
         .actionSheet(isPresented: $viewModel.showingDeleteConfirmation) {
@@ -80,6 +84,7 @@ struct MainView: View {
     var detailsNavigationButton: some View {
         Button(action: viewModel.openDetails) {
             NavbarDotsImage()
+                .offset(x: 10)
         }
         .buttonStyle(PlainButtonStyle())
         .animation(nil)

--- a/Tangem/Modules/TokenDetails/TokenDetailsView.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsView.swift
@@ -89,7 +89,7 @@ struct TokenDetailsView: View {
             }
         } label: {
             NavbarDotsImage()
-                .offset(x: 11)
+                .offset(x: 10)
         }
     }
 }


### PR DESCRIPTION
На 14 оси была сдвинута иконка `Details` на главном, из-за чего при переходе на `Token Details` было неверное наложение изображений. Похоже когда удаляли `+` поехало местоположение иконки, т.к. при добавлении ещё одного элемента в `Toolbar` все нормально выравнивается, а оффсет не работает на 14 оси для одного элемента О_о. Заодно поменял значения с 11 на 10, чтобы не было странных отступов

https://github.com/tangem/tangem-app-ios/assets/24321494/5c9ccd64-81f8-4cf5-aac4-20c2df98757c

