### PR TITLE
IOS-4585 remove send context button when cant send

### DIFF
--- a/Tangem/Common/TokenActions/TokenActionListBuilder.swift
+++ b/Tangem/Common/TokenActions/TokenActionListBuilder.swift
@@ -20,13 +20,18 @@ struct TokenActionListBuilder {
 
     func buildTokenContextActions(
         canExchange: Bool,
+        canSend: Bool,
         exchangeUtility: ExchangeCryptoUtility,
         canHide: Bool
     ) -> [TokenActionType] {
         let canBuy = exchangeUtility.buyAvailable
         let canSell = exchangeUtility.sellAvailable
 
-        var availableActions: [TokenActionType] = [.copyAddress, .send, .receive]
+        var availableActions: [TokenActionType] = [.copyAddress]
+        if canSend {
+            availableActions.append(.send)
+        }
+        availableActions.append(.receive)
 
         if canExchange {
             if canBuy {

--- a/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentView.swift
+++ b/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentView.swift
@@ -103,46 +103,10 @@ struct MultiWalletMainContentView: View {
 
                 ForEach(section.items) { item in
                     TokenItemView(viewModel: item)
-                        .background(Colors.Background.primary)
-                        .onTapGesture(perform: item.tapAction)
-                        .highlightable(color: Colors.Button.primary.opacity(0.03))
-                        // `previewContentShape` must be called just before `contextMenu` call, otherwise visual glitches may occur
-                        .previewContentShape(cornerRadius: Constants.cornerRadius)
-                        .contextMenu {
-                            ForEach(viewModel.contextActions(for: item), id: \.self) { menuAction in
-                                contextMenuButton(for: menuAction, tokenItem: item)
-                            }
-                        }
                 }
             }
         }
         .background(Colors.Background.primary)
-    }
-
-    @ViewBuilder
-    private func contextMenuButton(for actionType: TokenActionType, tokenItem: TokenItemViewModel) -> some View {
-        let action = { viewModel.didTapContextAction(actionType, for: tokenItem) }
-        if #available(iOS 15, *), actionType.isDestructive {
-            Button(
-                role: .destructive,
-                action: action,
-                label: {
-                    labelForContextButton(with: actionType)
-                }
-            )
-        } else {
-            Button(action: action, label: {
-                labelForContextButton(with: actionType)
-            })
-        }
-    }
-
-    private func labelForContextButton(with action: TokenActionType) -> some View {
-        HStack {
-            Text(action.title)
-            action.icon.image
-                .renderingMode(.template)
-        }
     }
 }
 

--- a/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentViewModel.swift
+++ b/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentViewModel.swift
@@ -139,8 +139,9 @@ final class MultiWalletMainContentViewModel: ObservableObject {
         )
         let canExchange = userWalletModel.config.isFeatureVisible(.exchange)
         let canHide = userWalletModel.userTokensManager.canRemove(walletModel.tokenItem, derivationPath: walletModel.blockchainNetwork.derivationPath)
+        let canSend = userWalletModel.config.hasFeature(.send) && walletModel.canSendTransaction
 
-        return actionsBuilder.buildTokenContextActions(canExchange: canExchange, exchangeUtility: utility, canHide: canHide)
+        return actionsBuilder.buildTokenContextActions(canExchange: canExchange, canSend: canSend, exchangeUtility: utility, canHide: canHide)
     }
 
     func didTapContextAction(_ action: TokenActionType, for tokenItem: TokenItemViewModel) {

--- a/Tangem/Modules/Main/MultiWalletMainContent/Views/TokenList/MultiWalletTokenItemsSectionFactory.swift
+++ b/Tangem/Modules/Main/MultiWalletMainContent/Views/TokenList/MultiWalletTokenItemsSectionFactory.swift
@@ -23,6 +23,8 @@ struct MultiWalletTokenItemsSectionFactory {
 
     func makeSectionItemViewModel(
         from sectionItem: TokenSectionsAdapter.SectionItem,
+        contextActionsProvider: TokenItemContextActionsProvider,
+        contextActionsDelegate: TokenItemContextActionDelegate,
         tapAction: @escaping (WalletModel.ID) -> Void
     ) -> TokenItemViewModel {
         let infoProvider = makeSectionItemInfoProvider(from: sectionItem)
@@ -44,7 +46,9 @@ struct MultiWalletTokenItemsSectionFactory {
             tokenIcon: tokenIcon,
             isTestnetToken: tokenItem.blockchain.isTestnet,
             infoProvider: infoProvider,
-            tokenTapped: tapAction
+            tokenTapped: tapAction,
+            contextActionsProvider: contextActionsProvider,
+            contextActionsDelegate: contextActionsDelegate
         )
     }
 

--- a/Tangem/Preview Content/Mocks/ForComponents/FakeTokenItemInfoProvider.swift
+++ b/Tangem/Preview Content/Mocks/ForComponents/FakeTokenItemInfoProvider.swift
@@ -31,7 +31,9 @@ class FakeTokenItemInfoProvider: ObservableObject {
                 tokenIcon: makeTokenIconInfo(for: walletModel),
                 isTestnetToken: walletModel.blockchainNetwork.blockchain.isTestnet,
                 infoProvider: DefaultTokenItemInfoProvider(walletModel: walletModel),
-                tokenTapped: modelTapped(with:)
+                tokenTapped: modelTapped(with:),
+                contextActionsProvider: self,
+                contextActionsDelegate: self
             )
         }
     }
@@ -57,4 +59,12 @@ class FakeTokenItemInfoProvider: ObservableObject {
                 isCustom: walletModel.isCustom
             )
     }
+}
+
+extension FakeTokenItemInfoProvider: TokenItemContextActionsProvider, TokenItemContextActionDelegate {
+    func buildContextActions(for tokenItemViewModel: TokenItemViewModel) -> [TokenActionType] {
+        [.copyAddress, .hide]
+    }
+
+    func didTapContextAction(_ action: TokenActionType, for tokenItemViewModel: TokenItemViewModel) {}
 }

--- a/Tangem/UIComponents/TokenItemView/TokenItemView.swift
+++ b/Tangem/UIComponents/TokenItemView/TokenItemView.swift
@@ -50,6 +50,42 @@ struct TokenItemView: View {
         }
         .padding(14.0)
         .readGeometry(\.size.width, bindTo: $totalWidth)
+        .background(Colors.Background.primary)
+        .onTapGesture(perform: viewModel.tapAction)
+        .highlightable(color: Colors.Button.primary.opacity(0.03))
+        // `previewContentShape` must be called just before `contextMenu` call, otherwise visual glitches may occur
+        .previewContentShape(cornerRadius: Constants.cornerRadius)
+        .contextMenu {
+            ForEach(viewModel.contextActions, id: \.self) { menuAction in
+                contextMenuButton(for: menuAction)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func contextMenuButton(for actionType: TokenActionType) -> some View {
+        let action = { viewModel.didTapContextAction(actionType) }
+        if #available(iOS 15, *), actionType.isDestructive {
+            Button(
+                role: .destructive,
+                action: action,
+                label: {
+                    labelForContextButton(with: actionType)
+                }
+            )
+        } else {
+            Button(action: action, label: {
+                labelForContextButton(with: actionType)
+            })
+        }
+    }
+
+    private func labelForContextButton(with action: TokenActionType) -> some View {
+        HStack {
+            Text(action.title)
+            action.icon.image
+                .renderingMode(.template)
+        }
     }
 }
 
@@ -58,6 +94,7 @@ struct TokenItemView: View {
 private extension TokenItemView {
     enum Constants {
         static let spacerLength = 12.0
+        static let cornerRadius = 14.0
     }
 }
 

--- a/Tangem/UIComponents/TokenItemView/TokenItemViewModel.swift
+++ b/Tangem/UIComponents/TokenItemView/TokenItemViewModel.swift
@@ -11,6 +11,14 @@ import BlockchainSdk
 
 typealias WalletModelId = Int
 
+protocol TokenItemContextActionsProvider: AnyObject {
+    func buildContextActions(for tokenItemViewModel: TokenItemViewModel) -> [TokenActionType]
+}
+
+protocol TokenItemContextActionDelegate: AnyObject {
+    func didTapContextAction(_ action: TokenActionType, for tokenItemViewModel: TokenItemViewModel)
+}
+
 final class TokenItemViewModel: ObservableObject, Identifiable {
     let id: WalletModelId
 
@@ -18,6 +26,7 @@ final class TokenItemViewModel: ObservableObject, Identifiable {
     @Published var balanceFiat: LoadableTextView.State = .loading
     @Published var priceChangeState: TokenPriceChangeView.State = .loading
     @Published var hasPendingTransactions: Bool = false
+    @Published var contextActions: [TokenActionType] = []
 
     @Published private var missingDerivation: Bool = false
     @Published private var networkUnreachable: Bool = false
@@ -49,25 +58,35 @@ final class TokenItemViewModel: ObservableObject, Identifiable {
 
     private var percentFormatter = PercentFormatter()
     private var bag = Set<AnyCancellable>()
+    private weak var contextActionsProvider: TokenItemContextActionsProvider?
+    private weak var contextActionsDelegate: TokenItemContextActionDelegate?
 
     init(
         id: Int,
         tokenIcon: TokenIconInfo,
         isTestnetToken: Bool,
         infoProvider: TokenItemInfoProvider,
-        tokenTapped: @escaping (WalletModelId) -> Void
+        tokenTapped: @escaping (WalletModelId) -> Void,
+        contextActionsProvider: TokenItemContextActionsProvider,
+        contextActionsDelegate: TokenItemContextActionDelegate
     ) {
         self.id = id
         self.tokenIcon = tokenIcon
         self.isTestnetToken = isTestnetToken
         self.infoProvider = infoProvider
         self.tokenTapped = tokenTapped
+        self.contextActionsProvider = contextActionsProvider
+        self.contextActionsDelegate = contextActionsDelegate
 
         bind()
     }
 
     func tapAction() {
         tokenTapped(id)
+    }
+
+    func didTapContextAction(_ actionType: TokenActionType) {
+        contextActionsDelegate?.didTapContextAction(actionType, for: self)
     }
 
     private func bind() {
@@ -98,6 +117,7 @@ final class TokenItemViewModel: ObservableObject, Identifiable {
                 }
 
                 updatePendingTransactionsStateIfNeeded()
+                buildContextActions()
             }
             .store(in: &bag)
     }
@@ -121,5 +141,9 @@ final class TokenItemViewModel: ObservableObject, Identifiable {
 
         let percent = percentFormatter.percentFormat(value: quote.change)
         priceChangeState = .loaded(signType: signType, text: percent)
+    }
+
+    private func buildContextActions() {
+        contextActions = contextActionsProvider?.buildContextActions(for: self) ?? []
     }
 }


### PR DESCRIPTION
Пришлось перенести контекстное меню во вьюху ячейкии, т.к. меню создается вместе с ячейкой, а т.к. при обновлении стейта `WalletModel` ячейка не пересоздается получалось что контекстное меню было устаревшее. В итоге после каждого обновления стейта `WalletModel` будет обновляться и контекстное меню для каждой ячейки по отдельности. Добавил 2 протокола по созданию списка действий и делегат.

https://github.com/tangem/tangem-app-ios/assets/24321494/0677f624-68c5-472c-8dff-4a69658308b5

https://github.com/tangem/tangem-app-ios/assets/24321494/95d8d352-da45-4877-bc6c-5aec3e026f4d

