### PR TITLE
IOS-5316 Hiding the promotion view when after its been hidden in other wallet

### DIFF
--- a/Tangem/App/Services/NotificationManagers/UserWalletNotifications/UserWalletNotificationManager.swift
+++ b/Tangem/App/Services/NotificationManagers/UserWalletNotifications/UserWalletNotificationManager.swift
@@ -117,6 +117,20 @@ final class UserWalletNotificationManager {
             .removeDuplicates()
             .sink(receiveValue: weakify(self, forFunction: UserWalletNotificationManager.addMissingDerivationWarningIfNeeded(pendingDerivationsCount:)))
             .store(in: &bag)
+
+        AppSettings.shared.$tangemExpressMainPromotionDismissed
+            .sink { [weak self] dismissed in
+                guard
+                    let self,
+                    dismissed
+                else {
+                    return
+                }
+
+                let promotionEvent = WarningEvent.tangemExpressPromotion
+                notificationInputsSubject.value.removeAll { $0.settings.event.hashValue == promotionEvent.hashValue }
+            }
+            .store(in: &bag)
     }
 
     // TODO: Move this logic into separate entity (IOS-4430)


### PR DESCRIPTION
Упустил этот момент. Если сохранено несколько воллетов то при скрытии плашки на одной главной надо на других их подчищать сразу же.