### PR TITLE
IOS-5161 Send Networks unreachable event after ptr

### DIFF
--- a/Tangem/App/Services/NotificationManagers/MultiWalletNotificationManager.swift
+++ b/Tangem/App/Services/NotificationManagers/MultiWalletNotificationManager.swift
@@ -55,20 +55,8 @@ final class MultiWalletNotificationManager {
     }
 
     private func setupSomeNetworksUnreachable() {
-        let containsNotification = notificationInputsSubject.value.contains {
-            guard let event = $0.settings.event as? TokenNotificationEvent else {
-                return false
-            }
-
-            return event == .someNetworksUnreachable
-        }
-
-        if containsNotification {
-            return
-        }
-
         let factory = NotificationsFactory()
-        notificationInputsSubject.value.append(factory.buildNotificationInput(for: .someNetworksUnreachable))
+        notificationInputsSubject.send([factory.buildNotificationInput(for: .someNetworksUnreachable)])
     }
 }
 

--- a/Tangem/App/Services/NotificationManagers/NotificationsAnalyticsService.swift
+++ b/Tangem/App/Services/NotificationManagers/NotificationsAnalyticsService.swift
@@ -24,7 +24,6 @@ class NotificationsAnalyticsService {
 
     private func bind() {
         subscription = notificationManager?.notificationPublisher
-            .removeDuplicates()
             .receive(on: DispatchQueue.global())
             .sink(receiveValue: weakify(self, forFunction: NotificationsAnalyticsService.sendEventsIfNeeded(for:)))
     }


### PR DESCRIPTION
Ивент не отправлялся после PTR, а только при запуске или если сеть стала доступна, а потом снова недоступна. Теперь будет отправляться после каждого PTR, визуально никаких скачков нет, т.к. id оповещения определяется по хэшу ивента, а он не меняется для оповещения