### PR TITLE
IOS-5257: Fix missed ru localization in tx history

### DIFF
--- a/Tangem/Resources/Localizations/ru.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/ru.lproj/Localizable.strings
@@ -76,7 +76,7 @@
 "common_enabled" = "Включено";
 "common_error" = "Ошибка";
 "common_exchange" = "Обменять";
-"common_explore" = "Explore";
+"common_explore" = "Обозреватель";
 "common_explore_history" = "Посмотреть историю";
 "common_explore_transaction_history" = "Посмотреть историю транзакций";
 "common_explorer" = "Обозреватель";


### PR DESCRIPTION
[IOS-5257](https://tangem.atlassian.net/browse/IOS-5257)


[IOS-5257]: https://tangem.atlassian.net/browse/IOS-5257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ