### PR TITLE
IOS-4884 Update Binding's connect 

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -441,7 +441,7 @@ SPEC CHECKSUMS:
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Solana.Swift: 81d52fee263fded11b0d4e7859863ae489fe753e
-  SPRMessengerClient: 898cf32fb49c4f37ff57ccb0da278c719ce86e71
+  SPRMessengerClient: f814ba9b241b9a05aa035a187242f619bd357704
   Starscream: 5178aed56b316f13fa3bc55694e583d35dd414d9
   stellar-ios-mac-sdk: d8ab1ff49ac48e25ac3097da4deebcef77af6047
   SwiftCBOR: ac340b74d3b2cf1f8884bb748bd09875848e3873

--- a/Tangem/Common/Types/BindingValue.swift
+++ b/Tangem/Common/Types/BindingValue.swift
@@ -101,13 +101,8 @@ extension Binding {
 
 extension View {
     func connect<V: Equatable>(state: Binding<V>, to binding: BindingValue<V>) -> some View {
-        onChange(of: binding.value) { [value = state.wrappedValue] newValue in
-            if value != newValue {
-                state.wrappedValue = newValue
-            }
-        }
-        .onChange(of: state.wrappedValue) { [value = binding.value] newValue in
-            if value != newValue {
+        onChange(of: state.wrappedValue) { newValue in
+            if binding.value != newValue {
                 binding.value = newValue
             }
         }


### PR DESCRIPTION
Проблема была в том что при втором нажатии на тоггл дергался onChange(binding.value) и менялось значение у state

Понял что этот код вообще не нужен, так как обратное обновление сейчас работает через только через пересоздание `ViewModel`