### PR TITLE
IOS-3929: WC debug analytics events

### DIFF
--- a/Tangem/App/Services/Analytics/Analytics.swift
+++ b/Tangem/App/Services/Analytics/Analytics.swift
@@ -124,6 +124,14 @@ class Analytics {
         logEventInternal(event, params: params, analyticsSystems: analyticsSystems)
     }
 
+    static func debugLog(eventInfo: any AnalyticsDebugEvent) {
+        logInternal(
+            eventInfo.title,
+            params: eventInfo.analyticsParams,
+            analyticsSystems: [.crashlytics]
+        )
+    }
+
     // MARK: - Private
 
     fileprivate static func log(error: Error, params: [ParameterKey: String] = [:]) {

--- a/Tangem/App/Services/Analytics/Debug/Analytics+DebugEvent.swift
+++ b/Tangem/App/Services/Analytics/Debug/Analytics+DebugEvent.swift
@@ -1,0 +1,14 @@
+//
+//  Analytics+DebugEvent.swift
+//  Tangem
+//
+//  Created by Andrew Son on 27/10/23.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+protocol AnalyticsDebugEvent {
+    var title: String { get }
+    var analyticsParams: [String: Any] { get }
+}

--- a/Tangem/App/Services/Analytics/Debug/Analytics+WalletConnectDebugEvent.swift
+++ b/Tangem/App/Services/Analytics/Debug/Analytics+WalletConnectDebugEvent.swift
@@ -1,0 +1,92 @@
+//
+//  Analytics+WalletConnectDebugEvent.swift
+//  Tangem
+//
+//  Created by Andrew Son on 31/10/23.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+extension Analytics {
+    enum WalletConnectDebugEvent {
+        case webSocketConnected
+        case webSocketDisconnected(closeCode: String, connectionState: String)
+        case webSocketReceiveText
+        case webSocketConnectionError(error: Error)
+        case attemptingToOpenSession(url: String)
+        case receiveSessionProposal(name: String, dAppURL: String)
+        case receiveRequestFromDApp(method: String)
+        case errorShownToTheUser(error: String)
+    }
+}
+
+extension Analytics.WalletConnectDebugEvent: AnalyticsDebugEvent {
+    var title: String {
+        let prefix = "[WalletConnect Debug] "
+        let webSocketPrefix = "Web socket "
+        let suffix: String
+        switch self {
+        case .webSocketConnected:
+            suffix = webSocketPrefix + "connected"
+        case .webSocketDisconnected:
+            suffix = webSocketPrefix + "receive disconnected event"
+        case .webSocketReceiveText:
+            suffix = webSocketPrefix + "receive text"
+        case .webSocketConnectionError:
+            suffix = webSocketPrefix + "receive connection error"
+        case .attemptingToOpenSession:
+            suffix = "Attempting to open new session"
+        case .receiveSessionProposal:
+            suffix = "Receive session proposal"
+        case .receiveRequestFromDApp:
+            suffix = "Receive request from dApp"
+        case .errorShownToTheUser:
+            suffix = "WalletConnectV2Service displays error to user"
+        }
+
+        return prefix + suffix
+    }
+
+    var analyticsParams: [String: Any] {
+        switch self {
+        case .webSocketConnected, .webSocketReceiveText:
+            return [:]
+        case .webSocketDisconnected(let closeCode, let connectionState):
+            return [
+                ParamKey.webSocketCloseCode.rawValue: closeCode,
+                ParamKey.webSocketState.rawValue: connectionState,
+            ]
+        case .webSocketConnectionError(let error):
+            return [ParamKey.webSocketConnectionError.rawValue: error.localizedDescription]
+        case .attemptingToOpenSession(let url):
+            return [ParamKey.dAppPairingURL.rawValue: url]
+        case .receiveSessionProposal(let name, let dAppURL):
+            return [
+                ParamKey.dAppName.rawValue: name,
+                ParamKey.dAppURL.rawValue: dAppURL,
+            ]
+        case .receiveRequestFromDApp(let method):
+            return [
+                ParamKey.requestMethod.rawValue: method,
+            ]
+        case .errorShownToTheUser(let error):
+            return [
+                ParamKey.errorShownToTheUser.rawValue: error,
+            ]
+        }
+    }
+}
+
+private extension Analytics.WalletConnectDebugEvent {
+    enum ParamKey: String {
+        case webSocketCloseCode
+        case webSocketState
+        case webSocketConnectionError
+        case dAppPairingURL
+        case dAppName
+        case dAppURL
+        case requestMethod
+        case errorShownToTheUser
+    }
+}

--- a/Tangem/App/Services/WalletConnect/Utilities/WalletConnectURLParser.swift
+++ b/Tangem/App/Services/WalletConnect/Utilities/WalletConnectURLParser.swift
@@ -47,4 +47,11 @@ extension WalletConnectURLParser {
 
 public enum WalletConnectRequestURI {
     case v2(WalletConnectV2URI)
+
+    var debugString: String {
+        switch self {
+        case .v2(let walletConnectV2URI):
+            return walletConnectV2URI.absoluteString
+        }
+    }
 }

--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
@@ -161,6 +161,7 @@ final class WalletConnectV2Service {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] sessionProposal, context in
                 self?.log("Session proposal: \(sessionProposal) with verify context: \(String(describing: context))")
+                Analytics.debugLog(eventInfo: Analytics.WalletConnectDebugEvent.receiveSessionProposal(name: sessionProposal.proposer.name, dAppURL: sessionProposal.proposer.url))
                 self?.validateProposal(sessionProposal)
             }
             .store(in: &sessionSubscriptions)
@@ -225,6 +226,7 @@ final class WalletConnectV2Service {
             .asyncMap { [weak self] request, context in
                 guard let self else { return }
 
+                Analytics.debugLog(eventInfo: Analytics.WalletConnectDebugEvent.receiveRequestFromDApp(method: request.method))
                 log("Receive message request: \(request) with verify context: \(String(describing: context))")
                 await handle(request)
             }
@@ -296,6 +298,7 @@ final class WalletConnectV2Service {
     }
 
     private func displayErrorUI(_ error: WalletConnectV2Error) {
+        Analytics.debugLog(eventInfo: Analytics.WalletConnectDebugEvent.errorShownToTheUser(error: error.localizedDescription))
         uiDelegate.showScreen(with: WalletConnectUIRequest(
             event: .error,
             message: error.localizedDescription,

--- a/Tangem/Modules/WalletConnect/WalletConnectViewModel.swift
+++ b/Tangem/Modules/WalletConnect/WalletConnectViewModel.swift
@@ -93,6 +93,7 @@ class WalletConnectViewModel: ObservableObject {
     }
 
     private func openSession(with uri: WalletConnectRequestURI) {
+        Analytics.debugLog(eventInfo: Analytics.WalletConnectDebugEvent.attemptingToOpenSession(url: uri.debugString))
         walletConnectService.openSession(with: uri)
     }
 

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -173,6 +173,7 @@
 		65C9FCB22864507600FDE63E /* LegacyMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C9FCB02864507600FDE63E /* LegacyMainView.swift */; };
 		65D87499287DA0F6009D0448 /* BottomSheetSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D87498287DA0F6009D0448 /* BottomSheetSettings.swift */; };
 		7411665441ED861CCD6B1A0C /* Pods_Tangem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90762CF1A18C0BF597E3E4DD /* Pods_Tangem.framework */; };
+		B00307042AF0E1BA00C13BCA /* Analytics+WalletConnectDebugEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00307032AF0E1BA00C13BCA /* Analytics+WalletConnectDebugEvent.swift */; };
 		B00371BE2A8A5E5900D77A4B /* FakeUserTokensManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00371BD2A8A5E5900D77A4B /* FakeUserTokensManager.swift */; };
 		B00371C02A8A5ECE00D77A4B /* FakeTangemApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00371BF2A8A5ECE00D77A4B /* FakeTangemApiService.swift */; };
 		B00371C22A8A5F8800D77A4B /* FakeDerivationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00371C12A8A5F8800D77A4B /* FakeDerivationManager.swift */; };
@@ -306,6 +307,7 @@
 		B06CF2932993BF77000C7D93 /* TransactionsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06CF2922993BF77000C7D93 /* TransactionsListView.swift */; };
 		B074BAC126779B28005D641B /* PushTxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B074BAC026779B28005D641B /* PushTxView.swift */; };
 		B074BAC326779BC8005D641B /* PushTxViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B074BAC226779BC8005D641B /* PushTxViewModel.swift */; };
+		B079DB722AEB937D00D2D0D5 /* Analytics+DebugEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B079DB712AEB937D00D2D0D5 /* Analytics+DebugEvent.swift */; };
 		B07AE16C25DD548A0045179A /* CommonRateAppService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B07AE16B25DD548A0045179A /* CommonRateAppService.swift */; };
 		B07C6A0B2A77E5A600ACCBB0 /* walletV2.json in Resources */ = {isa = PBXBuildFile; fileRef = B0F319062A73951E009F131E /* walletV2.json */; };
 		B07C6A0C2A77E5AA00ACCBB0 /* twinCard.json in Resources */ = {isa = PBXBuildFile; fileRef = B0F319072A73954E009F131E /* twinCard.json */; };
@@ -1407,6 +1409,7 @@
 		9656CA6948E56B0F430ECDEC /* Pods-Tangem.debug(beta).xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tangem.debug(beta).xcconfig"; path = "Target Support Files/Pods-Tangem/Pods-Tangem.debug(beta).xcconfig"; sourceTree = "<group>"; };
 		A8A58343726C3E405BBB7A03 /* Pods-TangemTests.release(production).xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TangemTests.release(production).xcconfig"; path = "Target Support Files/Pods-TangemTests/Pods-TangemTests.release(production).xcconfig"; sourceTree = "<group>"; };
 		ADDBC9E43D315C358E078BC8 /* Pods_TangemSwapping.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TangemSwapping.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B00307032AF0E1BA00C13BCA /* Analytics+WalletConnectDebugEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Analytics+WalletConnectDebugEvent.swift"; sourceTree = "<group>"; };
 		B00371BD2A8A5E5900D77A4B /* FakeUserTokensManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeUserTokensManager.swift; sourceTree = "<group>"; };
 		B00371BF2A8A5ECE00D77A4B /* FakeTangemApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeTangemApiService.swift; sourceTree = "<group>"; };
 		B00371C12A8A5F8800D77A4B /* FakeDerivationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeDerivationManager.swift; sourceTree = "<group>"; };
@@ -1547,6 +1550,7 @@
 		B06CF2922993BF77000C7D93 /* TransactionsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionsListView.swift; sourceTree = "<group>"; };
 		B074BAC026779B28005D641B /* PushTxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushTxView.swift; sourceTree = "<group>"; };
 		B074BAC226779BC8005D641B /* PushTxViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushTxViewModel.swift; sourceTree = "<group>"; };
+		B079DB712AEB937D00D2D0D5 /* Analytics+DebugEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Analytics+DebugEvent.swift"; sourceTree = "<group>"; };
 		B07AE16B25DD548A0045179A /* CommonRateAppService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonRateAppService.swift; sourceTree = "<group>"; };
 		B082E922255A8EF000A0CEA9 /* StorageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageType.swift; sourceTree = "<group>"; };
 		B084643B2A78D207004F0C4F /* FakeWalletModelsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeWalletModelsManager.swift; sourceTree = "<group>"; };
@@ -3539,6 +3543,15 @@
 			path = PushTx;
 			sourceTree = "<group>";
 		};
+		B079DB702AEB937000D2D0D5 /* Debug */ = {
+			isa = PBXGroup;
+			children = (
+				B079DB712AEB937D00D2D0D5 /* Analytics+DebugEvent.swift */,
+				B00307032AF0E1BA00C13BCA /* Analytics+WalletConnectDebugEvent.swift */,
+			);
+			path = Debug;
+			sourceTree = "<group>";
+		};
 		B07DBC9C2625E08A00BAE18E /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
@@ -3905,6 +3918,7 @@
 		B0D1AC302906718600584E6C /* Analytics */ = {
 			isa = PBXGroup;
 			children = (
+				B079DB702AEB937000D2D0D5 /* Debug */,
 				5D225CB82524B721001564A3 /* Analytics.swift */,
 				2DA8AB112A433BDB00C75D85 /* Analytics+BlockchainExceptionHandler.swift */,
 				DCF2369029924C0900FE1855 /* AnalyticsContext.swift */,
@@ -6988,6 +7002,7 @@
 				B04CD34029122C6E001EA84A /* ReferralCoordinator.swift in Sources */,
 				EFFE2CE928B8E0B300B9F279 /* UserWalletModel.swift in Sources */,
 				DC66BBFD285A389000CDF765 /* SheetModifier.swift in Sources */,
+				B079DB722AEB937D00D2D0D5 /* Analytics+DebugEvent.swift in Sources */,
 				B074BAC126779B28005D641B /* PushTxView.swift in Sources */,
 				B085154D26D7797400E1A836 /* TwinsOnboardingView.swift in Sources */,
 				B008E13E2980264D006E0E31 /* WebSocketEvent.swift in Sources */,
@@ -7696,6 +7711,7 @@
 				DAE6F76D2800011400411F45 /* AppError.swift in Sources */,
 				B63457772A3A097C00E164C5 /* View+ReadGeometry.swift in Sources */,
 				B0F318F92A7393FA009F131E /* WalletStubs.swift in Sources */,
+				B00307042AF0E1BA00C13BCA /* Analytics+WalletConnectDebugEvent.swift in Sources */,
 				B0431B47291A905A00F84DEF /* RoundedBackgroundModifier.swift in Sources */,
 				B6E8BBFB2A2F209B0012E7D3 /* InfinityFrameModifier.swift in Sources */,
 				B06C08502A73FB4E00D982BC /* MainRoutable.swift in Sources */,


### PR DESCRIPTION
В крашах непонятно делал ли пользователь что-то на экране, получал ли какие-то сообщения через `WebSocket` или нет. Добавил логику логирования в крашлитикс. По идее этого должно быть достаточно, чтобы разобраться с крашами. Краши пока что не закрываю в Firebase, т.к. это не исправляет причины краша, а может только добавить информации о происходящем

<img width="1275" alt="Tangem - closure #2 in closure #1 in WalletConnectView body getter - Firebase console 2023-10-31 12-14-10" src="https://github.com/tangem/tangem-app-ios/assets/24321494/107ad1cc-1a75-4e72-b533-b96642304985">
