### PR TITLE
IOS-4142 ExtendedLifetime for SignAndReadTask

### DIFF
--- a/Tangem/App/Services/Common/TangemSigner.swift
+++ b/Tangem/App/Services/Common/TangemSigner.swift
@@ -52,6 +52,8 @@ struct TangemSigner: TransactionSigner {
                 case .failure(let error):
                     promise(.failure(error))
                 }
+                
+                withExtendedLifetime(signCommand) {}
             }
         }
         .eraseToAnyPublisher()


### PR DESCRIPTION
Крэш в том, что `SignAndReadTask`  была deinit