### PR TITLE
IOS-5052: Display pending tx notif for coin

### DIFF
--- a/Tangem/App/ViewModels/WalletModel/WalletModel.swift
+++ b/Tangem/App/ViewModels/WalletModel/WalletModel.swift
@@ -180,15 +180,16 @@ class WalletModel {
             return .cantSignLongTransactions
         }
 
-        guard
-            let currentAmount = wallet.amounts[amountType],
-            let token = amountType.token
-        else {
+        guard let currentAmount = wallet.amounts[amountType] else {
             return nil
         }
 
-        if wallet.hasPendingTx, !wallet.hasPendingTx(for: amountType) { // has pending tx for fee
+        if wallet.hasPendingTx { // has pending tx for fee
             return .hasPendingCoinTx(symbol: blockchainNetwork.blockchain.currencySymbol)
+        }
+
+        guard let token = amountType.token else {
+            return nil
         }
 
         // no fee


### PR DESCRIPTION
Добавил оповещение для основной монеты в сети. Оповещение объясняет почему заблокирована кнопка `Send`

<img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/8045e147-357e-4a6b-a7c2-6cd1e8d59572">
