### PR TITLE
IOS-5349: One session-id and correct user-id for express

### DIFF
--- a/Tangem/App/Email/DataCollectors.swift
+++ b/Tangem/App/Email/DataCollectors.swift
@@ -26,8 +26,10 @@ extension EmailDataCollector {
 
 private extension EmailDataCollector {
     func formatData(_ collectedInfo: [EmailCollectedData], appendDeviceInfo: Bool = true) -> Data? {
+        let sessionPrefix = "Session ID: \(AppConstants.sessionId)\n"
         let collectedString = collectedInfo.reduce("") { $0 + $1.type.title + $1.data + "\n" } + (appendDeviceInfo ? DeviceInfoProvider.info() : "")
-        return collectedString.data(using: .utf8)
+        let messageToConvert = "\(sessionPrefix)\n\(collectedString)"
+        return messageToConvert.data(using: .utf8)
     }
 }
 

--- a/Tangem/App/Factories/ExpressModulesFactory/CommonExpressModulesFactory.swift
+++ b/Tangem/App/Factories/ExpressModulesFactory/CommonExpressModulesFactory.swift
@@ -16,12 +16,11 @@ class CommonExpressModulesFactory {
 
     private let userWalletModel: UserWalletModel
     private let initialWalletModel: WalletModel
+    private let expressAPIProviderFactory = ExpressAPIProviderFactory()
 
     // MARK: - Internal
 
     private lazy var expressInteractor = makeExpressInteractor()
-    private lazy var expressAPICredential = makeExpressAPICredential()
-    private lazy var expressAPIProvider = makeExpressAPIProvider()
     private lazy var swappingFactory = TangemSwappingFactory(oneInchApiKey: keysManager.oneInchApiKey)
     private lazy var allowanceProvider = makeAllowanceProvider()
 
@@ -58,7 +57,7 @@ extension CommonExpressModulesFactory: ExpressModulesFactory {
         ExpressTokensListViewModel(
             swapDirection: swapDirection,
             expressTokensListAdapter: expressTokensListAdapter,
-            expressAPIProvider: expressAPIProvider,
+            expressAPIProvider: expressAPIProviderFactory.makeExpressAPIProvider(userId: userWalletId, logger: logger),
             expressInteractor: expressInteractor,
             coordinator: coordinator
         )
@@ -160,7 +159,7 @@ private extension CommonExpressModulesFactory {
 
     func makeExpressInteractor() -> ExpressInteractor {
         let expressManager = swappingFactory.makeExpressManager(
-            expressAPIProvider: expressAPIProvider,
+            expressAPIProvider: expressAPIProviderFactory.makeExpressAPIProvider(userId: userWalletId, logger: logger),
             allowanceProvider: allowanceProvider,
             logger: logger
         )
@@ -184,22 +183,6 @@ private extension CommonExpressModulesFactory {
         let provider = CommonExpressAllowanceProvider()
         provider.setup(wallet: initialWalletModel)
         return provider
-    }
-
-    func makeExpressAPIProvider() -> ExpressAPIProvider {
-        swappingFactory.makeExpressAPIProvider(
-            credential: expressAPICredential,
-            configuration: .defaultConfiguration,
-            logger: logger
-        )
-    }
-
-    func makeExpressAPICredential() -> ExpressAPICredential {
-        ExpressAPICredential(
-            apiKey: keysManager.tangemExpressApiKey,
-            userId: userWalletId,
-            sessionId: UUID().uuidString
-        )
     }
 }
 

--- a/Tangem/App/Factories/SwappingModulesFactory/ExpressAPIProviderFactory.swift
+++ b/Tangem/App/Factories/SwappingModulesFactory/ExpressAPIProviderFactory.swift
@@ -8,15 +8,15 @@
 
 import TangemSwapping
 
-struct CommonExpressAPIFactory {
+struct ExpressAPIProviderFactory {
     @Injected(\.keysManager) private var keysManager: KeysManager
 
-    func makeExpressAPIProvider(userId: String = UUID().uuidString) -> ExpressAPIProvider {
+    func makeExpressAPIProvider(userId: String, logger: SwappingLogger) -> ExpressAPIProvider {
         let factory = TangemSwappingFactory(oneInchApiKey: keysManager.oneInchApiKey)
         let credentials = ExpressAPICredential(
             apiKey: keysManager.tangemExpressApiKey,
             userId: userId,
-            sessionId: UUID().uuidString
+            sessionId: AppConstants.sessionId
         )
 
         return factory.makeExpressAPIProvider(

--- a/Tangem/App/Services/Common/AppLog.swift
+++ b/Tangem/App/Services/Common/AppLog.swift
@@ -45,9 +45,10 @@ class AppLog {
 
     func logAppLaunch(_ currentLaunch: Int) {
         let dashSeparator = String(repeating: "-", count: 25)
-        let launchNumberMessage = "\(dashSeparator) New session. Current launch number: \(currentLaunch) \(dashSeparator)"
+        let sessionMessage = "\(dashSeparator) New session. Session id: \(AppConstants.sessionId) \(dashSeparator)"
+        let launchNumberMessage = "\(dashSeparator) Current launch number: \(currentLaunch) \(dashSeparator)"
         let deviceInfoMessage = "\(dashSeparator) \(DeviceInfoProvider.Subject.allCases.map { $0.description }.joined(separator: ", ")) \(dashSeparator)"
-        debug("\n\(launchNumberMessage)\n\(deviceInfoMessage)\n\n")
+        debug("\n\(sessionMessage)\n\(launchNumberMessage)\n\(deviceInfoMessage)\n\n")
     }
 }
 

--- a/Tangem/App/Services/Express/PendingExpressTransactionsManager.swift
+++ b/Tangem/App/Services/Express/PendingExpressTransactionsManager.swift
@@ -38,7 +38,7 @@ class CommonPendingExpressTransactionsManager {
         self.userWalletId = userWalletId
         self.blockchainNetwork = blockchainNetwork
         self.tokenItem = tokenItem
-        expressAPIProvider = CommonExpressAPIFactory().makeExpressAPIProvider(userId: userWalletId)
+        expressAPIProvider = ExpressAPIProviderFactory().makeExpressAPIProvider(userId: userWalletId, logger: AppLog.shared)
 
         bind()
     }

--- a/Tangem/App/Services/SwapAvailabilityManager/SwapAvailabilityManager.swift
+++ b/Tangem/App/Services/SwapAvailabilityManager/SwapAvailabilityManager.swift
@@ -11,7 +11,7 @@ import Combine
 typealias SwapAvailabilityManager = SwapAvailabilityProvider & SwapAvailabilityController
 
 protocol SwapAvailabilityController {
-    func loadSwapAvailability(for items: [TokenItem], forceReload: Bool)
+    func loadSwapAvailability(for items: [TokenItem], forceReload: Bool, userWalletId: String)
 }
 
 protocol SwapAvailabilityProvider {

--- a/Tangem/App/Services/UserTokensManager/CommonUserTokensManager.swift
+++ b/Tangem/App/Services/UserTokensManager/CommonUserTokensManager.swift
@@ -16,6 +16,7 @@ struct CommonUserTokensManager {
 
     let derivationManager: DerivationManager?
 
+    private let userWalletId: UserWalletId
     private let shouldLoadSwapAvailability: Bool
     private let userTokenListManager: UserTokenListManager
     private let walletModelsManager: WalletModelsManager
@@ -25,6 +26,7 @@ struct CommonUserTokensManager {
     private var bag: Set<AnyCancellable> = []
 
     init(
+        userWalletId: UserWalletId,
         shouldLoadSwapAvailability: Bool,
         userTokenListManager: UserTokenListManager,
         walletModelsManager: WalletModelsManager,
@@ -32,6 +34,7 @@ struct CommonUserTokensManager {
         derivationManager: DerivationManager?,
         cardDerivableProvider: CardDerivableProvider
     ) {
+        self.userWalletId = userWalletId
         self.shouldLoadSwapAvailability = shouldLoadSwapAvailability
         self.userTokenListManager = userTokenListManager
         self.walletModelsManager = walletModelsManager
@@ -82,7 +85,7 @@ struct CommonUserTokensManager {
         let converter = StorageEntryConverter()
         let nonCustomTokens = userTokenListManager.userTokensList.entries.filter { !$0.isCustom }
         let tokenItems = converter.convertToTokenItem(nonCustomTokens)
-        swapAvailabilityController.loadSwapAvailability(for: tokenItems, forceReload: forceReload)
+        swapAvailabilityController.loadSwapAvailability(for: tokenItems, forceReload: forceReload, userWalletId: userWalletId.stringValue)
     }
 }
 

--- a/Tangem/App/ViewModels/CardViewModel.swift
+++ b/Tangem/App/ViewModels/CardViewModel.swift
@@ -24,6 +24,7 @@ class CardViewModel: Identifiable, ObservableObject {
     var userTokensManager: UserTokensManager { _userTokensManager }
 
     private lazy var _userTokensManager = CommonUserTokensManager(
+        userWalletId: userWalletId,
         shouldLoadSwapAvailability: config.hasFeature(.swapping),
         userTokenListManager: userTokenListManager,
         walletModelsManager: walletModelsManager,

--- a/Tangem/Common/AppConstants.swift
+++ b/Tangem/Common/AppConstants.swift
@@ -23,4 +23,6 @@ enum AppConstants {
     static let defaultScrollViewKeyboardDismissMode = UIScrollView.KeyboardDismissMode.onDrag
 
     static let minusSign = "−"
+
+    static let sessionId = UUID().uuidString
 }

--- a/TangemSwapping/Services/ExpressAPIService/CommonExpressAPIService.swift
+++ b/TangemSwapping/Services/ExpressAPIService/CommonExpressAPIService.swift
@@ -94,7 +94,6 @@ private extension CommonExpressAPIService {
             """
             [ExpressAPIService]
             Request to target: \(target.path)
-            plugins: \(provider.plugins))
             task: \(target.task)
             ended with response: \(info)
             Error: \(String(describing: error))


### PR DESCRIPTION
Единый ID для трекинга сессии, обсуждение в канале было на этот счет.

Добавил прокидывание `user-id` в `SwapAvailabilityManager` чтобы можно было проставлять правильный `user-id` для запросов `assets`.

Добавил пока что всюду где мог айдишник сессии, чтобы можно было связывать обращение пользователя с его деятельностью в экспрессе.

Почистил немного логирование запросов в экспресс, т.к. там светился api-key к экспрессу