### PR TITLE
IOS-4839: Remove animation for token details when open

### DIFF
--- a/Tangem/App/Services/NotificationManagers/MultiWalletNotificationManager.swift
+++ b/Tangem/App/Services/NotificationManagers/MultiWalletNotificationManager.swift
@@ -43,23 +43,23 @@ class MultiWalletNotificationManager {
     }
 
     private func removeSomeNetworksUnreachable() {
-        notificationInputsSubject.value.removeAll(where: {
+        notificationInputsSubject.value.removeAll {
             guard let event = $0.settings.event as? TokenNotificationEvent else {
                 return false
             }
 
             return event == .someNetworksUnreachable
-        })
+        }
     }
 
     private func setupSomeNetworksUnreachable() {
-        let containsNotification = notificationInputsSubject.value.contains(where: {
+        let containsNotification = notificationInputsSubject.value.contains {
             guard let event = $0.settings.event as? TokenNotificationEvent else {
                 return false
             }
 
             return event == .someNetworksUnreachable
-        })
+        }
 
         if containsNotification {
             return

--- a/Tangem/App/Services/NotificationManagers/MultiWalletNotificationManager.swift
+++ b/Tangem/App/Services/NotificationManagers/MultiWalletNotificationManager.swift
@@ -12,7 +12,7 @@ import Combine
 class MultiWalletNotificationManager {
     private let walletModelsManager: WalletModelsManager
 
-    private let eventsSubject: CurrentValueSubject<[TokenNotificationEvent], Never> = .init([])
+    private let notificationInputsSubject: CurrentValueSubject<[NotificationViewInput], Never> = .init([])
     private var updateSubscription: AnyCancellable?
 
     init(walletModelsManager: WalletModelsManager) {
@@ -43,30 +43,45 @@ class MultiWalletNotificationManager {
     }
 
     private func removeSomeNetworksUnreachable() {
-        eventsSubject.value.removeAll(where: { $0 == .someNetworksUnreachable })
+        notificationInputsSubject.value.removeAll(where: {
+            guard let event = $0.settings.event as? TokenNotificationEvent else {
+                return false
+            }
+
+            return event == .someNetworksUnreachable
+        })
     }
 
     private func setupSomeNetworksUnreachable() {
-        if eventsSubject.value.contains(.someNetworksUnreachable) {
+        let containsNotification = notificationInputsSubject.value.contains(where: {
+            guard let event = $0.settings.event as? TokenNotificationEvent else {
+                return false
+            }
+
+            return event == .someNetworksUnreachable
+        })
+
+        if containsNotification {
             return
         }
 
-        eventsSubject.value.append(.someNetworksUnreachable)
+        let factory = NotificationsFactory()
+        notificationInputsSubject.value.append(factory.buildNotificationInput(for: .someNetworksUnreachable))
     }
 }
 
 extension MultiWalletNotificationManager: NotificationManager {
-    var notificationPublisher: AnyPublisher<[NotificationViewInput], Never> {
-        eventsSubject
-            .map { events in
-                let factory = NotificationsFactory()
-
-                return events.map { factory.buildNotificationInput(for: $0) }
-            }
-            .eraseToAnyPublisher()
+    var notificationInputs: [NotificationViewInput] {
+        notificationInputsSubject.value
     }
 
+    var notificationPublisher: AnyPublisher<[NotificationViewInput], Never> {
+        notificationInputsSubject.eraseToAnyPublisher()
+    }
+
+    func setupManager(with delegate: NotificationTapDelegate?) {}
+
     func dismissNotification(with id: NotificationViewId) {
-        eventsSubject.value.removeAll(where: { $0.hashValue == id })
+        notificationInputsSubject.value.removeAll(where: { $0.id == id })
     }
 }

--- a/Tangem/App/Services/NotificationManagers/NotificationManager.swift
+++ b/Tangem/App/Services/NotificationManagers/NotificationManager.swift
@@ -10,7 +10,15 @@ import Foundation
 import Combine
 
 protocol NotificationManager {
+    var notificationInputs: [NotificationViewInput] { get }
     var notificationPublisher: AnyPublisher<[NotificationViewInput], Never> { get }
 
+    func setupManager(with delegate: NotificationTapDelegate?)
     func dismissNotification(with id: NotificationViewId)
+}
+
+extension NotificationManager {
+    func setupManager() {
+        setupManager(with: nil)
+    }
 }

--- a/Tangem/App/Services/NotificationManagers/SingleTokenNotificationManager.swift
+++ b/Tangem/App/Services/NotificationManagers/SingleTokenNotificationManager.swift
@@ -73,10 +73,16 @@ class SingleTokenNotificationManager {
         notificationInputsSubject.send(inputs)
 
         notificationsUpdateTask = Task { [weak self] in
-            if let rentInput = await self?.loadRentNotificationIfNeeded(),
-               !(self?.notificationInputsSubject.value.contains(where: { $0.id == rentInput.id }) ?? false) {
+            guard
+                let rentInput = await self?.loadRentNotificationIfNeeded(),
+                let self
+            else {
+                return
+            }
+
+            if !notificationInputsSubject.value.contains(where: { $0.id == rentInput.id }) {
                 await runOnMain {
-                    self?.notificationInputsSubject.value.append(rentInput)
+                    self.notificationInputsSubject.value.append(rentInput)
                 }
             }
         }

--- a/Tangem/App/Services/NotificationManagers/UserWalletNotificationManager.swift
+++ b/Tangem/App/Services/NotificationManagers/UserWalletNotificationManager.swift
@@ -32,13 +32,6 @@ final class UserWalletNotificationManager {
         self.signatureCountValidator = signatureCountValidator
     }
 
-    func setupManager(with delegate: NotificationTapDelegate? = nil) {
-        self.delegate = delegate
-
-        createNotifications()
-        bind()
-    }
-
     private func createNotifications() {
         let factory = NotificationsFactory()
         let action: NotificationView.NotificationAction = { [weak self] id in
@@ -156,8 +149,19 @@ final class UserWalletNotificationManager {
 }
 
 extension UserWalletNotificationManager: NotificationManager {
+    var notificationInputs: [NotificationViewInput] {
+        notificationInputsSubject.value
+    }
+
     var notificationPublisher: AnyPublisher<[NotificationViewInput], Never> {
         notificationInputsSubject.eraseToAnyPublisher()
+    }
+
+    func setupManager(with delegate: NotificationTapDelegate?) {
+        self.delegate = delegate
+
+        createNotifications()
+        bind()
     }
 
     func dismissNotification(with id: NotificationViewId) {

--- a/Tangem/Modules/SingleTokenBase/SingleTokenBaseViewModel.swift
+++ b/Tangem/Modules/SingleTokenBase/SingleTokenBaseViewModel.swift
@@ -21,7 +21,7 @@ class SingleTokenBaseViewModel: NotificationTapDelegate {
     @Published var transactionHistoryState: TransactionsListView.State = .loading
     @Published var isReloadingTransactionHistory: Bool = false
     @Published var actionButtons: [ButtonWithIconInfo] = []
-    @Published private(set) var tokenNotificationInputs: [NotificationViewInput] = []
+    @Published var tokenNotificationInputs: [NotificationViewInput] = []
     @Published private(set) var pendingTransactionViews: [TransactionViewModel] = []
 
     lazy var testnetBuyCryptoService: TestnetBuyCryptoService = .init()

--- a/Tangem/Modules/TokenDetails/TokenDetailsView.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsView.swift
@@ -40,7 +40,7 @@ struct TokenDetailsView: View {
 
                 ForEach(viewModel.tokenNotificationInputs) { input in
                     NotificationView(input: input)
-                        .transition(.notificationTransition)
+                        .transition(viewModel.shouldShowNotificationsWithAnimation ? .notificationTransition : .identity)
                 }
 
                 if viewModel.isMarketPriceAvailable {
@@ -79,6 +79,7 @@ struct TokenDetailsView: View {
         .background(Colors.Background.secondary.edgesIgnoringSafeArea(.all))
         .ignoresSafeArea(.keyboard)
         .onAppear(perform: viewModel.onAppear)
+        .onDidAppear(viewModel.onDidAppear)
         .alert(item: $viewModel.alert) { $0.alert }
         .actionSheet(item: $viewModel.actionSheet) { $0.sheet }
         .coordinateSpace(name: coorditateSpaceName)

--- a/Tangem/Modules/TokenDetails/TokenDetailsViewModel.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsViewModel.swift
@@ -15,12 +15,14 @@ import TangemSwapping
 final class TokenDetailsViewModel: SingleTokenBaseViewModel, ObservableObject {
     @Published private var balance: LoadingValue<BalanceInfo> = .loading
     @Published var actionSheet: ActionSheetBinder?
+    @Published var shouldShowNotificationsWithAnimation: Bool = false
 
     private(set) var balanceWithButtonsModel: BalanceWithButtonsViewModel!
     private(set) lazy var tokenDetailsHeaderModel: TokenDetailsHeaderViewModel = .init(tokenItem: tokenItem)
 
     private unowned let coordinator: TokenDetailsRoutable
     private var bag = Set<AnyCancellable>()
+    private var notificatioChangeSubscription: AnyCancellable?
 
     var tokenItem: TokenItem {
         switch amountType {
@@ -64,13 +66,17 @@ final class TokenDetailsViewModel: SingleTokenBaseViewModel, ObservableObject {
             tokenRouter: tokenRouter
         )
         balanceWithButtonsModel = .init(balanceProvider: self, buttonsProvider: self)
+        notificationManager.setupManager(with: self)
 
         prepareSelf()
     }
 
     func onAppear() {
         Analytics.log(.detailsScreenOpened)
-        // TODO: Rent warning update will be added in IOS-3847
+    }
+
+    func onDidAppear() {
+        shouldShowNotificationsWithAnimation = true
     }
 
     override func didTapNotificationButton(with id: NotificationViewId, action: NotificationButtonActionType) {
@@ -134,6 +140,8 @@ extension TokenDetailsViewModel {
 
 private extension TokenDetailsViewModel {
     private func prepareSelf() {
+        updateBalance(walletModelState: walletModel.state)
+        tokenNotificationInputs = notificationManager.notificationInputs
         bind()
     }
 

--- a/Tangem/Preview Content/Fakes/FakeUserWalletNotificationManager.swift
+++ b/Tangem/Preview Content/Fakes/FakeUserWalletNotificationManager.swift
@@ -10,11 +10,17 @@ import Foundation
 import Combine
 
 class FakeUserWalletNotificationManager: NotificationManager {
+    var notificationInputs: [NotificationViewInput] {
+        notificationSubject.value
+    }
+
     var notificationPublisher: AnyPublisher<[NotificationViewInput], Never> {
         notificationSubject.eraseToAnyPublisher()
     }
 
     private let notificationSubject: CurrentValueSubject<[NotificationViewInput], Never> = .init([])
+
+    func setupManager(with delegate: NotificationTapDelegate?) {}
 
     func dismissNotification(with id: NotificationViewId) {
         notificationSubject.value.removeAll(where: { $0.id == id })


### PR DESCRIPTION
При открытии баланс и оповещения появлялись с анимацией, хотя информация уже была прогружена. Это актуально только для Solana, т.к. проверка происходит каждый раз при открытии экрана. Если мы хотим это поменять, но надо делать отдельно кэширование в `WalletModel`, но пока что не представляется возможным
как было до

https://github.com/tangem/tangem-app-ios/assets/24321494/e2f61502-7310-4878-a45e-70255922f71f

как теперь

https://github.com/tangem/tangem-app-ios/assets/24321494/d203b480-ba52-44b7-a6df-995af43db069

