### PR TITLE
IOS-4964: Organize tokens - token list performance improvements

### DIFF
--- a/Tangem/Modules/OrganizeTokens/OrganizeTokensView.swift
+++ b/Tangem/Modules/OrganizeTokens/OrganizeTokensView.swift
@@ -144,8 +144,8 @@ struct OrganizeTokensView: View {
                         .divided(atDistance: scrollViewBottomContentInset, from: .maxYEdge)
                         .remainder
                 }
-                .onChange(of: draggedItemFrame) { draggedItemFrame in
-                    changeAutoScrollStatusIfNeeded(draggedItemFrame: draggedItemFrame)
+                .onChange(of: draggedItemFrame) { newValue in
+                    changeAutoScrollStatusIfNeeded(draggedItemFrame: newValue)
                 }
                 .onReceive(dragAndDropController.autoScrollTargetPublisher) { newValue in
                     withAnimation(.linear(duration: Constants.autoScrollFrequency)) {

--- a/Tangem/Modules/OrganizeTokens/OrganizeTokensView.swift
+++ b/Tangem/Modules/OrganizeTokens/OrganizeTokensView.swift
@@ -348,14 +348,14 @@ struct OrganizeTokensView: View {
         }
 
         let intersection = visibleViewportFrame.intersection(draggedItemFrame)
-        if intersection.isNull || intersection.height < min(visibleViewportFrame.height, draggedItemFrame.height) {
+        if intersection.height < min(visibleViewportFrame.height, draggedItemFrame.height) {
             if draggedItemFrame.minY + Constants.autoScrollTriggerHeightDiff < visibleViewportFrame.minY {
                 dragAndDropController.startAutoScrolling(direction: .top)
             } else if draggedItemFrame.maxY - Constants.autoScrollTriggerHeightDiff > visibleViewportFrame.maxY {
                 dragAndDropController.startAutoScrolling(direction: .bottom)
-            } else {
-                dragAndDropController.stopAutoScrolling()
             }
+        } else if !intersection.isNull {
+            dragAndDropController.stopAutoScrolling()
         }
     }
 

--- a/Tangem/Modules/OrganizeTokens/OrganizeTokensView.swift
+++ b/Tangem/Modules/OrganizeTokens/OrganizeTokensView.swift
@@ -160,7 +160,7 @@ struct OrganizeTokensView: View {
             )
         }
         .coordinateSpace(name: scrollViewFrameCoordinateSpaceName)
-        .onChange(of: scrollState.contentOffset) { newValue in
+        .onReceive(scrollState.contentOffsetSubject) { newValue in
             dragAndDropController.contentOffsetSubject.send(newValue)
             updateDragAndDropDestinationIndexPath(using: dragGestureTranslation)
         }
@@ -171,8 +171,11 @@ struct OrganizeTokensView: View {
             viewModel.move(from: oldValue, to: newValue)
         }
         .onChange(of: hasActiveDrag) { newValue in
-            if !newValue {
+            if newValue {
+                scrollState.onDragStart()
+            } else {
                 // Perform required clean-up when the user lifts the finger
+                scrollState.onDragEnd()
                 dragAndDropController.stopAutoScrolling()
                 dragAndDropDestinationIndexPath = nil
                 dragAndDropSourceItemFrame = nil

--- a/Tangem/Modules/OrganizeTokens/OrganizeTokensView.swift
+++ b/Tangem/Modules/OrganizeTokens/OrganizeTokensView.swift
@@ -198,34 +198,44 @@ struct OrganizeTokensView: View {
                     ForEach(indexed: sectionViewModel.items.indexed()) { itemIndex, itemViewModel in
                         let indexPath = IndexPath(item: itemIndex, section: sectionIndex)
                         let identifier = itemViewModel.id
+                        let isDragged = identifier.asAnyHashable == dragAndDropSourceViewModelIdentifier
 
                         makeCell(
                             viewModel: itemViewModel,
                             indexPath: indexPath,
                             parametersProvider: parametersProvider
                         )
-                        .hidden(identifier.asAnyHashable == dragAndDropSourceViewModelIdentifier)
+                        .hidden(isDragged)
                         .readGeometry(
                             \.frame,
                             inCoordinateSpace: .named(scrollViewContentCoordinateSpaceName)
-                        ) { dragAndDropController.saveFrame($0, forItemAt: indexPath) }
+                        ) { frame in
+                            if !isDragged {
+                                dragAndDropController.saveFrame(frame, forItemAt: indexPath)
+                            }
+                        }
                         .id(identifier)
                     }
                 },
                 header: {
                     let indexPath = IndexPath(item: viewModel.sectionHeaderItemIndex, section: sectionIndex)
                     let identifier = sectionViewModel.id
+                    let isDragged = identifier == dragAndDropSourceViewModelIdentifier
 
                     makeSection(
                         from: sectionViewModel,
                         atIndex: sectionIndex,
                         parametersProvider: parametersProvider
                     )
-                    .hidden(identifier == dragAndDropSourceViewModelIdentifier)
+                    .hidden(isDragged)
                     .readGeometry(
                         \.frame,
                         inCoordinateSpace: .named(scrollViewContentCoordinateSpaceName)
-                    ) { dragAndDropController.saveFrame($0, forItemAt: indexPath) }
+                    ) { frame in
+                        if !isDragged {
+                            dragAndDropController.saveFrame(frame, forItemAt: indexPath)
+                        }
+                    }
                     .id(identifier)
                     .padding(.top, sectionIndex == 0 ? 0.0 : Constants.headerBottomInset)
                 }


### PR DESCRIPTION
[IOS-4964](https://tangem.atlassian.net/browse/IOS-4964)

Причина лагов при скролле - в постоянной перерерисовке вьюхи при скролле из-за изменения content offset:

> 2023-12-01 11:45:40.196356+0300 Tangem Alpha[1996:502477] 10.18.0 - <AppMeasurement>[I-ACS025018] Event not logged. Call +[FIRApp configure]: [Portfolio / Organize Tokens] Organize Tokens Screen Opened
> 🪲 11:45:40:196: Analytics event: [Portfolio / Organize Tokens] Organize Tokens Screen Opened. Params: {"Batch":"AC03", "Currency":"Multicurrency", "Firmware":"4.52r", "Product Type":"Wallet"}
> 2023-12-01 11:45:40.196765+0300 Tangem Alpha[1996:502477] 10.18.0 - [FirebaseCore][I-COR000003] The default Firebase app has not yet been configured. Add `FirebaseApp.configure()` to your application initialization. This can be done in in the App Delegate's application(_:didFinishLaunchingWithOptions:)` (or the `@main` struct's initializer in SwiftUI). Read more: https://goo.gl/ctyzm8.
> OrganizeTokensView: _scrollState, _scrollViewBottomContentInset changed.
> OrganizeTokensView: _viewModel changed.
> OrganizeTokensView: _scrollState changed.
> Bound preference GeometryInfoReaderPreferenceKey tried to update multiple times per frame.
> Bound preference GeometryInfoReaderPreferenceKey tried to update multiple times per frame.
> Bound preference GeometryInfoReaderPreferenceKey tried to update multiple times per frame.
> Bound preference GeometryInfoReaderPreferenceKey tried to update multiple times per frame.
> `appsFlyerDevKey` missing or empty.
> `appsFlyerDevKey` missing or empty.
> `appsFlyerDevKey` missing or empty.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> Bound preference GeometryInfoReaderPreferenceKey tried to update multiple times per frame.
> Bound preference GeometryInfoReaderPreferenceKey tried to update multiple times per frame.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> Bound preference GeometryInfoReaderPreferenceKey tried to update multiple times per frame.
> Bound preference GeometryInfoReaderPreferenceKey tried to update multiple times per frame.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> Bound preference GeometryInfoReaderPreferenceKey tried to update multiple times per frame.
> Bound preference GeometryInfoReaderPreferenceKey tried to update multiple times per frame.
> OrganizeTokensView: _scrollState changed.
> Bound preference GeometryInfoReaderPreferenceKey tried to update multiple times per frame.
> Bound preference GeometryInfoReaderPreferenceKey tried to update multiple times per frame.
> OrganizeTokensView: _scrollState changed.
> Bound preference GeometryInfoReaderPreferenceKey tried to update multiple times per frame.
> Bound preference GeometryInfoReaderPreferenceKey tried to update multiple times per frame.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> Bound preference GeometryInfoReaderPreferenceKey tried to update multiple times per frame.
> Bound preference GeometryInfoReaderPreferenceKey tried to update multiple times per frame.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> Bound preference GeometryInfoReaderPreferenceKey tried to update multiple times per frame.
> Bound preference GeometryInfoReaderPreferenceKey tried to update multiple times per frame.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> Bound preference GeometryInfoReaderPreferenceKey tried to update multiple times per frame.
> Bound preference GeometryInfoReaderPreferenceKey tried to update multiple times per frame.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.
> OrganizeTokensView: _scrollState changed.

Перерисовывать вью при изменении content offset требуется только когда происходит автоскроллинг при drag-and-drop и не требуется при простом скролле экрана, исправил это.
Заодно поправил иногда стреляющую проблему с неотключаемым автоскроллом - https://github.com/tangem/tangem-app-ios/pull/2471#discussion_r1411767643

[IOS-4964]: https://tangem.atlassian.net/browse/IOS-4964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ