### PR TITLE
IOS-4894: Fix context menu previews clipping on iOS 17.0 and above

### DIFF
--- a/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentView.swift
+++ b/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentView.swift
@@ -41,19 +41,19 @@ struct MultiWalletMainContentView: View {
         .bindAlert($viewModel.error)
     }
 
+    @ViewBuilder
     private var tokensContent: some View {
-        Group {
-            if viewModel.isLoadingTokenList {
-                TokenListLoadingPlaceholderView()
-            } else {
-                if viewModel.sections.isEmpty {
-                    emptyList
-                } else {
-                    tokensList
-                }
-            }
+        if viewModel.isLoadingTokenList {
+            TokenListLoadingPlaceholderView()
+                .cornerRadiusContinuous(Constants.cornerRadius)
+        } else if viewModel.sections.isEmpty {
+            emptyList
+                .cornerRadiusContinuous(Constants.cornerRadius)
+        } else {
+            // Don't apply `.cornerRadiusContinuous` modifier to this view
+            // This will cause clipping of iOS context menu previews in `TokenItemView` on iOS 17.0 and above
+            tokensList
         }
-        .cornerRadiusContinuous(Constants.cornerRadius)
     }
 
     private var emptyList: some View {
@@ -83,7 +83,7 @@ struct MultiWalletMainContentView: View {
                 }
             }
         }
-        .background(Colors.Background.primary)
+        .background(Colors.Background.primary.cornerRadiusContinuous(Constants.cornerRadius))
     }
 }
 

--- a/Tangem/UIComponents/TokenItemView/TokenItemView.swift
+++ b/Tangem/UIComponents/TokenItemView/TokenItemView.swift
@@ -92,7 +92,7 @@ struct TokenItemView: View {
             .readGeometry(\.size, bindTo: $textBlockSize)
         }
         .padding(14)
-        .background(Colors.Background.primary)
+        .background(Colors.Background.primary.cornerRadiusContinuous(Constants.cornerRadius))
         .onTapGesture(perform: viewModel.tapAction)
         .highlightable(color: Colors.Button.primary.opacity(0.03))
         // `previewContentShape` must be called just before `contextMenu` call, otherwise visual glitches may occur


### PR DESCRIPTION
[IOS-4894](https://tangem.atlassian.net/browse/IOS-4894)

---

До

https://github.com/tangem/tangem-app-ios/assets/21194149/c7307115-294e-430e-9e8c-b20a3880ceae

---

После

https://github.com/tangem/tangem-app-ios/assets/21194149/162205c2-e60b-43ca-b99f-1b887f5e14ce

---

Забавно, что не воспроизводится в previews на iOS 17, но воспроизводится на симуляторе iOS 17

Проверил, не отвалилось ли чего на iOS 14, 15, 16 - визуально все ок и с лейаутом и с контекстными меню

[IOS-4894]: https://tangem.atlassian.net/browse/IOS-4894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ