### PR TITLE
IOS-4856: Remove first receive step with warning

### DIFF
--- a/Tangem/UIComponents/ReceiveBottomSheetView/ReceiveBottomSheetViewModel.swift
+++ b/Tangem/UIComponents/ReceiveBottomSheetView/ReceiveBottomSheetViewModel.swift
@@ -48,7 +48,7 @@ class ReceiveBottomSheetViewModel: ObservableObject, Identifiable {
             tokenItem.networkName
         )
 
-        isUserUnderstandsAddressNetworkRequirements = AppSettings.shared.understandsAddressNetworkRequirements.contains(tokenItem.networkName)
+        isUserUnderstandsAddressNetworkRequirements = true
 
         bind()
     }


### PR DESCRIPTION
не убирал никакие условия и не чистил код, потому что этот экран будет дорабатываться и не до конца ясна его судьба, поэтому пока просто скрываем его. Теперь вместо предупреждающего экрана будет сразу показываться адрес

https://tangem.atlassian.net/browse/IOS-4856