### PR TITLE
IOS-5316 Fixed the swapping condition

### DIFF
--- a/Tangem/App/Services/SwapAvailabilityManager/SwapPairService.swift
+++ b/Tangem/App/Services/SwapAvailabilityManager/SwapPairService.swift
@@ -51,15 +51,14 @@ struct SwapPairService {
         )
 
         for swapPair in swapPairs {
-            if swapPair.destination == swapPair.source {
+            guard
+                swapPair.destination != swapPair.source,
+                currenciesWithBalance.contains(swapPair.source)
+            else {
                 continue
             }
 
-            if swapPair.source == selectedExpressCurrency, currenciesWithBalance.contains(swapPair.source) {
-                return true
-            }
-
-            if swapPair.destination == selectedExpressCurrency, currenciesWithBalance.contains(swapPair.destination) {
+            if swapPair.source == selectedExpressCurrency || swapPair.destination == selectedExpressCurrency {
                 return true
             }
         }


### PR DESCRIPTION
Ошибка в логике

Было так

```
          if swapPair.source == selectedExpressCurrency, currenciesWithBalance.contains(swapPair.source) {
                return true
            }

            if swapPair.destination == selectedExpressCurrency, currenciesWithBalance.contains(swapPair.destination) {
                return true
            }
```

Надо так
```
          if swapPair.source == selectedExpressCurrency, currenciesWithBalance.contains(swapPair.source) {
                return true
            }

            if swapPair.destination == selectedExpressCurrency, currenciesWithBalance.contains(swapPair.source) {
                return true
            }
```

Разница в конце второго IF-а