### PR TITLE
IOS-5014 Update MutipleAddressTransactionHistoryService

### DIFF
--- a/Tangem/App/Services/TransactionHistoryRepository/MutipleAddressTransactionHistoryService.swift
+++ b/Tangem/App/Services/TransactionHistoryRepository/MutipleAddressTransactionHistoryService.swift
@@ -161,7 +161,7 @@ private extension MutipleAddressTransactionHistoryService {
                     tokenTransfers: oldRecord.tokenTransfers
                 )
 
-                AppLog.shared.debug("TransactionRecord with hash: \(record.hash) in \(String(describing: self)) was zipped")
+                AppLog.shared.debug("TransactionRecord with hash: \(record.hash) was zipped")
             } else {
                 records.append(record)
             }


### PR DESCRIPTION
Убрал использование `self` в логировании, так в этот метод мы попадаем через `[weak self]`