### PR TITLE
IOS-4969: Add logInternal with primitive types

### DIFF
--- a/Tangem/App/Services/Analytics/Analytics.swift
+++ b/Tangem/App/Services/Analytics/Analytics.swift
@@ -23,7 +23,7 @@ class Analytics {
 
     static func beginLoggingCardScan(source: CardScanSource) {
         analyticsContext.set(value: source, forKey: .scanSource, scope: .common)
-        logInternal(source.cardScanButtonEvent)
+        logEventInternal(source.cardScanButtonEvent)
     }
 
     static func endLoggingCardScan() {
@@ -33,7 +33,7 @@ class Analytics {
         }
 
         analyticsContext.removeValue(forKey: .scanSource, scope: .common)
-        logInternal(.cardWasScanned, params: [.commonSource: source.cardWasScannedParameterValue.rawValue])
+        logEventInternal(.cardWasScanned, params: [.commonSource: source.cardWasScannedParameterValue.rawValue])
     }
 
     // MARK: - Others
@@ -43,7 +43,7 @@ class Analytics {
 
         // Send only first topped up event. Do not send the event to analytics on following topup events.
         if balance > 0, hasPreviousPositiveBalance == false {
-            logInternal(.toppedUp)
+            logEventInternal(.toppedUp)
             analyticsContext.set(value: true, forKey: .hasPositiveBalance, scope: .userWallet)
         } else if hasPreviousPositiveBalance == nil { // Do not save in a withdrawal case
             // Register the first app launch with balance.
@@ -78,7 +78,7 @@ class Analytics {
             AnalyticsParameterCurrency: order.currencyCode,
         ], uniquingKeysWith: { $1 }))
 
-        logInternal(.purchased, params: amplitudeDiscountParams.merging([
+        logEventInternal(.purchased, params: amplitudeDiscountParams.merging([
             .sku: sku,
             .count: "\(order.lineItems.count)",
             .amount: "\(order.total) \(order.currencyCode)",
@@ -121,7 +121,7 @@ class Analytics {
     ) {
         assert(event.canBeLoggedDirectly)
 
-        logInternal(event, params: params, analyticsSystems: analyticsSystems)
+        logEventInternal(event, params: params, analyticsSystems: analyticsSystems)
     }
 
     // MARK: - Private
@@ -158,7 +158,7 @@ class Analytics {
         }
     }
 
-    private static func logInternal(
+    private static func logEventInternal(
         _ event: Event,
         params: [ParameterKey: String] = [:],
         analyticsSystems: [Analytics.AnalyticsSystem] = [.firebase, .appsflyer, .amplitude, .crashlytics]
@@ -167,34 +167,46 @@ class Analytics {
             return
         }
 
-        var params = params
+        logInternal(
+            event.rawValue,
+            params: params.firebaseParams,
+            analyticsSystems: analyticsSystems
+        )
+    }
 
-        if let contextualParams = analyticsContext.contextData?.analyticsParams {
-            params.merge(contextualParams, uniquingKeysWith: { _, new in new })
+    private static func logInternal(
+        _ event: String,
+        params: [String: Any] = [:],
+        analyticsSystems: [Analytics.AnalyticsSystem] = [.firebase, .appsflyer, .amplitude, .crashlytics]
+    ) {
+        if AppEnvironment.current.isXcodePreview {
+            return
         }
 
-        let key = event.rawValue
-        let values = params.firebaseParams
+        var params = params
+
+        if let contextualParams = analyticsContext.contextData?.analyticsParams.firebaseParams {
+            params.merge(contextualParams, uniquingKeysWith: { _, new in new })
+        }
 
         for system in analyticsSystems {
             switch system {
             case .appsflyer:
-                AppsFlyerLib.shared().logEvent(key, withValues: values)
+                AppsFlyerLib.shared().logEvent(event, withValues: params)
             case .firebase:
-                FirebaseAnalytics.Analytics.logEvent(key, parameters: values)
+                FirebaseAnalytics.Analytics.logEvent(event, parameters: params)
             case .crashlytics:
-                let message = "\(key).\(values)"
+                let message = "\(event).\(params)"
                 Crashlytics.crashlytics().log(message)
             case .amplitude:
-                let convertedParams = params.reduce(into: [:]) { $0[$1.key.rawValue] = $1.value }
-                Amplitude.instance().logEvent(event.rawValue, withEventProperties: convertedParams)
+                Amplitude.instance().logEvent(event, withEventProperties: params)
             }
         }
 
-        let printableParams: [String: String] = params.reduce(into: [:]) { $0[$1.key.rawValue] = $1.value }
+        let printableParams: [String: String] = params.reduce(into: [:]) { $0[$1.key] = String(describing: $1.value) }
         if let data = try? JSONSerialization.data(withJSONObject: printableParams, options: .sortedKeys),
            let paramsString = String(data: data, encoding: .utf8)?.replacingOccurrences(of: ",\"", with: ", \"") {
-            let logMessage = "Analytics event: \(event.rawValue). Params: \(paramsString)"
+            let logMessage = "Analytics event: \(event). Params: \(paramsString)"
             AppLog.shared.debug(logMessage)
         }
     }


### PR DESCRIPTION
Небольшой рефакторинг, чтобы подготовиться к дебажным событиям. А то `logInternal` жестко завязан на `Analtyics.Event` и `Analytics.ParameterKey`. Не хочется захламлять `Analytics.Event` какими-то дебажными событиями, которые будут отправляться только в крашлитикс. Дебажные события изначально попробуем интегрировать в самую неоднозначную и проблемную часть приложения - WC, если там будет полезно, можно будет расширить на все приложение.