### PR TITLE
IOS-5369: Fix wrong currency symbol in permission notif

### DIFF
--- a/Tangem/App/Services/NotificationManagers/ExpressNotifications/ExpressNotificationManager.swift
+++ b/Tangem/App/Services/NotificationManagers/ExpressNotifications/ExpressNotificationManager.swift
@@ -128,8 +128,7 @@ class ExpressNotificationManager {
         guard let interactor = expressInteractor else { return }
 
         let sourceTokenItem = interactor.getSender().tokenItem
-        let sourceNetworkSymbol = sourceTokenItem.blockchain.currencySymbol
-        let event: ExpressNotificationEvent = .permissionNeeded(currencyCode: sourceNetworkSymbol)
+        let event: ExpressNotificationEvent = .permissionNeeded(currencyCode: sourceTokenItem.currencySymbol)
         let notificationsFactory = NotificationsFactory()
 
         let notification = notificationsFactory.buildNotificationInput(for: event) { [weak self] id, actionType in


### PR DESCRIPTION
Был код валюты сети был в тексте оповещения, а не код токена

<img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/0dadb915-5fc6-4865-aa59-97d1f7fdd74b">
