### PR TITLE
IOS-5000: Fix issues with missingDerivation state

### DIFF
--- a/Tangem/Modules/Main/MultiWalletMainContent/Views/TokenList/DefaultTokenItemInfoProvider.swift
+++ b/Tangem/Modules/Main/MultiWalletMainContent/Views/TokenList/DefaultTokenItemInfoProvider.swift
@@ -20,9 +20,13 @@ class DefaultTokenItemInfoProvider {
 extension DefaultTokenItemInfoProvider: TokenItemInfoProvider {
     var id: Int { walletModel.id }
 
+    var tokenItemState: TokenItemViewState {
+        TokenItemViewState(walletModelState: walletModel.state)
+    }
+
     var tokenItemStatePublisher: AnyPublisher<TokenItemViewState, Never> {
         walletModel.walletDidChangePublisher
-            .map { TokenItemViewState(walletModelState: $0) }
+            .map(TokenItemViewState.init)
             .eraseToAnyPublisher()
     }
 

--- a/Tangem/Modules/Main/MultiWalletMainContent/Views/TokenList/TokenWithoutDerivationInfoProvider.swift
+++ b/Tangem/Modules/Main/MultiWalletMainContent/Views/TokenList/TokenWithoutDerivationInfoProvider.swift
@@ -19,7 +19,8 @@ class TokenWithoutDerivationInfoProvider: TokenItemInfoProvider {
     let fiatBalance: String = BalanceFormatter.defaultEmptyBalanceString
     var quote: TokenQuote? { nil }
 
-    var tokenItemStatePublisher: AnyPublisher<TokenItemViewState, Never> { .just(output: .noDerivation) }
+    var tokenItemState: TokenItemViewState = .noDerivation
+    var tokenItemStatePublisher: AnyPublisher<TokenItemViewState, Never> { .just(output: tokenItemState) }
     var actionsUpdatePublisher: AnyPublisher<Void, Never> { .just(output: ()) }
 
     init(id: Int, tokenItem: TokenItem) {

--- a/Tangem/UIComponents/TokenItemView/TokenItemInfoProvider.swift
+++ b/Tangem/UIComponents/TokenItemView/TokenItemInfoProvider.swift
@@ -11,6 +11,7 @@ import BlockchainSdk
 
 protocol TokenItemInfoProvider: AnyObject {
     var id: Int { get }
+    var tokenItemState: TokenItemViewState { get }
     var tokenItemStatePublisher: AnyPublisher<TokenItemViewState, Never> { get }
     var tokenItem: TokenItem { get }
     var hasPendingTransactions: Bool { get }

--- a/Tangem/UIComponents/TokenItemView/TokenItemViewModel.swift
+++ b/Tangem/UIComponents/TokenItemView/TokenItemViewModel.swift
@@ -81,6 +81,7 @@ final class TokenItemViewModel: ObservableObject, Identifiable {
         self.contextActionsProvider = contextActionsProvider
         self.contextActionsDelegate = contextActionsDelegate
 
+        setupState(infoProvider.tokenItemState)
         bind()
     }
 
@@ -97,33 +98,7 @@ final class TokenItemViewModel: ObservableObject, Identifiable {
             .receive(on: DispatchQueue.main)
             // We need this debounce to prevent initial sequential state updates that can skip `loading` state
             .debounce(for: 0.1, scheduler: DispatchQueue.main)
-            .sink { [weak self] newState in
-                guard let self else { return }
-
-                switch newState {
-                case .noDerivation:
-                    missingDerivation = true
-                    networkUnreachable = false
-                    updateBalances()
-                    updatePriceChange()
-                case .networkError:
-                    missingDerivation = false
-                    networkUnreachable = true
-                case .notLoaded:
-                    missingDerivation = false
-                    networkUnreachable = false
-                case .loaded, .noAccount:
-                    missingDerivation = false
-                    networkUnreachable = false
-                    updateBalances()
-                    updatePriceChange()
-                case .loading:
-                    break
-                }
-
-                updatePendingTransactionsStateIfNeeded()
-                buildContextActions()
-            }
+            .sink(receiveValue: weakify(self, forFunction: TokenItemViewModel.setupState(_:)))
             .store(in: &bag)
 
         infoProvider.actionsUpdatePublisher
@@ -132,6 +107,32 @@ final class TokenItemViewModel: ObservableObject, Identifiable {
                 self?.buildContextActions()
             }
             .store(in: &bag)
+    }
+
+    private func setupState(_ state: TokenItemViewState) {
+        switch state {
+        case .noDerivation:
+            missingDerivation = true
+            networkUnreachable = false
+            updateBalances()
+            updatePriceChange()
+        case .networkError:
+            missingDerivation = false
+            networkUnreachable = true
+        case .notLoaded:
+            missingDerivation = false
+            networkUnreachable = false
+        case .loaded, .noAccount:
+            missingDerivation = false
+            networkUnreachable = false
+            updateBalances()
+            updatePriceChange()
+        case .loading:
+            break
+        }
+
+        updatePendingTransactionsStateIfNeeded()
+        buildContextActions()
     }
 
     private func updatePendingTransactionsStateIfNeeded() {


### PR DESCRIPTION
Тут всплыло сразу 2 проблемы с дебаунсом:
1. `Just` отправляет `output` и следом сразу `completion`, который в дебаунсе сбрасывает первое значение и до `TokenItemViewModel` не доходит оно
2. Если добавить `CurrentValueSubject` в `TokenWithoutDerivationInfoProvider`, тогда на главной при появлении экрана будет в начале виден изначальный стейт с загрузчиком

В итоге добавил изначальную настройку, чтобы нивелировать эффект `Just` паблишера и перескоки между состояниями

https://github.com/tangem/tangem-app-ios/assets/24321494/3d118a79-84b5-4784-a1e3-77410f885b89

