### PR TITLE
IOS-4871: Add missing alert modifier

### DIFF
--- a/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentView.swift
+++ b/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentView.swift
@@ -58,10 +58,7 @@ struct MultiWalletMainContentView: View {
         .animation(.default, value: viewModel.notificationInputs)
         .animation(.default, value: viewModel.tokensNotificationInputs)
         .padding(.horizontal, 16)
-        .background(
-            Color.clear
-                .alert(item: $viewModel.error, content: { $0.alert })
-        )
+        .bindAlert($viewModel.error)
     }
 
     private var tokensContent: some View {

--- a/Tangem/Modules/Main/SingleWalletMainContent/SingleWalletMainContentView.swift
+++ b/Tangem/Modules/Main/SingleWalletMainContent/SingleWalletMainContentView.swift
@@ -50,6 +50,7 @@ struct SingleWalletMainContentView: View {
         .animation(.default, value: viewModel.notificationInputs)
         .animation(.default, value: viewModel.tokenNotificationInputs)
         .padding(.horizontal, 16)
+        .bindAlert($viewModel.alert)
     }
 }
 

--- a/Tangem/UIComponents/Extensions/View+AlertBinder.swift
+++ b/Tangem/UIComponents/Extensions/View+AlertBinder.swift
@@ -1,0 +1,21 @@
+//
+//  View+AlertBinder.swift
+//  Tangem
+//
+//  Created by Andrew Son on 18/10/23.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import SwiftUI
+
+extension View {
+    /// This binder is safier than just adding `alert` modifier to the view.
+    /// When you add `alert` modifier to the parent and child view, child view will not be able to display alert
+    /// So we need to wrap alerts in background views to fix this. Same fix as for navigation
+    func bindAlert(_ item: Binding<AlertBinder?>) -> some View {
+        background(
+            Color.clear
+                .alert(item: item) { $0.alert }
+        )
+    }
+}

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@
 		B003BDAA2A0291C200B282F7 /* TokenIconInfoBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B003BDA92A0291C200B282F7 /* TokenIconInfoBuilder.swift */; };
 		B003BDAC2A029C4300B282F7 /* BalanceConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B003BDAB2A029C4300B282F7 /* BalanceConverter.swift */; };
 		B004C40E298AA9E00029C14A /* WalletConnectV2SendTransactionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B004C40D298AA9E00029C14A /* WalletConnectV2SendTransactionHandler.swift */; };
+		B005ADA02ADFF83B008B6D1F /* View+AlertBinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B005AD9F2ADFF83B008B6D1F /* View+AlertBinder.swift */; };
 		B008E13A29802157006E0E31 /* WebSocketError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B008E13929802157006E0E31 /* WebSocketError.swift */; };
 		B008E13C29802612006E0E31 /* WebSocketConnectionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B008E13B29802612006E0E31 /* WebSocketConnectionDelegate.swift */; };
 		B008E13E2980264D006E0E31 /* WebSocketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B008E13D2980264D006E0E31 /* WebSocketEvent.swift */; };
@@ -1384,6 +1385,7 @@
 		B003BDA92A0291C200B282F7 /* TokenIconInfoBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenIconInfoBuilder.swift; sourceTree = "<group>"; };
 		B003BDAB2A029C4300B282F7 /* BalanceConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceConverter.swift; sourceTree = "<group>"; };
 		B004C40D298AA9E00029C14A /* WalletConnectV2SendTransactionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletConnectV2SendTransactionHandler.swift; sourceTree = "<group>"; };
+		B005AD9F2ADFF83B008B6D1F /* View+AlertBinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+AlertBinder.swift"; sourceTree = "<group>"; };
 		B008E13929802157006E0E31 /* WebSocketError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketError.swift; sourceTree = "<group>"; };
 		B008E13B29802612006E0E31 /* WebSocketConnectionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketConnectionDelegate.swift; sourceTree = "<group>"; };
 		B008E13D2980264D006E0E31 /* WebSocketEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketEvent.swift; sourceTree = "<group>"; };
@@ -3024,6 +3026,7 @@
 			isa = PBXGroup;
 			children = (
 				B0120A952A0E0FB900F485F1 /* Text+NSAttributedString.swift */,
+				B005AD9F2ADFF83B008B6D1F /* View+AlertBinder.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -7469,6 +7472,7 @@
 				DC7D39F329E00290007BCD23 /* SingleCardOnboardingStepsBuilder.swift in Sources */,
 				DC261CB5292CF6B700875E64 /* UncompletedBackupView.swift in Sources */,
 				EF1339B12AB2522200B78BA3 /* LegacyTransactionMapper.swift in Sources */,
+				B005ADA02ADFF83B008B6D1F /* View+AlertBinder.swift in Sources */,
 				B0B2DF6026E1FD5400BC0934 /* AnimatedView.swift in Sources */,
 				DCD9CBA529F7F4EF00440C93 /* LogFileProvider.swift in Sources */,
 				65C9FCAE28644F9D00FDE63E /* DetailsView.swift in Sources */,


### PR DESCRIPTION
Не отображались алерты для демо карточек. Не было модификатора для алертов для одновалюток.

Сделал отдельный модификатор для алертов, чтобы не было конфликтов с родительскими модификаторами алертов.