### PR TITLE
IOS-4906: Hide buy and sell for cards with hidden exchange

### DIFF
--- a/Tangem/Common/TokenActions/TokenActionListBuilder.swift
+++ b/Tangem/Common/TokenActions/TokenActionListBuilder.swift
@@ -9,8 +9,18 @@
 import Foundation
 
 struct TokenActionListBuilder {
-    func buildActionsForButtonsList(canShowSwap: Bool) -> [TokenActionType] {
-        var actions: [TokenActionType] = [.buy, .send, .receive, .sell]
+    func buildActionsForButtonsList(canShowBuySell: Bool, canShowSwap: Bool) -> [TokenActionType] {
+        var actions: [TokenActionType] = []
+        if canShowBuySell {
+            actions.append(.buy)
+        }
+
+        actions.append(contentsOf: [.send, .receive])
+
+        if canShowBuySell {
+            actions.append(.sell)
+        }
+
         if canShowSwap {
             actions.append(.exchange)
         }

--- a/Tangem/Modules/SingleTokenBase/SingleTokenBaseViewModel.swift
+++ b/Tangem/Modules/SingleTokenBase/SingleTokenBaseViewModel.swift
@@ -221,7 +221,8 @@ extension SingleTokenBaseViewModel {
     private func setupActionButtons() {
         let listBuilder = TokenActionListBuilder()
         let canShowSwap = userWalletModel.config.hasFeature(.swapping)
-        availableActions = listBuilder.buildActionsForButtonsList(canShowSwap: canShowSwap)
+        let canShowBuySell = userWalletModel.config.isFeatureVisible(.exchange)
+        availableActions = listBuilder.buildActionsForButtonsList(canShowBuySell: canShowBuySell, canShowSwap: canShowSwap)
     }
 
     private func bind() {
@@ -298,11 +299,10 @@ extension SingleTokenBaseViewModel {
     }
 
     private func isButtonDisabled(with type: TokenActionType) -> Bool {
-        let canExchange = userWalletModel.config.isFeatureVisible(.exchange)
         let isBlockchainUnreachable = walletModel.state.isBlockchainUnreachable
         switch type {
         case .buy:
-            return !(canExchange && exchangeUtility.buyAvailable)
+            return !exchangeUtility.buyAvailable
         case .send:
             return !canSend
         case .receive:
@@ -310,7 +310,7 @@ extension SingleTokenBaseViewModel {
         case .exchange:
             return isBlockchainUnreachable || !isSwapAvailable
         case .sell:
-            return isBlockchainUnreachable || !(canExchange && exchangeUtility.sellAvailable)
+            return isBlockchainUnreachable || !exchangeUtility.sellAvailable
         case .copyAddress, .hide:
             return true
         }


### PR DESCRIPTION
Убрал кнопки buy и sell. Теперь будет определяться конфигом, если в конфиге для одноватюных карточек указано что `hidden` -  кнопки на главном экране не будут отображаться. Для мультивалютных карточек показываются все кнопки, просто отключенные, это пока что не поменяли...

<img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/b2c0c5b1-0483-4a80-a529-af8b31f308d6">
<img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/78fe91cd-7ca6-4332-83ea-be481b9b3de2">
