### PR TITLE
IOS-4873: Remove shadows under buttons in header view

### DIFF
--- a/Tangem/Modules/OrganizeTokens/ListHeader/OrganizeTokensHeaderView.swift
+++ b/Tangem/Modules/OrganizeTokens/ListHeader/OrganizeTokensHeaderView.swift
@@ -11,12 +11,6 @@ import SwiftUI
 struct OrganizeTokensHeaderView: View {
     @ObservedObject var viewModel: OrganizeTokensHeaderViewModel
 
-    @Environment(\.colorScheme) private var colorScheme
-
-    private var buttonShadowOpacity: CGFloat {
-        return colorScheme == .light ? Constants.lightModeButtonShadowOpacity : Constants.darkModeButtonShadowOpacity
-    }
-
     var body: some View {
         HStack(spacing: 8.0) {
             Group {
@@ -26,14 +20,12 @@ struct OrganizeTokensHeaderView: View {
                     isToggled: viewModel.isSortByBalanceEnabled,
                     action: viewModel.toggleSortState
                 )
-                .shadow(color: Colors.Icon.inactive.opacity(sortByBalanceButtonShadowOpacity), radius: 4.0)
 
                 FlexySizeButtonWithLeadingIcon(
                     title: viewModel.groupingButtonTitle,
                     icon: Assets.OrganizeTokens.makeGroupIcon.image,
                     action: viewModel.toggleGroupState
                 )
-                .shadow(color: Colors.Icon.inactive.opacity(groupingButtonShadowOpacity), radius: 4.0)
             }
             .background(
                 Colors.Background
@@ -42,23 +34,6 @@ struct OrganizeTokensHeaderView: View {
             )
             .onAppear(perform: viewModel.onViewAppear)
         }
-    }
-
-    private var sortByBalanceButtonShadowOpacity: CGFloat {
-        return buttonShadowOpacity / (viewModel.isSortByBalanceEnabled ? 3.0 : 1.0)
-    }
-
-    private var groupingButtonShadowOpacity: CGFloat {
-        return buttonShadowOpacity
-    }
-}
-
-// MARK: - Constants
-
-private extension OrganizeTokensHeaderView {
-    enum Constants {
-        static let lightModeButtonShadowOpacity = 0.37
-        static let darkModeButtonShadowOpacity = 0.57
     }
 }
 


### PR DESCRIPTION
[IOS-4873](https://tangem.atlassian.net/browse/IOS-4873)

Как по мне - с тенями под кнопками лучше
Но дизайнеру виднее

<img src="https://github.com/tangem/tangem-app-ios/assets/21194149/0bccdf06-d2b6-4404-b76e-1d912fa3f6eb" width=350px>
<img src="https://github.com/tangem/tangem-app-ios/assets/21194149/f7cac079-2a11-4b03-ad5d-cb52e5b26c16" width=350px>


[IOS-4873]: https://tangem.atlassian.net/browse/IOS-4873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ