### PR TITLE
IOS-5423: Manage tokens bottom sheet - conflicting gestures

### DIFF
--- a/Tangem/Modules/ManageTokens/TokenList/ManageTokensView.swift
+++ b/Tangem/Modules/ManageTokens/TokenList/ManageTokensView.swift
@@ -20,7 +20,6 @@ struct ManageTokensView: View {
 
             list
         }
-        .background(Colors.Background.primary)
         .scrollDismissesKeyboardCompat(true)
         .alert(item: $viewModel.alert, content: { $0.alert })
     }

--- a/Tangem/UIComponents/BottomScrollableSheet/BottomScrollableSheet.swift
+++ b/Tangem/UIComponents/BottomScrollableSheet/BottomScrollableSheet.swift
@@ -87,12 +87,10 @@ struct BottomScrollableSheet<Header: View, Content: View, Overlay: View>: View {
     }
 
     /// - Note: Invisible and receives touches only when the sheet is in a collapsed state (`BottomScrollableSheetState.bottom`).
-    @ViewBuilder
-    private func headerGestureOverlayView(proxy: GeometryProxy) -> some View {
+    @ViewBuilder private var headerGestureOverlayView: some View {
         // The reduced hittest area is used here to prevent simultaneous recognition of the `headerDragGesture`
         // or `headerTapGesture` gestures and the system `app switcher` screen edge drag gesture.
-        let overlayViewBottomInset = stateObject.state.isBottom ? proxy.safeAreaInsets.bottom : 0.0
-        let overlayViewHeight = max(0.0, stateObject.headerHeight - overlayViewBottomInset)
+        let overlayViewHeight = max(0.0, stateObject.headerHeight - UIApplication.safeAreaInsets.bottom)
         Color.clear
             .frame(height: overlayViewHeight, alignment: .top)
             .contentShape(Rectangle())
@@ -165,7 +163,7 @@ struct BottomScrollableSheet<Header: View, Content: View, Overlay: View>: View {
                 isHidden = true
             }
         }
-        .overlay(headerGestureOverlayView(proxy: proxy), alignment: .top) // Mustn't be hidden (by the 'isHidden' flag applied above)
+        .overlay(headerGestureOverlayView, alignment: .top) // Mustn't be hidden (by the 'isHidden' flag applied above)
         .offset(y: proxy.size.height - stateObject.visibleHeight - stateObject.topInset)
     }
 


### PR DESCRIPTION
[IOS-5423](https://tangem.atlassian.net/browse/IOS-5423)

Фикс конфликта любых кнопок/tap gesture в хедере с жестами сворачивания/разворачивания шита по тапу/драгу.

Интересно, что тап в `SwiftUI.TextField` для установки фокуса на инпуте работал совершенно без проблем, из-за чего собственно эта проблема всплыла только сейчас, когда понадобилось добавить кнопку в хедер.

[IOS-5423]: https://tangem.atlassian.net/browse/IOS-5423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ