### PR TITLE
iOS-5042: Organize tokens - Add workaround to prevent OOB crash on drag-and-drop

### DIFF
--- a/Tangem/Common/Extensions/MutableCollection+.swift
+++ b/Tangem/Common/Extensions/MutableCollection+.swift
@@ -1,0 +1,45 @@
+//
+//  MutableCollection+.swift
+//  Tangem
+//
+//  Created by Andrey Fedorov on 14.12.2023.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+extension MutableCollection where Self.Index == Int {
+    /// `MutableCollection.move(fromOffsets:toOffset:)` with bounds checking.
+    /// - Throws: `MutableCollectionTryMoveError` if there is an OOB for source/destination.
+    mutating func tryMove(
+        fromOffsets source: IndexSet,
+        toOffset destination: Int
+    ) throws {
+        guard !source.isEmpty else {
+            return
+        }
+
+        for offset in source {
+            // “past the end” source offset (the position one greater than the last valid subscript argument) is
+            // perfectly valid for the `move(fromOffsets:toOffset:)` method, therefore `<= count` comparison is used
+            guard offset >= 0, offset <= count else {
+                throw MutableCollectionTryMoveError.sourceOffsetOutOfBound(offset: offset, count: count)
+            }
+        }
+
+        // “past the end” destination (the position one greater than the last valid subscript argument) is
+        // perfectly valid for the `move(fromOffsets:toOffset:)` method, therefore `<= count` comparison is used
+        guard destination >= 0, destination <= count else {
+            throw MutableCollectionTryMoveError.destinationOffsetOutOfBound(offset: destination, count: count)
+        }
+
+        move(fromOffsets: source, toOffset: destination)
+    }
+}
+
+// MARK: - Auxiliary types
+
+enum MutableCollectionTryMoveError: Error {
+    case sourceOffsetOutOfBound(offset: Int, count: Int)
+    case destinationOffsetOutOfBound(offset: Int, count: Int)
+}

--- a/Tangem/Modules/OrganizeTokens/OrganizeTokensViewModel.swift
+++ b/Tangem/Modules/OrganizeTokens/OrganizeTokensViewModel.swift
@@ -279,7 +279,7 @@ extension OrganizeTokensViewModel {
             )
 
             dragAndDropActionsCache.addDragAndDropAction(isGroupingEnabled: isGroupingEnabled) { sectionsToMutate in
-                sectionsToMutate.move(
+                try sectionsToMutate.tryMove(
                     fromOffsets: IndexSet(integer: sourceIndexPath.section),
                     toOffset: destinationIndexPath.section + diff
                 )
@@ -297,7 +297,11 @@ extension OrganizeTokensViewModel {
             )
 
             dragAndDropActionsCache.addDragAndDropAction(isGroupingEnabled: isGroupingEnabled) { sectionsToMutate in
-                sectionsToMutate[sourceIndexPath.section].items.move(
+                guard sectionsToMutate.indices.contains(sourceIndexPath.section) else {
+                    throw Error.sectionOffsetOutOfBound(offset: sourceIndexPath.section, count: sectionsToMutate.count)
+                }
+
+                try sectionsToMutate[sourceIndexPath.section].items.tryMove(
                     fromOffsets: IndexSet(integer: sourceIndexPath.item),
                     toOffset: destinationIndexPath.item + diff
                 )
@@ -387,5 +391,13 @@ extension OrganizeTokensViewModel: OrganizeTokensDragAndDropControllerDataSource
         listViewIdentifierForItemAt indexPath: IndexPath
     ) -> AnyHashable {
         return section(at: indexPath)?.id ?? itemViewModel(at: indexPath).id.asAnyHashable
+    }
+}
+
+// MARK: - Auxiliary types
+
+extension OrganizeTokensViewModel {
+    enum Error: Swift.Error {
+        case sectionOffsetOutOfBound(offset: Int, count: Int)
     }
 }

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -524,6 +524,7 @@
 		B63B63BA2A44012D00A7CECF /* OrganizeTokensListHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63B63B92A44012D00A7CECF /* OrganizeTokensListHeader.swift */; };
 		B63B63BD2A44013E00A7CECF /* OrganizeTokensListFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63B63BC2A44013E00A7CECF /* OrganizeTokensListFooter.swift */; };
 		B63B72892AF5F23B004B80BF /* TokenSectionsSourcePublisherFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63B72882AF5F23B004B80BF /* TokenSectionsSourcePublisherFactory.swift */; };
+		B63D4CAD2B2B8C6200DB2420 /* MutableCollection+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63D4CAC2B2B8C6200DB2420 /* MutableCollection+.swift */; };
 		B63FDB182A5F09F10080240F /* CardsInfoPagerFlexibleFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63FDB172A5F09F10080240F /* CardsInfoPagerFlexibleFooterView.swift */; };
 		B643B8072B1965EA002DE401 /* PerformanceMonitorConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B643B8062B1965EA002DE401 /* PerformanceMonitorConfigurator.swift */; };
 		B644EC272ACBF217007D9F4B /* UIPanGestureRecognizer+Value.swift in Sources */ = {isa = PBXBuildFile; fileRef = B644EC262ACBF217007D9F4B /* UIPanGestureRecognizer+Value.swift */; };
@@ -1925,6 +1926,7 @@
 		B63B63B92A44012D00A7CECF /* OrganizeTokensListHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizeTokensListHeader.swift; sourceTree = "<group>"; };
 		B63B63BC2A44013E00A7CECF /* OrganizeTokensListFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrganizeTokensListFooter.swift; sourceTree = "<group>"; };
 		B63B72882AF5F23B004B80BF /* TokenSectionsSourcePublisherFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSectionsSourcePublisherFactory.swift; sourceTree = "<group>"; };
+		B63D4CAC2B2B8C6200DB2420 /* MutableCollection+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MutableCollection+.swift"; sourceTree = "<group>"; };
 		B63FDB172A5F09F10080240F /* CardsInfoPagerFlexibleFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardsInfoPagerFlexibleFooterView.swift; sourceTree = "<group>"; };
 		B643B8062B1965EA002DE401 /* PerformanceMonitorConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceMonitorConfigurator.swift; sourceTree = "<group>"; };
 		B644EC262ACBF217007D9F4B /* UIPanGestureRecognizer+Value.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIPanGestureRecognizer+Value.swift"; sourceTree = "<group>"; };
@@ -3289,6 +3291,7 @@
 				EF50A5B0288976140081C5BB /* View+ConditionalModifiers.swift */,
 				DCFCA17428F4232F0037586C /* Array+.swift */,
 				B62E42502A79328A0045AB31 /* Collection+.swift */,
+				B63D4CAC2B2B8C6200DB2420 /* MutableCollection+.swift */,
 				B674D6D82A96AC8800172491 /* Sequence+.swift */,
 				DA28D57C290AAE2000F0C335 /* ScrollView+.swift */,
 				B68907842A32482F00A0D246 /* ForEach+.swift */,
@@ -8344,6 +8347,7 @@
 				DA4371A62A7D1937006215CA /* LegacyAddCustomTokenView.swift in Sources */,
 				2D788E8A2ADD657000E0884B /* ManageTokensNetworkSelectorAlertBuilder.swift in Sources */,
 				B0E0AF5D2996488100E52F7B /* TransactionHistoryMapper.swift in Sources */,
+				B63D4CAD2B2B8C6200DB2420 /* MutableCollection+.swift in Sources */,
 				EF48E6E42B02408500FE0072 /* ExpressViewModel.swift in Sources */,
 				B0BB97302B18654300053954 /* ExpressPendingTransactionRepository.swift in Sources */,
 				B0F318FD2A739432009F131E /* UserWalletStubs.swift in Sources */,


### PR DESCRIPTION
[IOS-5042](https://tangem.atlassian.net/browse/IOS-5042)

Причина не в гонке на разных потоках, как я думал изначально.
Повторить никак не удалось, поэтому это скорее воркараунд, чем фикс

[IOS-5042]: https://tangem.atlassian.net/browse/IOS-5042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ