### PR TITLE
IOS-5039: Attempt to fix AnyPublisher+ crash

### DIFF
--- a/Tangem/App/Services/NotificationManagers/SingleTokenNotificationManager.swift
+++ b/Tangem/App/Services/NotificationManagers/SingleTokenNotificationManager.swift
@@ -76,10 +76,15 @@ class SingleTokenNotificationManager {
             )
         }
 
+        notificationsUpdateTask?.cancel()
         notificationsUpdateTask = Task { [weak self] in
             var inputs = inputs
             if let rentInput = await self?.loadRentNotificationIfNeeded() {
                 inputs.append(rentInput)
+            }
+
+            if Task.isCancelled {
+                return
             }
 
             await runOnMain {

--- a/Tangem/App/ViewModels/WalletModel/WalletModel.swift
+++ b/Tangem/App/ViewModels/WalletModel/WalletModel.swift
@@ -564,7 +564,7 @@ extension WalletModel {
 
         return rentProvider.rentAmount()
             .zip(rentProvider.minimalBalanceForRentExemption())
-            .receive(on: RunLoop.main)
+            .receive(on: DispatchQueue.main)
             .map { [weak self] rentAmount, minimalBalanceForRentExemption in
                 guard
                     let self = self,

--- a/Tangem/Common/Extensions/Combine/AnyPublisher+.swift
+++ b/Tangem/Common/Extensions/Combine/AnyPublisher+.swift
@@ -35,13 +35,11 @@ extension AnyPublisher where Failure == Never {
     func async() async -> Output {
         await withCheckedContinuation { continuation in
             var cancellable: AnyCancellable?
-
             cancellable = first()
-                .sink { completion in
-                    cancellable?.cancel()
-                } receiveValue: { output in
+                .sink(receiveValue: { output in
                     continuation.resume(returning: output)
-                }
+                    withExtendedLifetime(cancellable) {}
+                })
         }
     }
 }


### PR DESCRIPTION
Не удается воспроизвести краш, тыркал по разному солану, не удалось. Нашел на форме разработчиков яблок, что это связано с конфликтами типов при обращении по селектору, но проблема в том что стэк краша указывает на `.store(in &bag)` и `sink { completion in`
Обновил `AnyPublisher+` с `sink(completion:,receiveValue:)` на `sink(receiveValue:)`, потому что нас все равно интересует всегда именно первое значение и `Error == Never`, т.е. обращаться к `completion.failure` мы все равно не будет. Это расширение используется при загрузке Quotes, при загрузке фи для `WaterCloset` и для загрузки информации об арендной плате. Прогнал по всем этим кейсам - исправно работает на 14.6 и 17.0.2