### PR TITLE
iOS-5295: Main screen token list corner radius

### DIFF
--- a/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentView.swift
+++ b/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentView.swift
@@ -41,19 +41,19 @@ struct MultiWalletMainContentView: View {
         .bindAlert($viewModel.error)
     }
 
-    @ViewBuilder
     private var tokensContent: some View {
-        if viewModel.isLoadingTokenList {
-            TokenListLoadingPlaceholderView()
-                .cornerRadiusContinuous(Constants.cornerRadius)
-        } else if viewModel.sections.isEmpty {
-            emptyList
-                .cornerRadiusContinuous(Constants.cornerRadius)
-        } else {
-            // Don't apply `.cornerRadiusContinuous` modifier to this view
-            // This will cause clipping of iOS context menu previews in `TokenItemView` on iOS 17.0 and above
-            tokensList
+        Group {
+            if viewModel.isLoadingTokenList {
+                TokenListLoadingPlaceholderView()
+            } else {
+                if viewModel.sections.isEmpty {
+                    emptyList
+                } else {
+                    tokensList
+                }
+            }
         }
+        .cornerRadiusContinuous(Constants.cornerRadius)
     }
 
     private var emptyList: some View {
@@ -83,7 +83,7 @@ struct MultiWalletMainContentView: View {
                 }
             }
         }
-        .background(Colors.Background.primary.cornerRadiusContinuous(Constants.cornerRadius))
+        .background(Colors.Background.primary)
     }
 }
 

--- a/Tangem/UIComponents/TokenItemView/TokenItemView.swift
+++ b/Tangem/UIComponents/TokenItemView/TokenItemView.swift
@@ -92,7 +92,7 @@ struct TokenItemView: View {
             .readGeometry(\.size, bindTo: $textBlockSize)
         }
         .padding(14)
-        .background(Colors.Background.primary.cornerRadiusContinuous(Constants.cornerRadius))
+        .background(Colors.Background.primary)
         .onTapGesture(perform: viewModel.tapAction)
         .highlightable(color: Colors.Button.primary.opacity(0.03))
         // `previewContentShape` must be called just before `contextMenu` call, otherwise visual glitches may occur


### PR DESCRIPTION
[IOS-5295](https://tangem.atlassian.net/browse/IOS-5295)

Реверт фикса из [IOS-4894](https://tangem.atlassian.net/browse/IOS-4894)

Он вызывает 
<img width="300" src="https://github.com/tangem/tangem-app-ios/assets/21194149/3f03836b-4919-49be-b2fc-cc825283bb45">
и
<img width="300" src="https://github.com/tangem/tangem-app-ios/assets/21194149/514a2c53-096c-486c-8d4e-2fb4a9cc3afc">

Надо придумывать какой-то другой способ фикса iOS 17 (задание corner radius только на определенных углах ударяет по производительности)

[IOS-5295]: https://tangem.atlassian.net/browse/IOS-5295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IOS-4894]: https://tangem.atlassian.net/browse/IOS-4894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ