### PR TITLE
IOS-4933: Load exchangeAvailable data from express

### DIFF
--- a/Tangem/App/Factories/SwappingModulesFactory/ExpressAPIProviderFactory.swift
+++ b/Tangem/App/Factories/SwappingModulesFactory/ExpressAPIProviderFactory.swift
@@ -1,0 +1,28 @@
+//
+//  ExpressAPIProviderFactory.swift
+//  Tangem
+//
+//  Created by Andrew Son on 24/11/23.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import TangemSwapping
+
+struct CommonExpressAPIFactory {
+    @Injected(\.keysManager) private var keysManager: KeysManager
+
+    func makeExpressAPIProvider() -> ExpressAPIProvider {
+        let factory = TangemSwappingFactory()
+        let credentials = ExpressAPICredential(
+            apiKey: keysManager.tangemExpressApiKey,
+            userId: UUID().uuidString,
+            sessionId: UUID().uuidString
+        )
+
+        return factory.makeExpressAPIProvider(
+            credential: credentials,
+            configuration: .defaultConfiguration,
+            logger: AppLog.shared
+        )
+    }
+}

--- a/Tangem/App/Factories/SwappingModulesFactory/ExpressItemsFactory.swift
+++ b/Tangem/App/Factories/SwappingModulesFactory/ExpressItemsFactory.swift
@@ -1,0 +1,32 @@
+//
+//  ExpressItemsFactory.swift
+//  Tangem
+//
+//  Created by Andrew Son on 24/11/23.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import BlockchainSdk
+import TangemSwapping
+
+struct ExpressItemsFactory {
+    func convertToTokenItem(_ asset: ExpressAsset, availableBlockchains: [String: Blockchain]) -> TokenItem? {
+        guard let blockchain = availableBlockchains[asset.currency.network] else {
+            return nil
+        }
+
+        if asset.currency.contractAddress == ExpressConstants.coinContractAddress {
+            return .blockchain(blockchain)
+        } else {
+            let token = Token(
+                name: asset.name,
+                symbol: asset.symbol,
+                contractAddress: asset.currency.contractAddress,
+                decimalCount: asset.decimals,
+                id: asset.token
+            )
+            return .token(token, blockchain)
+        }
+    }
+}

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -295,6 +295,8 @@
 		B06A828029C81E3A00B6160E /* SeedPhraseTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06A827F29C81E3A00B6160E /* SeedPhraseTextView.swift */; };
 		B06ADFD829B9CEEC00E92E5E /* OnboardingSeedPhraseGenerateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06ADFD729B9CEEC00E92E5E /* OnboardingSeedPhraseGenerateView.swift */; };
 		B06ADFDB29BAFA4600E92E5E /* SeedPhraseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06ADFDA29BAFA4600E92E5E /* SeedPhraseManager.swift */; };
+		B06B62E02B10D20C00042A39 /* ExpressAPIProviderFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06B62DF2B10D20C00042A39 /* ExpressAPIProviderFactory.swift */; };
+		B06B62E22B10D7B900042A39 /* ExpressItemsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06B62E12B10D7B900042A39 /* ExpressItemsFactory.swift */; };
 		B06C083B2A73E0D400D982BC /* MainHeaderSubtitleProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06C083A2A73E0D400D982BC /* MainHeaderSubtitleProvider.swift */; };
 		B06C083D2A73E0E900D982BC /* MainHeaderSubtitleInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06C083C2A73E0E900D982BC /* MainHeaderSubtitleInfo.swift */; };
 		B06C083F2A73E0F700D982BC /* MainHeaderSubtitleProviderFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06C083E2A73E0F700D982BC /* MainHeaderSubtitleProviderFactory.swift */; };
@@ -1648,6 +1650,8 @@
 		B06A827F29C81E3A00B6160E /* SeedPhraseTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedPhraseTextView.swift; sourceTree = "<group>"; };
 		B06ADFD729B9CEEC00E92E5E /* OnboardingSeedPhraseGenerateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSeedPhraseGenerateView.swift; sourceTree = "<group>"; };
 		B06ADFDA29BAFA4600E92E5E /* SeedPhraseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedPhraseManager.swift; sourceTree = "<group>"; };
+		B06B62DF2B10D20C00042A39 /* ExpressAPIProviderFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressAPIProviderFactory.swift; sourceTree = "<group>"; };
+		B06B62E12B10D7B900042A39 /* ExpressItemsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressItemsFactory.swift; sourceTree = "<group>"; };
 		B06C083A2A73E0D400D982BC /* MainHeaderSubtitleProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainHeaderSubtitleProvider.swift; sourceTree = "<group>"; };
 		B06C083C2A73E0E900D982BC /* MainHeaderSubtitleInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainHeaderSubtitleInfo.swift; sourceTree = "<group>"; };
 		B06C083E2A73E0F700D982BC /* MainHeaderSubtitleProviderFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainHeaderSubtitleProviderFactory.swift; sourceTree = "<group>"; };
@@ -6520,6 +6524,8 @@
 			children = (
 				EF8D7813298281F700B67418 /* SwappingModulesFactory.swift */,
 				EF9241312934C25400C28551 /* CommonSwappingModulesFactory.swift */,
+				B06B62DF2B10D20C00042A39 /* ExpressAPIProviderFactory.swift */,
+				B06B62E12B10D7B900042A39 /* ExpressItemsFactory.swift */,
 			);
 			path = SwappingModulesFactory;
 			sourceTree = "<group>";
@@ -7593,6 +7599,7 @@
 				B63B63BD2A44013E00A7CECF /* OrganizeTokensListFooter.swift in Sources */,
 				B008E13C29802612006E0E31 /* WebSocketConnectionDelegate.swift in Sources */,
 				EFAD02402A7D17BB00E9B959 /* CommonTransactionHistoryService.swift in Sources */,
+				B06B62E02B10D20C00042A39 /* ExpressAPIProviderFactory.swift in Sources */,
 				B68B356B2A4B0FAB0069129F /* UIAppearanceBoundaryContainerView.swift in Sources */,
 				2DDF91942A14DA2700B31113 /* TokenItemMenuActions.swift in Sources */,
 				DA4055272ABDD3A300353F8A /* AddCustomTokenNetworkSelectorDelegate.swift in Sources */,
@@ -8468,6 +8475,7 @@
 				DC3DCADB2A40AACF00F72554 /* DemoWalletModelsFactory.swift in Sources */,
 				DC51187C2860B728004FB954 /* AppCoordinatorView.swift in Sources */,
 				B0F62C5025DE4EC9005C8BA0 /* MailView.swift in Sources */,
+				B06B62E22B10D7B900042A39 /* ExpressItemsFactory.swift in Sources */,
 				B60B9FDB2A95D96B00A7E905 /* OrganizeTokensListSectionViewModel.swift in Sources */,
 				DAC37FBA2A2DFB730068F3ED /* PromotionView.swift in Sources */,
 				DA559C392B0261F400F59584 /* SendViewModel.swift in Sources */,


### PR DESCRIPTION
Загрузка доступности для обмена монет из `Express`. Пока что Лазуткин не утвердил что можно игнорировать для запроса `assets` `user-id`, но скорее всего так и останется рандомная строка просто для запроса доступности свопать монеты