### PR TITLE
IOS-4758: Remove error message from main header

### DIFF
--- a/Tangem/Modules/Main/MainHeaderView/MainHeaderSubtitleProvider/SingleWalletMainHeaderSubtitleProvider.swift
+++ b/Tangem/Modules/Main/MainHeaderView/MainHeaderSubtitleProvider/SingleWalletMainHeaderSubtitleProvider.swift
@@ -62,8 +62,8 @@ class SingleWalletMainHeaderSubtitleProvider: MainHeaderSubtitleProvider {
                 isLoadingSubject.send(false)
 
                 switch newState {
-                case .failed(let error):
-                    formatErrorMessage(with: error)
+                case .failed:
+                    formatErrorMessage()
                 case .idle, .noAccount:
                     formatBalanceMessage()
                 case .created, .loading, .noDerivation:
@@ -79,8 +79,8 @@ class SingleWalletMainHeaderSubtitleProvider: MainHeaderSubtitleProvider {
         subject.send(.init(message: balance, formattingOption: .default))
     }
 
-    private func formatErrorMessage(with text: String) {
-        subject.send(.init(message: text, formattingOption: .error))
+    private func formatErrorMessage() {
+        subject.send(.init(message: BalanceFormatter.defaultEmptyBalanceString, formattingOption: .default))
     }
 
     private func displayLockedWalletMessage() {


### PR DESCRIPTION
Наконец определились с требованиями и решили убрать сообщение из подзаголовка и текст ошибки не добавлять в оповещение

<img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/371670b4-bc3a-406c-a9f1-12716f86c01f">
