### PR TITLE
IOS-4637: Display 0 instead of dashes for no account state

### DIFF
--- a/Tangem/Modules/TokenDetails/TokenDetailsViewModel.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsViewModel.swift
@@ -146,13 +146,13 @@ private extension TokenDetailsViewModel {
         switch walletModelState {
         case .created, .loading:
             balance = .loading
-        case .idle:
+        case .idle, .noAccount:
             balance = .loaded(.init(
                 balance: walletModel.getDecimalBalance(for: amountType) ?? 0,
                 currencyId: walletModel.tokenItem.currencyId,
                 currencyCode: currencySymbol
             ))
-        case .noAccount(let message), .failed(let message):
+        case .failed(let message):
             balance = .failedToLoad(error: message)
         case .noDerivation:
             // User can't reach this screen without derived keys


### PR DESCRIPTION
Требования поменялись и теперь надо показывать 0 вместо прочерков для отсутствующих балансов

<img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/3ff2882b-487b-4d74-a93b-bb55a621d3c0">
