### PR TITLE
IOS-4688: Filtering legacyDerivation for User wallet notifs

### DIFF
--- a/Tangem/App/Services/NotificationManagers/UserWalletNotificationManager.swift
+++ b/Tangem/App/Services/NotificationManagers/UserWalletNotificationManager.swift
@@ -48,8 +48,10 @@ final class UserWalletNotificationManager {
             self?.dismissNotification(with: id)
         }
 
+        // We need to remove legacyDerivation WarningEvent, because it must be shown in Manage tokens only
+        let eventsWithoutDerivationWarning = userWalletModel.config.warningEvents.filter { $0 != .legacyDerivation }
         let notificationInputsFromConfig = factory.buildNotificationInputs(
-            for: userWalletModel.config.warningEvents,
+            for: eventsWithoutDerivationWarning,
             action: action,
             dismissAction: dismissAction
         )


### PR DESCRIPTION
Сообщение из `ManageTokens` показывалось на главном экране. Думаю просто фильтровать пока достаточно будет, не знаю как будет выглядеть в новом дизайне `ManageTokens`, может надо будет перенести в другое место из конфига этот event