### PR TITLE
IOS-4600: Display dash in total balance for case when no derivations

### DIFF
--- a/Tangem/App/Services/NotificationManagers/MultiWalletNotificationManager.swift
+++ b/Tangem/App/Services/NotificationManagers/MultiWalletNotificationManager.swift
@@ -25,7 +25,7 @@ class MultiWalletNotificationManager {
         updateSubscription = walletModelsManager.walletModelsPublisher
             .removeDuplicates()
             .flatMap { walletModels in
-                let coinsOnlyModels = walletModels.filter { $0.tokenItem.isToken }
+                let coinsOnlyModels = walletModels.filter { !$0.tokenItem.isToken }
                 return Publishers.MergeMany(coinsOnlyModels.map { $0.walletDidChangePublisher })
                     .map { _ in coinsOnlyModels }
                     .filter { walletModels in

--- a/Tangem/App/Services/TotalBalanceProvider/TotalBalanceProvider.swift
+++ b/Tangem/App/Services/TotalBalanceProvider/TotalBalanceProvider.swift
@@ -82,7 +82,7 @@ private extension TotalBalanceProvider {
     }
 
     func updateTotalBalance(with currencyCode: String, _ walletModels: [WalletModel], _ hasEntriesWithoutDerivation: Bool) {
-        guard !hasEntriesWithoutDerivation else {
+        if hasEntriesWithoutDerivation {
             totalBalanceSubject.send(.loaded(.init(balance: nil, currencyCode: currencyCode, hasError: false)))
             return
         }

--- a/Tangem/App/Services/UserWalletRepository/LockedUserWallet.swift
+++ b/Tangem/App/Services/UserWalletRepository/LockedUserWallet.swift
@@ -68,5 +68,5 @@ extension LockedUserWallet: MainHeaderInfoProvider {
         config.cardHeaderImage
     }
 
-    var isWalletModelListEmpty: Bool { false }
+    var isTokensListEmpty: Bool { false }
 }

--- a/Tangem/App/ViewModels/CardViewModel.swift
+++ b/Tangem/App/ViewModels/CardViewModel.swift
@@ -567,7 +567,7 @@ extension CardViewModel: MainHeaderInfoProvider {
 
     var userWalletNamePublisher: AnyPublisher<String, Never> { _userWalletNamePublisher.eraseToAnyPublisher() }
 
-    var isWalletModelListEmpty: Bool { walletModelsManager.walletModels.isEmpty }
+    var isTokensListEmpty: Bool { userTokenListManager.userTokensList.entries.isEmpty }
 }
 
 // TODO: refactor storage to single source

--- a/Tangem/Modules/Main/MainHeaderView/MainHeaderInfoProvider.swift
+++ b/Tangem/Modules/Main/MainHeaderView/MainHeaderInfoProvider.swift
@@ -11,6 +11,6 @@ import Combine
 protocol MainHeaderInfoProvider: AnyObject {
     var cardHeaderImage: ImageType? { get }
     var isUserWalletLocked: Bool { get }
-    var isWalletModelListEmpty: Bool { get }
+    var isTokensListEmpty: Bool { get }
     var userWalletNamePublisher: AnyPublisher<String, Never> { get }
 }

--- a/Tangem/Modules/Main/MainHeaderView/MainHeaderViewModel.swift
+++ b/Tangem/Modules/Main/MainHeaderView/MainHeaderViewModel.swift
@@ -78,7 +78,7 @@ final class MainHeaderViewModel: ObservableObject {
 
                     let balanceFormatter = BalanceFormatter()
                     var balanceToFormat = balance.balance
-                    if balanceToFormat == nil, infoProvider.isWalletModelListEmpty {
+                    if balanceToFormat == nil, infoProvider.isTokensListEmpty {
                         balanceToFormat = 0
                     }
                     let fiatBalanceFormatted = balanceFormatter.formatFiatBalance(balanceToFormat, formattingOptions: .defaultFiatFormattingOptions)

--- a/Tangem/Preview Content/Fakes/FakeUserWalletModel.swift
+++ b/Tangem/Preview Content/Fakes/FakeUserWalletModel.swift
@@ -84,7 +84,7 @@ extension FakeUserWalletModel: MainHeaderInfoProvider {
         UserWalletConfigFactory(userWallet.cardInfo()).makeConfig().cardHeaderImage
     }
 
-    var isWalletModelListEmpty: Bool { walletModelsManager.walletModels.isEmpty }
+    var isTokensListEmpty: Bool { walletModelsManager.walletModels.isEmpty }
 }
 
 extension FakeUserWalletModel {

--- a/Tangem/Preview Content/Mocks/UserWalletModelMock.swift
+++ b/Tangem/Preview Content/Mocks/UserWalletModelMock.swift
@@ -46,7 +46,7 @@ class UserWalletModelMock: UserWalletModel {
         )
     }
 
-    var isWalletModelListEmpty: Bool { walletModelsManager.walletModels.isEmpty }
+    var isTokensListEmpty: Bool { walletModelsManager.walletModels.isEmpty }
 
     var updatePublisher: AnyPublisher<Void, Never> { .just }
 


### PR DESCRIPTION
* Неправильно совершалась проверка на наличие `WalletModel`, а должен был проверяться список записей, если их нет, тогда показывать 0 в тотал балансе, а если есть токены без деривации показывать прочерк. Переименовал в протоколе свойство, чтобы больше соответствовало проверяемой логике
* пока копался по сущностям немного обновил код, чтобы проще читался
* исправил бажок, что оповещение о недоступности сетей не всегда появлялось, была проблема что подписывались на апдейты только токенов, а не сетей

<img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/6ea2eb72-9642-455f-b86e-48c044a195fa">
<img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/3a0f5fd9-c007-4ad5-9b50-85bd8d9ebca8">
