### PR TITLE
IOS-4703: Update TokenItem layout, add minWidth constraint for price change

### DIFF
--- a/Tangem/UIComponents/TokenItemView/TokenItemView.swift
+++ b/Tangem/UIComponents/TokenItemView/TokenItemView.swift
@@ -25,17 +25,19 @@ struct TokenItemView: View {
 
             VStack(spacing: 4) {
                 HStack(alignment: .firstTextBaseline, spacing: 0) {
-                    Text(viewModel.name)
-                        .style(
-                            Fonts.Bold.subheadline,
-                            color: viewModel.hasError ? Colors.Text.tertiary : Colors.Text.primary1
-                        )
-                        .frame(minWidth: 0.20 * viewSize.width, alignment: .leading)
-                        .lineLimit(1)
+                    HStack(spacing: 6) {
+                        Text(viewModel.name)
+                            .style(
+                                Fonts.Bold.subheadline,
+                                color: viewModel.hasError ? Colors.Text.tertiary : Colors.Text.primary1
+                            )
+                            .lineLimit(1)
 
-                    if viewModel.hasPendingTransactions {
-                        Assets.pendingTxIndicator.image
+                        if viewModel.hasPendingTransactions {
+                            Assets.pendingTxIndicator.image
+                        }
                     }
+                    .frame(minWidth: 0.20 * viewSize.width, alignment: .leading)
 
                     Spacer(minLength: 8)
 
@@ -67,6 +69,7 @@ struct TokenItemView: View {
                         Spacer(minLength: Constants.spacerLength)
 
                         TokenPriceChangeView(state: viewModel.priceChangeState)
+                            .frame(minWidth: 0.16 * viewSize.width, alignment: .trailing)
                             .layoutPriority(1)
                     }
                 }


### PR DESCRIPTION
* Вчера обсуждали требования, что блок Price change должен иметь минимальную ширину в 16% от общей ширины ячейки
* Исправил верстку для названия токена и иконки обрабатываемой транзакции, до этого была проблема что иконка была далеко от текста

<img width="400" alt="pendingTxIcon" src="https://github.com/tangem/tangem-app-ios/assets/24321494/ce3733ff-e424-4b46-8626-1f0a7d40e2b9">
