### PR TITLE
IOS-5279: Token details - performance improvements

### DIFF
--- a/Tangem/Common/Extensions/View+ReadContentOffset.swift
+++ b/Tangem/Common/Extensions/View+ReadContentOffset.swift
@@ -30,7 +30,7 @@ extension View {
     /// ```
     func readContentOffset(
         inCoordinateSpace coordinateSpace: CoordinateSpace,
-        throttleInterval: GeometryInfo.ThrottleInterval = .standard,
+        throttleInterval: GeometryInfo.ThrottleInterval = .zero,
         bindTo contentOffset: Binding<CGPoint>
     ) -> some View {
         modifier(

--- a/Tangem/Modules/OrganizeTokens/OrganizeTokensScrollState.swift
+++ b/Tangem/Modules/OrganizeTokens/OrganizeTokensScrollState.swift
@@ -65,7 +65,7 @@ final class OrganizeTokensScrollState: ObservableObject {
 
         contentOffsetSubject
             .map { contentOffset in
-                // `CGPoint` doesn't conform to `Comporable`, so we're applying `max(_:_:)` manually here
+                // `CGPoint` doesn't conform to `Comparable`, so we're applying `max(_:_:)` manually here
                 return CGPoint(
                     x: max(contentOffset.x, .zero),
                     y: max(contentOffset.y, .zero)

--- a/Tangem/Modules/OrganizeTokens/OrganizeTokensView.swift
+++ b/Tangem/Modules/OrganizeTokens/OrganizeTokensView.swift
@@ -126,7 +126,6 @@ struct OrganizeTokensView: View {
                         )
                         .readContentOffset(
                             inCoordinateSpace: .named(scrollViewFrameCoordinateSpaceName),
-                            throttleInterval: .zero,
                             bindTo: scrollState.contentOffsetSubject.asWriteOnlyBinding(.zero)
                         )
                         .overlay(makeDragAndDropGestureOverlayView())

--- a/Tangem/Modules/TokenDetails/TokenDetailsScrollState.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsScrollState.swift
@@ -39,7 +39,7 @@ final class TokenDetailsScrollState: ObservableObject {
 
         _contentOffsetSubject
             .map { contentOffset in
-                // `CGPoint` doesn't conform to `Comporable`, so we're applying `max(_:_:)` manually here
+                // `CGPoint` doesn't conform to `Comparable`, so we're applying `max(_:_:)` manually here
                 return CGPoint(
                     x: max(contentOffset.x, .zero),
                     y: max(contentOffset.y, .zero)

--- a/Tangem/Modules/TokenDetails/TokenDetailsScrollState.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsScrollState.swift
@@ -1,0 +1,68 @@
+//
+//  TokenDetailsScrollState.swift
+//  Tangem
+//
+//  Created by Andrey Fedorov on 30.11.2023.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import Combine
+import CombineExt
+
+final class TokenDetailsScrollState: ObservableObject {
+    @Published private(set) var toolbarIconOpacity: Double = .zero
+
+    var contentOffsetSubject: some Subject<CGPoint, Never> { _contentOffsetSubject }
+    private let _contentOffsetSubject = CurrentValueSubject<CGPoint, Never>(.zero)
+
+    private let tokenIconSizeSettings: IconViewSizeSettings
+    private let headerTopPadding: CGFloat
+
+    private var bag: Set<AnyCancellable> = []
+    private var didBind = false
+
+    init(
+        tokenIconSizeSettings: IconViewSizeSettings,
+        headerTopPadding: CGFloat
+    ) {
+        self.tokenIconSizeSettings = tokenIconSizeSettings
+        self.headerTopPadding = headerTopPadding
+    }
+
+    func onViewAppear() {
+        bind()
+    }
+
+    private func bind() {
+        if didBind { return }
+
+        _contentOffsetSubject
+            .map { contentOffset in
+                // `CGPoint` doesn't conform to `Comporable`, so we're applying `max(_:_:)` manually here
+                return CGPoint(
+                    x: max(contentOffset.x, .zero),
+                    y: max(contentOffset.y, .zero)
+                )
+            }
+            .withWeakCaptureOf(self)
+            .map { scrollState, contentOffset in
+                let iconHeight = scrollState.tokenIconSizeSettings.iconSize.height
+                let startAppearingOffset = scrollState.headerTopPadding + iconHeight
+
+                let fullAppearanceDistance = iconHeight / 2.0
+                let fullAppearanceOffset = startAppearingOffset + fullAppearanceDistance
+
+                return clamp(
+                    (contentOffset.y - startAppearingOffset) / (fullAppearanceOffset - startAppearingOffset),
+                    min: 0.0,
+                    max: 1.0
+                )
+            }
+            .removeDuplicates()
+            .assign(to: \.toolbarIconOpacity, on: self, ownership: .weak)
+            .store(in: &bag)
+
+        didBind = true
+    }
+}

--- a/Tangem/Modules/TokenDetails/TokenDetailsView.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsView.swift
@@ -11,25 +11,12 @@ import SwiftUI
 struct TokenDetailsView: View {
     @ObservedObject var viewModel: TokenDetailsViewModel
 
-    @State private var contentOffset: CGPoint = .zero
+    @StateObject private var scrollState = TokenDetailsScrollState(
+        tokenIconSizeSettings: Constants.tokenIconSizeSettings,
+        headerTopPadding: Constants.headerTopPadding
+    )
 
-    private let tokenIconSizeSettings: IconViewSizeSettings = .tokenDetails
-    private let headerTopPadding: CGFloat = 14
-    private let coorditateSpaceName = "token_details_scroll_space"
-
-    private var toolbarIconOpacity: Double {
-        let iconSize = tokenIconSizeSettings.iconSize
-        let startAppearingOffset = headerTopPadding + iconSize.height
-
-        let fullAppearanceDistance = iconSize.height / 2
-        let fullAppearanceOffset = startAppearingOffset + fullAppearanceDistance
-
-        return clamp(
-            (contentOffset.y - startAppearingOffset) / (fullAppearanceOffset - startAppearingOffset),
-            min: 0,
-            max: 1
-        )
-    }
+    private let coorditateSpaceName = UUID()
 
     var body: some View {
         RefreshableScrollView(onRefresh: viewModel.onPullToRefresh(completionHandler:)) {
@@ -67,10 +54,10 @@ struct TokenDetailsView: View {
                 )
                 .padding(.bottom, 40)
             }
-            .padding(.top, headerTopPadding)
+            .padding(.top, Constants.headerTopPadding)
             .readContentOffset(
                 inCoordinateSpace: .named(coorditateSpaceName),
-                bindTo: $contentOffset
+                bindTo: scrollState.contentOffsetSubject.asWriteOnlyBinding(.zero)
             )
         }
         .animation(.default, value: viewModel.tokenNotificationInputs)
@@ -79,6 +66,7 @@ struct TokenDetailsView: View {
         .background(Colors.Background.secondary.edgesIgnoringSafeArea(.all))
         .ignoresSafeArea(.keyboard)
         .onAppear(perform: viewModel.onAppear)
+        .onAppear(perform: scrollState.onViewAppear)
         .onDidAppear(viewModel.onDidAppear)
         .alert(item: $viewModel.alert) { $0.alert }
         .actionSheet(item: $viewModel.actionSheet) { $0.sheet }
@@ -95,7 +83,7 @@ struct TokenDetailsView: View {
                     ),
                     size: IconViewSizeSettings.tokenDetailsToolbar.iconSize
                 )
-                .opacity(toolbarIconOpacity)
+                .opacity(scrollState.toolbarIconOpacity)
             }
 
             ToolbarItem(placement: .navigationBarTrailing) { navbarTrailingButton }
@@ -116,5 +104,14 @@ struct TokenDetailsView: View {
                 NavbarDotsImage()
             }
         }
+    }
+}
+
+// MARK: - Constants
+
+private extension TokenDetailsView {
+    enum Constants {
+        static let tokenIconSizeSettings: IconViewSizeSettings = .tokenDetails
+        static let headerTopPadding: CGFloat = 14.0
     }
 }

--- a/Tangem/UIComponents/BottomScrollableSheet/BottomScrollableSheet.swift
+++ b/Tangem/UIComponents/BottomScrollableSheet/BottomScrollableSheet.swift
@@ -86,6 +86,7 @@ struct BottomScrollableSheet<Header: View, Content: View, Overlay: View>: View {
                     content()
                         .readContentOffset(
                             inCoordinateSpace: .named(coordinateSpaceName),
+                            throttleInterval: .standard,
                             bindTo: stateObject.contentOffsetSubject.asWriteOnlyBinding(.zero)
                         )
 

--- a/Tangem/UIComponents/CardsInfoPagerView/CardsInfoPagerView.swift
+++ b/Tangem/UIComponents/CardsInfoPagerView/CardsInfoPagerView.swift
@@ -315,7 +315,6 @@ struct CardsInfoPagerView<
             .readGeometry(\.size, bindTo: scrollState.contentSizeSubject.asWriteOnlyBinding(.zero))
             .readContentOffset(
                 inCoordinateSpace: .named(scrollViewFrameCoordinateSpaceName),
-                throttleInterval: .zero,
                 bindTo: scrollState.contentOffsetSubject.asWriteOnlyBinding(.zero)
             )
 

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -492,6 +492,7 @@
 		B61980102AB8BD5200153886 /* PreviewContentShapeModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B619800F2AB8BD5200153886 /* PreviewContentShapeModifier.swift */; };
 		B61980122AB98ACE00153886 /* HighlightableViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61980112AB98ACE00153886 /* HighlightableViewModifier.swift */; };
 		B61B14CD2A25DD33001AF997 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61B14CC2A25DD33001AF997 /* Lock.swift */; };
+		B61D2A202B1947E6004F2C2D /* TokenDetailsScrollState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61D2A1F2B1947E6004F2C2D /* TokenDetailsScrollState.swift */; };
 		B6210DEF2A94708700F885D5 /* OrganizeTokensListFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6210DEE2A94708700F885D5 /* OrganizeTokensListFactory.swift */; };
 		B62E42512A79328A0045AB31 /* Collection+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62E42502A79328A0045AB31 /* Collection+.swift */; };
 		B63127D42A2F52E2007C124C /* OrganizeTokensListSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63127D32A2F52E2007C124C /* OrganizeTokensListSection.swift */; };
@@ -1851,6 +1852,7 @@
 		B619800F2AB8BD5200153886 /* PreviewContentShapeModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewContentShapeModifier.swift; sourceTree = "<group>"; };
 		B61980112AB98ACE00153886 /* HighlightableViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightableViewModifier.swift; sourceTree = "<group>"; };
 		B61B14CC2A25DD33001AF997 /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
+		B61D2A1F2B1947E6004F2C2D /* TokenDetailsScrollState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenDetailsScrollState.swift; sourceTree = "<group>"; };
 		B6210DEE2A94708700F885D5 /* OrganizeTokensListFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizeTokensListFactory.swift; sourceTree = "<group>"; };
 		B62E42502A79328A0045AB31 /* Collection+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Collection+.swift"; sourceTree = "<group>"; };
 		B63127D32A2F52E2007C124C /* OrganizeTokensListSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizeTokensListSection.swift; sourceTree = "<group>"; };
@@ -4323,6 +4325,7 @@
 				B0DD16232A331C2100CB23AA /* TokenDetailsCoordinator.swift */,
 				B0DD16242A331C2100CB23AA /* TokenDetailsCoordinatorView.swift */,
 				B0DD16252A331C2100CB23AA /* TokenDetailsView.swift */,
+				B61D2A1F2B1947E6004F2C2D /* TokenDetailsScrollState.swift */,
 				B0DD16262A331C2100CB23AA /* TokenDetailsViewModel.swift */,
 				B0DD16272A331C2100CB23AA /* TokenDetailsRoutable.swift */,
 			);
@@ -8421,6 +8424,7 @@
 				EF57693E2A8BAF6700901571 /* TransactionHistoryService.swift in Sources */,
 				B0CAE5AB2AAB275C00670C2B /* MultiWalletMainContentDelegate.swift in Sources */,
 				B0F319022A7394AA009F131E /* FakeUserWalletRepository.swift in Sources */,
+				B61D2A202B1947E6004F2C2D /* TokenDetailsScrollState.swift in Sources */,
 				B691A8C02AFE43CE0059D182 /* CardsInfoPagerSwipeDiscoveryAnimationModifier.swift in Sources */,
 				659768172837B61000F9F04A /* LegacyTokenItemView.swift in Sources */,
 				B6AEF9742A796713004663C3 /* TokenSectionsAdapter.swift in Sources */,


### PR DESCRIPTION
[IOS-5279](https://tangem.atlassian.net/browse/IOS-5279)

Причина лагов при скролле - в постоянной перерерисовке вьюхи при скролле из-за изменения content offset:

> 🪲 11:42:52:237: Analytics event: [Details Screen] Details Screen Opened. Params: {"Batch":"AC03", "Currency":"Multicurrency", "Firmware":"4.52r", "Product Type":"Wallet", "Token":"ETH"}
> 2023-12-01 11:42:52.237232+0300 Tangem Alpha[1996:502198] 10.18.0 - [FirebaseCore][I-COR000003] The default Firebase app has not yet been configured. Add `FirebaseApp.configure()` to your application initialization. This can be done in in the App Delegate's application(_:didFinishLaunchingWithOptions:)` (or the `@main` struct's initializer in SwiftUI). Read more: https://goo.gl/ctyzm8.
> 2023-12-01 11:42:52.237468+0300 Tangem Alpha[1996:502198] 10.18.0 - <AppMeasurement>[I-ACS025018] Event not logged. Call +[FIRApp configure]: [Details Screen] Details Screen Opened
> TokenDetailsView: _contentOffset changed.
> `appsFlyerDevKey` missing or empty.
> `appsFlyerDevKey` missing or empty.
> TokenDetailsView: _viewModel changed.
> 🪲 11:42:53:697: Optional(<CommonTransactionHistoryService: 0x000000011fdac7e0; name = Ethereum; type = Coin; address = 0xa8d06dcb315a01ac9aa40d833d9b1e98487efbbb; totalPages = 5; currentPage = 1>) loaded
> 🪲 11:42:53:697: New transaction history state: TransactionHistoryState.loaded with items: 20
> TokenDetailsView: _viewModel changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> TokenDetailsView: _contentOffset changed.
> 🪲 11:42:56:181: <CommonTransactionHistoryService: 0x000000011fdac7e0; name = Ethereum; type = Coin; address = 0xa8d06dcb315a01ac9aa40d833d9b1e98487efbbb; totalPages = 5; currentPage = 1> start loading
> 🪲 11:42:56:187: New transaction history state: TransactionHistoryState.loading
> TokenDetailsView: _contentOffset changed.
> 🪲 11:42:56:205: <CommonTransactionHistoryService: 0x000000011fdac7e0; name = Ethereum; type = Coin; address = 0xa8d06dcb315a01ac9aa40d833d9b1e98487efbbb; totalPages = 5; currentPage = 1> start loading
> 🪲 11:42:56:207: New transaction history state: TransactionHistoryState.loading
> TokenDetailsView: _contentOffset changed.

Вынес логику, связанную с content offset, в отдельную сущность (по аналогии с другими местами с аналогичными проблемами), которая триггерит перерисовку вью только когда надо (несколько раз за скролл, когда есть изменения opacity иконки токена)



[IOS-5279]: https://tangem.atlassian.net/browse/IOS-5279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ