### PR TITLE
IOS-4780: Update total balance and image logic

### DIFF
--- a/Tangem/Modules/Main/MainHeaderView/MainHeaderView.swift
+++ b/Tangem/Modules/Main/MainHeaderView/MainHeaderView.swift
@@ -39,7 +39,6 @@ struct MainHeaderView: View {
 
                 if let cardImage = viewModel.cardImage, contentSettings.shouldShowTrailingContent {
                     Spacer(minLength: horizontalSpacing)
-                        .background(Color.yellow)
 
                     cardImage.image
                         .frame(size: imageSize)

--- a/Tangem/Modules/Main/MainHeaderView/MainHeaderView.swift
+++ b/Tangem/Modules/Main/MainHeaderView/MainHeaderView.swift
@@ -18,6 +18,8 @@ struct MainHeaderView: View {
     var body: some View {
         GeometryReader { proxy in
             HStack(spacing: 0) {
+                let contentSettings = contentSettings(containerWidth: proxy.size.width)
+
                 VStack(alignment: .leading, spacing: 6) {
                     titleView
 
@@ -33,12 +35,11 @@ struct MainHeaderView: View {
                     subtitleText
                 }
                 .lineLimit(1)
-                .frame(width: leadingContentWidth(containerWidth: proxy.size.width), alignment: .leading)
-                .padding(.vertical, 12)
+                .frame(width: contentSettings.leadingContentWidth, height: imageSize.height, alignment: .leading)
 
-                if let cardImage = viewModel.cardImage {
-                    Spacer()
-                        .frame(minWidth: horizontalSpacing)
+                if let cardImage = viewModel.cardImage, contentSettings.shouldShowTrailingContent {
+                    Spacer(minLength: horizontalSpacing)
+                        .background(Color.yellow)
 
                     cardImage.image
                         .frame(size: imageSize)
@@ -75,14 +76,26 @@ struct MainHeaderView: View {
         }
     }
 
-    private func leadingContentWidth(containerWidth: CGFloat) -> CGFloat {
-        var trailingOffset: CGFloat = 0
+    private func calculateTextWidth(_ text: NSAttributedString) -> CGFloat {
+        return text.string
+            .size(withAttributes: text.attributes(at: 0, effectiveRange: nil))
+            .width
+    }
 
-        if viewModel.cardImage != nil {
-            trailingOffset = imageSize.width + horizontalSpacing
+    private func widthForBalanceWithImage(containerWidth: CGFloat) -> CGFloat {
+        let imageWidth = viewModel.cardImage != nil ? imageSize.width : 0
+        return containerWidth - imageWidth - horizontalSpacing
+    }
+
+    private func contentSettings(containerWidth: CGFloat) -> (leadingContentWidth: CGFloat, shouldShowTrailingContent: Bool) {
+        let balanceWidth = calculateTextWidth(viewModel.balance)
+
+        let widthForBalanceWithImage = widthForBalanceWithImage(containerWidth: containerWidth)
+        if balanceWidth > widthForBalanceWithImage {
+            return (containerWidth, false)
         }
 
-        return max(containerWidth - trailingOffset, 0.0)
+        return (max(widthForBalanceWithImage, 0), true)
     }
 }
 

--- a/Tangem/Modules/Main/MainHeaderView/MainHeaderViewModel.swift
+++ b/Tangem/Modules/Main/MainHeaderView/MainHeaderViewModel.swift
@@ -15,7 +15,7 @@ final class MainHeaderViewModel: ObservableObject {
 
     @Published private(set) var userWalletName: String = ""
     @Published private(set) var subtitleInfo: MainHeaderSubtitleInfo = .empty
-    @Published private(set) var balance: NSAttributedString = .init(string: "")
+    @Published private(set) var balance: NSAttributedString = .init(string: BalanceFormatter.defaultEmptyBalanceString)
     @Published var isLoadingFiatBalance: Bool = true
     @Published var isLoadingSubtitle: Bool = true
 

--- a/Tangem/Preview Content/Cards/PreviewCards.swift
+++ b/Tangem/Preview Content/Cards/PreviewCards.swift
@@ -9,24 +9,8 @@
 import TangemSdk
 
 extension Card {
-    private static var walletWithBackupUrl: URL {
-        Bundle.main.url(forResource: "walletWithBackup", withExtension: "json")!
-    }
-
-    private static var walletV2URL: URL {
-        Bundle.main.url(forResource: "walletV2", withExtension: "json")!
-    }
-
-    private static var twinURL: URL {
-        Bundle.main.url(forResource: "twinCard", withExtension: "json")!
-    }
-
-    private static var xrpNoteURL: URL {
-        Bundle.main.url(forResource: "xrpNote", withExtension: "json")!
-    }
-
     static var walletWithBackup: Card {
-        return decodeFromURL(walletWithBackupUrl)!
+        return decodeFromURL(walletWithBackupURL)!
     }
 
     static var walletV2: Card {
@@ -39,6 +23,34 @@ extension Card {
 
     static var xrpNote: Card {
         return decodeFromURL(xrpNoteURL)!
+    }
+
+    static var xlmBird: Card {
+        return decodeFromURL(xlmBirdURL)!
+    }
+
+    private static var walletWithBackupURL: URL {
+        url(fileName: "walletWithBackup")
+    }
+
+    private static var walletV2URL: URL {
+        url(fileName: "walletV2")
+    }
+
+    private static var twinURL: URL {
+        url(fileName: "twinCard")
+    }
+
+    private static var xrpNoteURL: URL {
+        url(fileName: "xrpNote")
+    }
+
+    private static var xlmBirdURL: URL {
+        url(fileName: "xlmBird")
+    }
+
+    private static func url(fileName: String) -> URL {
+        Bundle.main.url(forResource: fileName, withExtension: "json")!
     }
 
     private static func decodeFromURL(_ url: URL) -> Card? {

--- a/Tangem/Preview Content/Cards/xlmBird.json
+++ b/Tangem/Preview Content/Cards/xlmBird.json
@@ -1,0 +1,73 @@
+{
+    "isAccessCodeSet" : false,
+    "linkedTerminalStatus" : "none",
+    "cardPublicKey" : "04F1CDEE71100B81322CA82A61E760A235325A721059F92DC613F41B5E9C9571B06E34FF39EF8775825B168B19C0259EA141E89DB3A335162DCB1CDE0E994143C6",
+    "settings" : {
+        "maxWalletsCount" : 1,
+        "isRemovingUserCodesAllowed" : true,
+        "isLinkedTerminalEnabled" : true,
+        "isFilesAllowed" : true,
+        "supportedEncryptionModes" : [
+            "strong",
+            "fast",
+            "none"
+        ],
+        "securityDelay" : 15000,
+        "isBackupAllowed" : false,
+        "isSettingAccessCodeAllowed" : false,
+        "isHDWalletAllowed" : false,
+        "isKeysImportAllowed" : false,
+        "isSettingPasscodeAllowed" : true,
+        "isOverwritingIssuerExtraDataRestricted": true,
+        "isIssuerDataProtectedAgainstReplay": true,
+        "isSelectBlockchainAllowed": false
+    },
+    "supportedCurves" : [
+        "ed25519"
+    ],
+    "issuer" : {
+        "name" : "TANGEM",
+        "publicKey" : "048196AA4B410AC44A3B9CCE18E7BE226AEA070ACC83A9CF67540FAC49AF25129F6A538A28AD6341358E3C4F9963064F7E365372A651D374E5C23CDD37FD099BF2"
+    },
+    "firmwareVersion" : {
+        "minor" : 5,
+        "patch" : 0,
+        "major" : 3,
+        "stringValue" : "3.05r",
+        "type" : "r"
+    },
+    "batchId" : "0052",
+    "isPasscodeSet" : false,
+    "manufacturer" : {
+        "name" : "TANGEM",
+        "manufactureDate" : "2020-03-12",
+        "signature" : "5D001070E4C660CDC19F4B779147F866B7476FD1EB86DD13BF13D1E602B6869A56A24E6B1FED9F629537CE10112D139B107A2FFF2DF25F7E3CA87F4938E74A58"
+    },
+    "attestation" : {
+        "cardKeyAttestation" : "verified",
+        "walletKeysAttestation" : "skipped",
+        "firmwareAttestation" : "skipped",
+        "cardUniquenessAttestation" : "skipped"
+    },
+    "cardId" : "CB43000000002950",
+    "wallets" : [
+        {
+            "totalSignedHashes" : 19,
+            "isImported" : false,
+            "hasBackup" : false,
+            "remainingSignatures" : 999981,
+            "derivedKeys" : {
+
+            },
+            "curve" : "ed25519",
+            "publicKey" : "9FE5BB2CC7D83C1DA10845AFD8A34B141FD8FD72500B95B1547E12B9BB8AAC3D",
+            "settings" : {
+                "isPermanent" : false
+            },
+            "index" : 0
+        }
+    ],
+    "userSettings" : {
+        "isUserCodeRecoveryAllowed" : false
+    }
+}

--- a/Tangem/Preview Content/Fakes/FakeUserWalletModel.swift
+++ b/Tangem/Preview Content/Fakes/FakeUserWalletModel.swift
@@ -123,4 +123,14 @@ extension FakeUserWalletModel {
         walletManagers: [.xrpManager],
         userWallet: UserWalletStubs.xrpNoteStub
     )
+
+    static let xlmBird = FakeUserWalletModel(
+        userWalletName: "XLM Bird",
+        isMultiWallet: false,
+        isUserWalletLocked: false,
+        cardsCount: 1,
+        userWalletId: .init(with: Data.randomData(count: 32)),
+        walletManagers: [.xlmManager],
+        userWallet: UserWalletStubs.xlmBirdStub
+    )
 }

--- a/Tangem/Preview Content/Fakes/FakeWalletManager.swift
+++ b/Tangem/Preview Content/Fakes/FakeWalletManager.swift
@@ -129,4 +129,10 @@ extension FakeWalletManager {
         wallet.add(coinValue: 5828830)
         return FakeWalletManager(wallet: wallet)
     }()
+
+    static let xlmManager: FakeWalletManager = {
+        var wallet = Wallet.xrpWalletStub
+        wallet.add(coinValue: 5828830)
+        return FakeWalletManager(wallet: wallet)
+    }()
 }

--- a/Tangem/Preview Content/Mocks/ForComponents/CardHeader/FakeCardHeaderPreviewProvider.swift
+++ b/Tangem/Preview Content/Mocks/ForComponents/CardHeader/FakeCardHeaderPreviewProvider.swift
@@ -17,14 +17,37 @@ final class FakeCardHeaderPreviewProvider: ObservableObject {
             walletModel: FakeUserWalletModel.wallet3Cards,
             tapAction: { provider in
                 provider.walletModel.updateWalletName(provider.walletModel.userWalletName == "William Wallet" ? "Uilleam Uallet" : "William Wallet")
+                let firstValue: Decimal = 4346824.2189
+                let secondValue: Decimal = 4346820004.2189
+                let thirdValue: Decimal = 4346213820004.2189
+                let fourthValue: Decimal? = nil
                 switch provider.balance {
                 case .loading:
                     provider.balance = .loaded(TotalBalanceProvider.TotalBalance(
-                        balance: 4346437892534324.2189,
+                        balance: firstValue,
                         currencyCode: "USD",
                         hasError: false
                     ))
-                case .loaded, .failedToLoad:
+                case .loaded(let total):
+                    let newValue: Decimal?
+                    switch total.balance {
+                    case .none:
+                        newValue = firstValue
+                    case firstValue:
+                        newValue = secondValue
+                    case secondValue:
+                        newValue = thirdValue
+                    case thirdValue:
+                        newValue = fourthValue
+                    default:
+                        newValue = firstValue
+                    }
+                    provider.balance = .loaded(TotalBalanceProvider.TotalBalance(
+                        balance: newValue,
+                        currencyCode: "USD",
+                        hasError: false
+                    ))
+                case .failedToLoad:
                     provider.balance = .loading
                 }
             }
@@ -52,6 +75,21 @@ final class FakeCardHeaderPreviewProvider: ObservableObject {
                 case .loading:
                     provider.balance = .loaded(TotalBalanceProvider.TotalBalance(
                         balance: 4567575476468896456534878754.2114313,
+                        currencyCode: "USD",
+                        hasError: false
+                    ))
+                case .loaded, .failedToLoad:
+                    provider.balance = .loading
+                }
+            }
+        ),
+        CardInfoProvider(
+            walletModel: FakeUserWalletModel.xlmBird,
+            tapAction: { provider in
+                switch provider.balance {
+                case .loading:
+                    provider.balance = .loaded(TotalBalanceProvider.TotalBalance(
+                        balance: 4567575476468896456532344878754.2114313,
                         currencyCode: "USD",
                         hasError: false
                     ))

--- a/Tangem/Preview Content/Stubs/UserWalletStubs.swift
+++ b/Tangem/Preview Content/Stubs/UserWalletStubs.swift
@@ -49,4 +49,14 @@ struct UserWalletStubs {
         artwork: nil,
         isHDWalletAllowed: false
     )
+
+    static var xlmBirdStub: UserWallet = .init(
+        userWalletId: Data.randomData(count: 32),
+        name: "XLM Bird",
+        card: .init(card: .xrpNote),
+        associatedCardIds: [],
+        walletData: .file(.init(blockchain: "XLM", token: nil)),
+        artwork: nil,
+        isHDWalletAllowed: false
+    )
 }

--- a/Tangem/Preview Content/Stubs/WalletStubs.swift
+++ b/Tangem/Preview Content/Stubs/WalletStubs.swift
@@ -75,4 +75,18 @@ extension Wallet {
             ),
         ]
     )
+
+    static let xlmWalletStub = Wallet(
+        blockchain: .stellar(curve: .ed25519, testnet: false),
+        addresses: [
+            .default: PlainAddress(
+                value: "GCYURTBQWFCOR4QUVZLVJR2TYQFJX4VDGWO3IJDOAPDKF5Q2QLBIFC7R",
+                publicKey: .init(
+                    seedKey: Data(hexString: "0374D0F81F42DDFE34114D533E95E6AE5FE6EA271C96F1FA505199FDC365AE9720"),
+                    derivationType: .plain(.xrpDerivationStub)
+                ),
+                type: .default
+            ),
+        ]
+    )
 }

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -1571,6 +1571,7 @@
 		B0BDFD212A8BAB3600479F53 /* UnlockUserWalletBottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockUserWalletBottomSheetView.swift; sourceTree = "<group>"; };
 		B0BE30642A7BA74000B3AD13 /* MultiWalletTokenItemsSectionFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiWalletTokenItemsSectionFactory.swift; sourceTree = "<group>"; };
 		B0BE7D942AC2EB580012D9EE /* SwapAvailabilityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapAvailabilityManager.swift; sourceTree = "<group>"; };
+		B0BEBED82AD3DF2900FD722C /* xlmBird.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = xlmBird.json; sourceTree = "<group>"; };
 		B0BF631A2A0D1C6F009EB975 /* TotalBalanceFormattingOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalBalanceFormattingOptions.swift; sourceTree = "<group>"; };
 		B0C171CD264C173400E4BA5C /* CameraAccessDeniedModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraAccessDeniedModifier.swift; sourceTree = "<group>"; };
 		B0C4A1D22671F3FB00DCB921 /* TestnetBuyCryptoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestnetBuyCryptoService.swift; sourceTree = "<group>"; };
@@ -3831,6 +3832,7 @@
 				B0F319062A73951E009F131E /* walletV2.json */,
 				B0F319072A73954E009F131E /* twinCard.json */,
 				B0F319052A7394E2009F131E /* xrpNote.json */,
+				B0BEBED82AD3DF2900FD722C /* xlmBird.json */,
 				B0DC10D32927564000BBE854 /* PreviewCards.swift */,
 			);
 			path = Cards;


### PR DESCRIPTION
Изменения только в `MainHeaderView` и `MainHeaderViewModel`
все остальное чтобы в превью можно было просмотреть результаты. Так что превью файлы можно не смотреть.

Пока что карточка исчезает без анимации, пробовал прикрутить, но появляется проблема с балансом, он как-то странно анимируется, надо больше времени разобраться где именно косячок, может быть во вложенных вьюхах, пробовал обновлять скелетон, но не помогло, пока что убрал эти изменения. `IOS-4791` задача на доработку анимаций. Пока отложил её, думаю в целом это не блочит релиз

https://github.com/tangem/tangem-app-ios/assets/24321494/0582519f-304b-45ff-95a6-8616a6cecf5d

