### PR TITLE
IOS-4930: Display full address

### DIFF
--- a/Tangem/UIComponents/ReceiveBottomSheetView/ReceiveBottomSheetView.swift
+++ b/Tangem/UIComponents/ReceiveBottomSheetView/ReceiveBottomSheetView.swift
@@ -75,10 +75,10 @@ struct ReceiveBottomSheetView: View {
                         .padding(.horizontal, 56)
 
                     Text(info.address)
-                        .lineLimit(1)
+                        .lineLimit(nil)
+                        .multilineTextAlignment(.center)
                         .style(Fonts.Bold.callout, color: Colors.Text.primary1)
                         .padding(.horizontal, 60)
-                        .truncationMode(.middle)
                 }
             }
             .padding(.top, 28)

--- a/Tangem/UIComponents/ReceiveBottomSheetView/ReceiveBottomSheetView.swift
+++ b/Tangem/UIComponents/ReceiveBottomSheetView/ReceiveBottomSheetView.swift
@@ -75,7 +75,6 @@ struct ReceiveBottomSheetView: View {
                         .padding(.horizontal, 56)
 
                     Text(info.address)
-                        .lineLimit(nil)
                         .multilineTextAlignment(.center)
                         .style(Fonts.Bold.callout, color: Colors.Text.primary1)
                         .padding(.horizontal, 60)


### PR DESCRIPTION
Отображаем адрес теперь полностью не обрезая центральную часть

<img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/472a2b47-a71a-400a-abaf-002e86c62364">
<img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/5250ab85-23d6-4314-8e71-494c57b5cee2">
<img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/49ea502c-c126-41ca-bf76-2a7de5c9cc1d">
