### PR TITLE
IOS-4781: Add delay for token list loader update

### DIFF
--- a/Tangem/App/Services/UserTokenListManager/CommonUserTokenListManager.swift
+++ b/Tangem/App/Services/UserTokenListManager/CommonUserTokenListManager.swift
@@ -136,11 +136,11 @@ private extension CommonUserTokenListManager {
     func notifyAboutTokenListUpdates(with userTokenList: StoredUserTokenList? = nil) {
         let updatedUserTokenList = userTokenList ?? tokenItemsRepository.getList()
         DispatchQueue.main.async {
+            self.userTokensListSubject.send(updatedUserTokenList)
+
             if !self.initialized, self.tokenItemsRepository.containsFile {
                 self.initializedSubject.send(true)
             }
-
-            self.userTokensListSubject.send(updatedUserTokenList)
         }
     }
 


### PR DESCRIPTION
Была проблема, что при первичной загрузке появлялся на доли секунды пустой список токенов, потом сменялся реальным списком. Проблема в задержке, которую добавили для снижения количества апдейтов. Кажется будто такое решение немного ненадежное в плане изменений. Проблема кроется в том, что у нас всегда есть список, если для карточки не сохранен никакой список мы берем пустой, хотя это не правильно, лучше было бы явно на всех уровнях понимать что списка нет и он пока что грузится, а когда он не загрузился или загрузился пустой - сохранять пустой список и отображать его. Но мне кажется это много чего затронет и лучше сейчас сделать таким образом, а когда будем выпиливать `StorageEntry` уже обсудить как лучше сделать эту логику.
Еще поменял очередность вызова оповещений об обновленном списке, чтобы в начале создавались все модели (WalletManager, WalletModel, запускался отсчет для создание секций на главной), а потом уже оповещали о завершении загрузки списка

https://github.com/tangem/tangem-app-ios/assets/24321494/7c1ce348-7e84-4b0d-ba70-9d2e288e0c98

