### PR TITLE
IOS-4940: Filtering duplicated records

### DIFF
--- a/Tangem/App/Services/TokenItemsRepository/StorageEntryConverter.swift
+++ b/Tangem/App/Services/TokenItemsRepository/StorageEntryConverter.swift
@@ -59,7 +59,7 @@ struct StorageEntryConverter {
             )
 
             partialResult += entry.tokens.map { convertToStoredUserToken($0, in: blockchainNetwork) }
-        }
+        }.unique()
     }
 
     func convertToStoredUserToken(

--- a/Tangem/App/Services/TokenItemsRepository/StoredUserTokenList.swift
+++ b/Tangem/App/Services/TokenItemsRepository/StoredUserTokenList.swift
@@ -19,7 +19,7 @@ struct StoredUserTokenList: Codable, Equatable {
         case byBalance
     }
 
-    struct Entry: Codable, Equatable {
+    struct Entry: Codable, Hashable {
         let id: String?
         let name: String
         let symbol: String

--- a/Tangem/App/Services/TokenItemsRepository/UserTokenListConverter.swift
+++ b/Tangem/App/Services/TokenItemsRepository/UserTokenListConverter.swift
@@ -104,7 +104,7 @@ struct UserTokenListConverter {
             }
 
         return StoredUserTokenList(
-            entries: entries,
+            entries: entries.unique(),
             grouping: convertToGroupingOption(groupType: remoteUserTokenList.group),
             sorting: convertToSortingOption(sortType: remoteUserTokenList.sort)
         )


### PR DESCRIPTION
Проблема была в том что если добавить в начале токен, а не монету появлялись дубликаты и они не фильтровались. Поправил и для локального добавления и для списка, который пришел с бэка. На видео локальное добавление. Так же попробовал перезаписать ответ с бека, чтобы в нем были дубликаты, норм. Кстати, на 17 оси появлялись пустые строки, а на 14.6 приложение крашилось из-за одинаковых `id`.

https://github.com/tangem/tangem-app-ios/assets/24321494/965de6ee-5722-4773-bafb-e558e0daadb9

