### PR TITLE
IOS-4636: Remove geometry reader from token item

### DIFF
--- a/Tangem/UIComponents/TokenItemView/TokenItemView.swift
+++ b/Tangem/UIComponents/TokenItemView/TokenItemView.swift
@@ -11,8 +11,6 @@ import SwiftUI
 struct TokenItemView: View {
     @ObservedObject var viewModel: TokenItemViewModel
 
-    @State private var totalWidth: CGFloat = .zero
-
     var body: some View {
         HStack(alignment: .center, spacing: 0.0) {
             TokenItemViewLeadingComponent(
@@ -44,12 +42,10 @@ struct TokenItemView: View {
                     balanceFiat: viewModel.balanceFiat,
                     priceChangeState: viewModel.priceChangeState
                 )
-                .frame(maxWidth: totalWidth * 0.3, alignment: .trailing)
                 .fixedSize(horizontal: true, vertical: false)
             }
         }
         .padding(14.0)
-        .readGeometry(\.size.width, bindTo: $totalWidth)
     }
 }
 


### PR DESCRIPTION
Стейт вьюх обновлялся нормально, но вот размеры проставлялись неправильные. Пока что удалил чтение геометрии, т.к. иерархия будет переделываться основательно из группы `HStack` с вложенными `VStack` в `VStack` с вложенными `HStack`, но с этой правкой можно будет сделать билд и отдать дальше в тесты.

https://github.com/tangem/tangem-app-ios/assets/24321494/e04933fb-9213-42f4-ba13-2c95cc1868dd

