### PR TITLE
IOS-5088: Fix duplicate coin request

### DIFF
--- a/Tangem/App/Services/UserTokenListManager/CommonUserTokenListManager.swift
+++ b/Tangem/App/Services/UserTokenListManager/CommonUserTokenListManager.swift
@@ -135,9 +135,8 @@ extension CommonUserTokenListManager: UserTokenListManager {
 private extension CommonUserTokenListManager {
     func notifyAboutTokenListUpdates(with userTokenList: StoredUserTokenList? = nil) {
         let updatedUserTokenList = userTokenList ?? tokenItemsRepository.getList()
+        userTokensListSubject.send(updatedUserTokenList)
         DispatchQueue.main.async {
-            self.userTokensListSubject.send(updatedUserTokenList)
-
             if !self.initialized, self.tokenItemsRepository.containsFile {
                 self.initializedSubject.send(true)
             }


### PR DESCRIPTION
Было 2 проблемы:
1. в подписке не учитывалось что первый список берется из репозитория, а второй список прилетает во время синка. Поэтому дропаем первые 2 элемента, а во время синка полностью перезагружаем весь список токенов
2. отправка листа происходила через `DispatchQueue.main.async` из-за чего во время синка списка токенов запрашивался не правильный список, но это в предыдущем случае нивелировалось двойными запросами.

В целом мне кажется что нам надо снова пересмотреть синхронизацию списка токенов, кажется что сложно...

Проверил синк, добавление, удаление токенов, синк с другим устройством, все норм