### PR TITLE
IOS-5236: ChangeNow anal and stuff

### DIFF
--- a/Tangem/App/Services/Analytics/Analytics+Event.swift
+++ b/Tangem/App/Services/Analytics/Analytics+Event.swift
@@ -182,6 +182,12 @@ extension Analytics {
 
         case onboardingSeedScreenCapture = "[Onboarding / Seed Phrase] Screen Capture"
 
+        // MARK: Express
+
+        case tokenChangeNowStatus = "[Token] - ChangeNow Status"
+        case tokenChangeNowStatusScreenOpened = "[Token] - ChangeNow Status Opened"
+        case tokenChangeNowButtonGoToProvider = "[Token] - Button - Go To Provider"
+
         // MARK: - App settings
 
         case appSettingsAppThemeSwitched = "[Settings / App Settings] App Theme Swithed"

--- a/Tangem/App/Services/Analytics/Analytics+ParameterKey.swift
+++ b/Tangem/App/Services/Analytics/Analytics+ParameterKey.swift
@@ -65,5 +65,6 @@ extension Analytics {
         case methodName = "Method Name"
         case groupType = "Group"
         case sortType = "Sort"
+        case place = "Place"
     }
 }

--- a/Tangem/App/Services/Analytics/Analytics+ParameterValue.swift
+++ b/Tangem/App/Services/Analytics/Analytics+ParameterValue.swift
@@ -84,6 +84,16 @@ extension Analytics {
 
         case balance = "Balance"
 
+        // MARK: - Express
+
+        case status = "Status"
+
+        // CEX statuses
+        case inProgress = "In Progress"
+        case done = "Done"
+        case kyc = "KYC"
+        case refunded = "Refunded"
+
         // App theme
         case system = "System"
         case light = "Light"

--- a/Tangem/App/Services/Express/AnalyticsTracker/CommonPendingExpressTransactionAnalyticsTracker.swift
+++ b/Tangem/App/Services/Express/AnalyticsTracker/CommonPendingExpressTransactionAnalyticsTracker.swift
@@ -1,0 +1,50 @@
+//
+//  CommonPendingExpressTransactionAnalyticsTracker.swift
+//  Tangem
+//
+//  Created by Andrew Son on 06/12/23.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+class CommonPendingExpressTransactionAnalyticsTracker: PendingExpressTransactionAnalyticsTracker {
+    typealias PendingTransactionId = String
+
+    private let mapper = PendingExpressTransactionAnalyticsStatusMapper()
+    private var trackedStatuses = [PendingTransactionId: Set<Analytics.ParameterValue>]()
+
+    func trackStatusForTransaction(with transactionId: PendingTransactionId, tokenSymbol: String, status: PendingExpressTransactionStatus) {
+        let statusToTrack = mapper.mapToAnalyticsStatus(pendingTxStatus: status)
+        var trackedStatusesSet = trackedStatuses[transactionId] ?? []
+        if trackedStatusesSet.contains(statusToTrack) {
+            return
+        }
+
+        Analytics.log(event: .tokenChangeNowStatus, params: [
+            .token: tokenSymbol,
+            .status: statusToTrack.rawValue,
+        ])
+        trackedStatusesSet.insert(statusToTrack)
+        trackedStatuses[transactionId] = trackedStatusesSet
+    }
+}
+
+extension CommonPendingExpressTransactionAnalyticsTracker {
+    struct PendingExpressTransactionAnalyticsStatusMapper {
+        func mapToAnalyticsStatus(pendingTxStatus: PendingExpressTransactionStatus) -> Analytics.ParameterValue {
+            switch pendingTxStatus {
+            case .awaitingDeposit, .confirming, .exchanging, .sendingToUser:
+                return .inProgress
+            case .done:
+                return .done
+            case .failed:
+                return .fail
+            case .refunded:
+                return .refunded
+            case .verificationRequired:
+                return .kyc
+            }
+        }
+    }
+}

--- a/Tangem/App/Services/Express/AnalyticsTracker/PendingExpressTransactionAnalyticsTracker.swift
+++ b/Tangem/App/Services/Express/AnalyticsTracker/PendingExpressTransactionAnalyticsTracker.swift
@@ -1,0 +1,28 @@
+//
+//  PendingExpressTransactionAnalyticsTracker.swift
+//  Tangem
+//
+//  Created by Andrew Son on 06/12/23.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+protocol PendingExpressTransactionAnalyticsTracker {
+    func trackStatusForTransaction(
+        with transactionId: String,
+        tokenSymbol: String,
+        status: PendingExpressTransactionStatus
+    )
+}
+
+private struct PendingExpressTransactionAnalyticsTrackerKey: InjectionKey {
+    static var currentValue: PendingExpressTransactionAnalyticsTracker = CommonPendingExpressTransactionAnalyticsTracker()
+}
+
+extension InjectedValues {
+    var pendingExpressTransactionAnalayticsTracker: PendingExpressTransactionAnalyticsTracker {
+        get { Self[PendingExpressTransactionAnalyticsTrackerKey.self] }
+        set { Self[PendingExpressTransactionAnalyticsTrackerKey.self] = newValue }
+    }
+}

--- a/Tangem/App/Services/Express/PendingExpressTransactionsManager.swift
+++ b/Tangem/App/Services/Express/PendingExpressTransactionsManager.swift
@@ -10,13 +10,14 @@ import Foundation
 import Combine
 import TangemSwapping
 
-protocol PendingExpressTransactionsManager {
+protocol PendingExpressTransactionsManager: AnyObject {
     var pendingTransactions: [PendingExpressTransaction] { get }
     var pendingTransactionsPublisher: AnyPublisher<[PendingExpressTransaction], Never> { get }
 }
 
 class CommonPendingExpressTransactionsManager {
     @Injected(\.expressPendingTransactionsRepository) private var expressPendingTransactionsRepository: ExpressPendingTransactionRepository
+    @Injected(\.pendingExpressTransactionAnalayticsTracker) private var pendingExpressTransactionAnalyticsTracker: PendingExpressTransactionAnalyticsTracker
 
     private let userWalletId: String
     private let blockchainNetwork: BlockchainNetwork
@@ -41,6 +42,11 @@ class CommonPendingExpressTransactionsManager {
         expressAPIProvider = CommonExpressAPIFactory().makeExpressAPIProvider(userId: userWalletId)
 
         bind()
+    }
+
+    deinit {
+        print("CommonPendingExpressTransactionsManager deinit")
+        cancelTask()
     }
 
     private func bind() {
@@ -71,15 +77,15 @@ class CommonPendingExpressTransactionsManager {
     private func updateTransactionsStatuses(_ records: [ExpressPendingTransactionRecord]) {
         cancelTask()
 
-        updateTask = runTask(in: self) { manager in
+        updateTask = Task { [weak self] in
             do {
                 var recordsToRequest = [ExpressPendingTransactionRecord]()
                 var transactionsInProgress = [PendingExpressTransaction]()
                 for record in records {
-                    guard let pendingTransaction = await manager.loadPendingTransactionStatus(for: record) else {
+                    guard let pendingTransaction = await self?.loadPendingTransactionStatus(for: record) else {
                         // If received error from backend and transaction was already displayed on TokenDetails screen
                         // we need to send previously received transaction, otherwise it will hide on TokenDetails
-                        if let previousResult = manager.transactionsInProgressSubject.value.first(where: { $0.transactionRecord.expressTransactionId == record.expressTransactionId }) {
+                        if let previousResult = self?.transactionsInProgressSubject.value.first(where: { $0.transactionRecord.expressTransactionId == record.expressTransactionId }) {
                             transactionsInProgress.append(previousResult)
                         }
                         recordsToRequest.append(record)
@@ -89,7 +95,7 @@ class CommonPendingExpressTransactionsManager {
                     // We need to send finished transaction one more time to properly update status on bottom sheet
                     transactionsInProgress.append(pendingTransaction)
                     guard pendingTransaction.currentStatus.isTransactionInProgress else {
-                        manager.removeTransactionFromRepository(record)
+                        self?.removeTransactionFromRepository(record)
                         continue
                     }
 
@@ -97,7 +103,7 @@ class CommonPendingExpressTransactionsManager {
                     try Task.checkCancellation()
                 }
 
-                manager.transactionsInProgressSubject.send(transactionsInProgress)
+                self?.transactionsInProgressSubject.send(transactionsInProgress)
 
                 try Task.checkCancellation()
 
@@ -105,14 +111,14 @@ class CommonPendingExpressTransactionsManager {
 
                 try Task.checkCancellation()
 
-                manager.updateTransactionsStatuses(recordsToRequest)
+                self?.updateTransactionsStatuses(recordsToRequest)
             } catch {
-                if error is CancellationError || error.isCancelled {
-                    manager.log("Pending express txs status check task was cancelled")
+                if error is CancellationError || Task.isCancelled {
+                    self?.log("Pending express txs status check task was cancelled")
                     return
                 }
 
-                manager.updateTransactionsStatuses(records)
+                self?.updateTransactionsStatuses(records)
             }
         }
     }
@@ -136,6 +142,11 @@ class CommonPendingExpressTransactionsManager {
         do {
             let expressTransaction = try await expressAPIProvider.exchangeStatus(transactionId: transactionRecord.expressTransactionId)
             let pendingTransaction = pendingTransactionFactory.buildPendingExpressTransaction(currentExpressStatus: expressTransaction.externalStatus, for: transactionRecord)
+            pendingExpressTransactionAnalyticsTracker.trackStatusForTransaction(
+                with: transactionRecord.expressTransactionId,
+                tokenSymbol: tokenItem.currencySymbol,
+                status: pendingTransaction.currentStatus
+            )
             return pendingTransaction
         } catch {
             log("Failed to load status info for transaction with id: \(transactionRecord.expressTransactionId). Error: \(error)")

--- a/Tangem/Modules/TokenDetails/ExpressBottomSheet/PendingExpressTransactionStatusRow.swift
+++ b/Tangem/Modules/TokenDetails/ExpressBottomSheet/PendingExpressTransactionStatusRow.swift
@@ -15,10 +15,8 @@ struct PendingExpressTransactionStatusRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             if !isFirstRow {
-                HStack {
-                    Assets.verticalLine.image
-                        .foregroundColor(Colors.Field.focused)
-                }
+                Assets.verticalLine.image
+                    .foregroundColor(Colors.Field.focused)
             }
 
             HStack(spacing: 12) {

--- a/Tangem/Modules/TokenDetails/ExpressBottomSheet/PendingExpressTxStatusBottomSheetView.swift
+++ b/Tangem/Modules/TokenDetails/ExpressBottomSheet/PendingExpressTxStatusBottomSheetView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct PendingExpressTxStatusBottomSheetView: View {
     @ObservedObject var viewModel: PendingExpressTxStatusBottomSheetViewModel
 
-    private let tokenIconSize = CGSize(bothDimensions: 36)
+    private let iconSize = CGSize(bothDimensions: 36)
 
     // This animation is created explicitly to synchronise them with the delayed appearance of the notification
     private var animation: Animation {
@@ -46,6 +46,7 @@ struct PendingExpressTxStatusBottomSheetView: View {
             .padding(.vertical, 22)
             .padding(.horizontal, 16)
         }
+        .onAppear(perform: viewModel.onAppear)
         // This animations are set explicitly to synchronise them with the delayed appearance of the notification
         .animation(animation, value: viewModel.statusesList)
         .animation(animation, value: viewModel.currentStatusIndex)
@@ -101,7 +102,7 @@ struct PendingExpressTxStatusBottomSheetView: View {
             HStack(spacing: 12) {
                 IconView(
                     url: viewModel.providerIconURL,
-                    size: .init(bothDimensions: 36)
+                    size: iconSize
                 )
 
                 VStack(alignment: .leading, spacing: 4) {
@@ -113,10 +114,8 @@ struct PendingExpressTxStatusBottomSheetView: View {
                             .style(Fonts.Regular.footnote, color: Colors.Text.tertiary)
                     }
 
-                    HStack {
-                        Text(Localization.expressFloatingRate)
-                            .style(Fonts.Regular.subheadline, color: Colors.Text.tertiary)
-                    }
+                    Text(Localization.expressFloatingRate)
+                        .style(Fonts.Regular.subheadline, color: Colors.Text.tertiary)
                 }
                 Spacer()
             }
@@ -136,7 +135,7 @@ struct PendingExpressTxStatusBottomSheetView: View {
 
                 Spacer()
 
-                Button(action: viewModel.openProvider, label: {
+                Button(action: viewModel.openProviderFromStatusHeader, label: {
                     HStack(spacing: 4) {
                         Assets.arrowRightUpMini.image
                             .resizable()
@@ -152,9 +151,7 @@ struct PendingExpressTxStatusBottomSheetView: View {
             }
 
             VStack(spacing: 0) {
-                // We always display 4 states
-                ForEach(0 ..< 4) { index in
-                    let status = viewModel.statusesList[index]
+                ForEach(viewModel.statusesList.indexed(), id: \.1) { index, status in
                     PendingExpressTransactionStatusRow(isFirstRow: index == 0, info: status)
                 }
             }
@@ -166,7 +163,7 @@ struct PendingExpressTxStatusBottomSheetView: View {
 
     private func tokenInfo(with tokenIconInfo: TokenIconInfo, cryptoAmountText: String, fiatAmountTextState: LoadableTextView.State) -> some View {
         HStack(spacing: 12) {
-            TokenIcon(tokenIconInfo: tokenIconInfo, size: tokenIconSize)
+            TokenIcon(tokenIconInfo: tokenIconInfo, size: iconSize)
 
             VStack(alignment: .leading, spacing: 2) {
                 SensitiveText(cryptoAmountText)
@@ -217,6 +214,7 @@ struct ExpressPendingTxStatusBottomSheetView_Preview: PreviewProvider {
         let pendingTransaction = factory.buildPendingExpressTransaction(currentExpressStatus: .sending, for: record)
         return .init(
             pendingTransaction: pendingTransaction,
+            currentTokenItem: tokenItem,
             pendingTransactionsManager: CommonPendingExpressTransactionsManager(
                 userWalletId: userWalletId,
                 blockchainNetwork: blockchainNetwork,

--- a/Tangem/Modules/TokenDetails/TokenDetailsCoordinator.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsCoordinator.swift
@@ -88,10 +88,12 @@ extension TokenDetailsCoordinator {
 extension TokenDetailsCoordinator: TokenDetailsRoutable {
     func openPendingExpressTransactionDetails(
         for pendingTransaction: PendingExpressTransaction,
+        tokenItem: TokenItem,
         pendingTransactionsManager: PendingExpressTransactionsManager
     ) {
         pendingExpressTxStatusBottomSheetViewModel = .init(
             pendingTransaction: pendingTransaction,
+            currentTokenItem: tokenItem,
             pendingTransactionsManager: pendingTransactionsManager
         )
     }

--- a/Tangem/Modules/TokenDetails/TokenDetailsRoutable.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsRoutable.swift
@@ -14,6 +14,7 @@ protocol TokenDetailsRoutable: AnyObject {
     func openNetworkCurrency(for model: WalletModel, userWalletModel: UserWalletModel)
     func openPendingExpressTransactionDetails(
         for pendingTransaction: PendingExpressTransaction,
+        tokenItem: TokenItem,
         pendingTransactionsManager: PendingExpressTransactionsManager
     )
 }

--- a/Tangem/Modules/TokenDetails/TokenDetailsViewModel.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsViewModel.swift
@@ -209,6 +209,7 @@ private extension TokenDetailsViewModel {
 
         coordinator.openPendingExpressTransactionDetails(
             for: pendingTransaction,
+            tokenItem: tokenItem,
             pendingTransactionsManager: pendingExpressTransactionsManager
         )
     }

--- a/Tangem/UIComponents/BottomSheet/BottomSheetModifier.swift
+++ b/Tangem/UIComponents/BottomSheet/BottomSheetModifier.swift
@@ -88,6 +88,7 @@ struct BottomSheetModifier<Item: Identifiable, ContentView: View>: ViewModifier 
             // We should deinit controller to avoid unnecessary call update(item:) method
             controller = nil
             item = nil
+            stateObject.viewDidHidden = {}
         }
     }
 }

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -196,6 +196,8 @@
 		B008E13C29802612006E0E31 /* WebSocketConnectionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B008E13B29802612006E0E31 /* WebSocketConnectionDelegate.swift */; };
 		B008E13E2980264D006E0E31 /* WebSocketEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B008E13D2980264D006E0E31 /* WebSocketEvent.swift */; };
 		B00D7150258A1B6C00A9442C /* JsonUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00D714F258A1B6C00A9442C /* JsonUtils.swift */; };
+		B00EBF832B20EDE800071EB0 /* PendingExpressTransactionAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00EBF822B20EDE800071EB0 /* PendingExpressTransactionAnalyticsTracker.swift */; };
+		B00EBF862B20EE1D00071EB0 /* CommonPendingExpressTransactionAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00EBF852B20EE1D00071EB0 /* CommonPendingExpressTransactionAnalyticsTracker.swift */; };
 		B00FC6A92949A6460007ACCA /* CardImageResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00FC6A82949A6460007ACCA /* CardImageResult.swift */; };
 		B0120A932A0E0F4400F485F1 /* FakeCardHeaderPreviewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0120A922A0E0F4400F485F1 /* FakeCardHeaderPreviewProvider.swift */; };
 		B0120A962A0E0FB900F485F1 /* Text+NSAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0120A952A0E0FB900F485F1 /* Text+NSAttributedString.swift */; };
@@ -1552,6 +1554,8 @@
 		B008E13B29802612006E0E31 /* WebSocketConnectionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketConnectionDelegate.swift; sourceTree = "<group>"; };
 		B008E13D2980264D006E0E31 /* WebSocketEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketEvent.swift; sourceTree = "<group>"; };
 		B00D714F258A1B6C00A9442C /* JsonUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonUtils.swift; sourceTree = "<group>"; };
+		B00EBF822B20EDE800071EB0 /* PendingExpressTransactionAnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingExpressTransactionAnalyticsTracker.swift; sourceTree = "<group>"; };
+		B00EBF852B20EE1D00071EB0 /* CommonPendingExpressTransactionAnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonPendingExpressTransactionAnalyticsTracker.swift; sourceTree = "<group>"; };
 		B00FC6A82949A6460007ACCA /* CardImageResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardImageResult.swift; sourceTree = "<group>"; };
 		B01178482AC1B86200C5AD07 /* FakeTokenQuotesRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeTokenQuotesRepository.swift; sourceTree = "<group>"; };
 		B0120A922A0E0F4400F485F1 /* FakeCardHeaderPreviewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeCardHeaderPreviewProvider.swift; sourceTree = "<group>"; };
@@ -3398,6 +3402,15 @@
 			path = WalletConnectSessionsStorage;
 			sourceTree = "<group>";
 		};
+		B00EBF842B20EE0C00071EB0 /* AnalyticsTracker */ = {
+			isa = PBXGroup;
+			children = (
+				B00EBF822B20EDE800071EB0 /* PendingExpressTransactionAnalyticsTracker.swift */,
+				B00EBF852B20EE1D00071EB0 /* CommonPendingExpressTransactionAnalyticsTracker.swift */,
+			);
+			path = AnalyticsTracker;
+			sourceTree = "<group>";
+		};
 		B0120A912A0E0F3000F485F1 /* CardHeader */ = {
 			isa = PBXGroup;
 			children = (
@@ -4125,6 +4138,7 @@
 		B0AF2DED2B1D8FD2001A8696 /* Express */ = {
 			isa = PBXGroup;
 			children = (
+				B00EBF842B20EE0C00071EB0 /* AnalyticsTracker */,
 				B0AF2DEE2B1D8FF9001A8696 /* PendingExpressTransactionsManager.swift */,
 			);
 			path = Express;
@@ -7724,6 +7738,7 @@
 				B0BDFD222A8BAB3600479F53 /* UnlockUserWalletBottomSheetView.swift in Sources */,
 				DC66BBE32858E7A600CDF765 /* WelcomeRoutable.swift in Sources */,
 				EFFE2CEC28B8E1B000B9F279 /* CommonDerivationManager.swift in Sources */,
+				B00EBF862B20EE1D00071EB0 /* CommonPendingExpressTransactionAnalyticsTracker.swift in Sources */,
 				EF729B402AEFC1DA00D80205 /* DebouncedCollector.swift in Sources */,
 				EFE23AC8292CB6F700A3C554 /* SwappingTokenListRoutable.swift in Sources */,
 				B0BB97312B18654300053954 /* ExpressPendingTransactionRecord.swift in Sources */,
@@ -8233,6 +8248,7 @@
 				B0C4F76B26F0896E0086D815 /* SingleCardOnboardingCardsLayout.swift in Sources */,
 				B60C13B32A530C500003F68F /* ScrollDetector.swift in Sources */,
 				DA4371A42A7D1937006215CA /* LegacyAddCustomTokenViewModel.swift in Sources */,
+				B00EBF832B20EDE800071EB0 /* PendingExpressTransactionAnalyticsTracker.swift in Sources */,
 				B06C08412A73E11000D982BC /* SingleWalletMainHeaderSubtitleProvider.swift in Sources */,
 				EF9F9090299FAE84006F638F /* SupportChatInputModel.swift in Sources */,
 				5D15F9E8258A522500392BA5 /* PickerView.swift in Sources */,


### PR DESCRIPTION
Как договаривались с Серегой, сюда попали правки из предыдущего МРа - небольшие изменения в верстке

Так же наткнулся, что у нас утекало ~~нижнее дерьмо~~ боттом щит, поэтому пришлось сделать небольшую правку. Причем утекало очень неприятно - вью модель могла задеинититься, а вот сам `BottomSheetModifier` и `StateObject` повисали в памяти и не скидывались, причем там получается связь не напрямую с `BottomSheetModifier` а с координатором `TokenDetails`. Из-за этого не деинитился `TokenDetailsViewModel` а вместе с ним и `PendingExpressTransactionsManager` в итоге запросы продолжали сыпаться в сеть. Воть

Ещё откатил изменения в `PendingExpressTransactionsManager` с `runTask(in: self)` в пользу `Task { [weak self] in`, чтобы раньше происходил деинит менеджера и отменялись таски на запрос статуса, т.к. эта информация уже ненужна и будет перезапрашиваться по новой при заходе на `TokenDetailsViewModel`.