### PR TITLE
IOS-4633: Move buy button after copy address

### DIFF
--- a/Tangem/Common/TokenActions/TokenActionListBuilder.swift
+++ b/Tangem/Common/TokenActions/TokenActionListBuilder.swift
@@ -27,18 +27,18 @@ struct TokenActionListBuilder {
         let canSell = exchangeUtility.sellAvailable
 
         var availableActions: [TokenActionType] = [.copyAddress]
+        if canExchange, canBuy {
+            availableActions.append(.buy)
+        }
+
         if canSend {
             availableActions.append(.send)
         }
+
         availableActions.append(.receive)
 
-        if canExchange {
-            if canBuy {
-                availableActions.insert(.buy, at: 0)
-            }
-            if canSell {
-                availableActions.append(.sell)
-            }
+        if canExchange, canSell {
+            availableActions.append(.sell)
         }
 
         availableActions.append(.hide)


### PR DESCRIPTION
Упростил логику, сделал без вставки, все же проще когда последовательно заполняется список действий и меньше потенциальных багов. Вдобавок вставка в центр массива более тяжелая операция, чем проверка булки

<img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/b9bc189f-6fa0-463a-9e2a-c05d3719f2a2">
