### PR TITLE
IOS-4695: Allow the `sort-by-balance` button only to enable balance sorting, but not to disable it

### DIFF
--- a/Tangem/Modules/OrganizeTokens/ListHeader/OrganizeTokensHeaderViewModel.swift
+++ b/Tangem/Modules/OrganizeTokens/ListHeader/OrganizeTokensHeaderViewModel.swift
@@ -74,7 +74,7 @@ final class OrganizeTokensHeaderViewModel: ObservableObject {
             .withWeakCaptureOf(self)
             .sink { viewModel, _ in
                 // The 'sort-by-balance' button only allows to enable balance sorting but not to disable it
-                guard !viewModel.isSortByBalanceEnabled else { return }
+                if viewModel.isSortByBalanceEnabled { return }
 
                 Analytics.log(.organizeTokensButtonSortByBalance)
                 viewModel.optionsEditing.sort(

--- a/Tangem/Modules/OrganizeTokens/ListHeader/OrganizeTokensHeaderViewModel.swift
+++ b/Tangem/Modules/OrganizeTokens/ListHeader/OrganizeTokensHeaderViewModel.swift
@@ -73,6 +73,9 @@ final class OrganizeTokensHeaderViewModel: ObservableObject {
             .throttle(for: 1.0, scheduler: DispatchQueue.main, latest: false)
             .withWeakCaptureOf(self)
             .sink { viewModel, _ in
+                // The 'sort-by-balance' button only allows to enable balance sorting but not to disable it
+                guard !viewModel.isSortByBalanceEnabled else { return }
+
                 Analytics.log(.organizeTokensButtonSortByBalance)
                 viewModel.optionsEditing.sort(
                     by: viewModel.isSortByBalanceEnabled ? .dragAndDrop : .byBalance


### PR DESCRIPTION
[IOS-4695](https://tangem.atlassian.net/browse/IOS-4695)

[IOS-4695]: https://tangem.atlassian.net/browse/IOS-4695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ