### PR TITLE
IOS-5441: [Express] Fix for updating exchangeable state

### DIFF
--- a/Tangem/App/Services/SwapAvailabilityManager/CommonSwapAvailabilityManager.swift
+++ b/Tangem/App/Services/SwapAvailabilityManager/CommonSwapAvailabilityManager.swift
@@ -83,12 +83,12 @@ class CommonSwapAvailabilityManager: SwapAvailabilityManager {
             }
             let provider = ExpressAPIProviderFactory().makeExpressAPIProvider(userId: userWalletId, logger: AppLog.shared)
             let assets = try await provider.assets(with: expressCurrencies)
-            let preparedSwapStates: [TokenItem: Bool] = assets.reduce(into: [:]) { partialResult, currency in
-                guard let tokenItem = requestedItems[currency] else {
+            let preparedSwapStates: [TokenItem: Bool] = assets.reduce(into: [:]) { partialResult, asset in
+                guard let tokenItem = requestedItems[asset.currency] else {
                     return
                 }
 
-                partialResult[tokenItem] = true
+                partialResult[tokenItem] = asset.isExchangeable
             }
 
             manager.saveTokenItemsAvailability(for: preparedSwapStates)

--- a/Tangem/App/ViewModels/WalletModel/WalletModel.swift
+++ b/Tangem/App/ViewModels/WalletModel/WalletModel.swift
@@ -208,14 +208,6 @@ class WalletModel {
     var actionsUpdatePublisher: AnyPublisher<Void, Never> {
         swapAvailabilityProvider
             .tokenItemsAvailableToSwapPublisher
-            .contains { [weak self] itemsAvailableToSwap in
-                guard let self else {
-                    return false
-                }
-
-                return itemsAvailableToSwap[tokenItem] ?? false
-            }
-            .removeDuplicates()
             .mapToVoid()
             .eraseToAnyPublisher()
     }

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 		B05D063429DEA4580031C6AB /* AccessCodeRecoverySettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05D063329DEA4580031C6AB /* AccessCodeRecoverySettingsViewModel.swift */; };
 		B05DD9652A9F12A700B24ED9 /* TokenNotificationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05DD9642A9F12A700B24ED9 /* TokenNotificationEvent.swift */; };
 		B05F1E66299CB81D00E27E32 /* TransactionViewPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05F1E65299CB81D00E27E32 /* TransactionViewPlaceholder.swift */; };
+		B05FF3172B2C2D9A00F71338 /* ExpressAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05FF3162B2C2D9A00F71338 /* ExpressAsset.swift */; };
 		B06015E529730C3D00D0F809 /* WalletConnectUIDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06015E429730C3D00D0F809 /* WalletConnectUIDelegate.swift */; };
 		B0606E122684A946004004ED /* BlinkingModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0606E112684A946004004ED /* BlinkingModifier.swift */; };
 		B06243082AA9B77C00F7B9B2 /* SingleTokenRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06243072AA9B77C00F7B9B2 /* SingleTokenRouter.swift */; };
@@ -1670,6 +1671,7 @@
 		B05D063329DEA4580031C6AB /* AccessCodeRecoverySettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessCodeRecoverySettingsViewModel.swift; sourceTree = "<group>"; };
 		B05DD9642A9F12A700B24ED9 /* TokenNotificationEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenNotificationEvent.swift; sourceTree = "<group>"; };
 		B05F1E65299CB81D00E27E32 /* TransactionViewPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionViewPlaceholder.swift; sourceTree = "<group>"; };
+		B05FF3162B2C2D9A00F71338 /* ExpressAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressAsset.swift; sourceTree = "<group>"; };
 		B06015E429730C3D00D0F809 /* WalletConnectUIDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletConnectUIDelegate.swift; sourceTree = "<group>"; };
 		B0606E112684A946004004ED /* BlinkingModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlinkingModifier.swift; sourceTree = "<group>"; };
 		B06243072AA9B77C00F7B9B2 /* SingleTokenRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleTokenRouter.swift; sourceTree = "<group>"; };
@@ -6217,6 +6219,7 @@
 				EF48E6AD2AFE98D500FE0072 /* ExpressRestriction.swift */,
 				EF6A8B042B27950D00CA3535 /* ExpressApproveData.swift */,
 				EF6A8B062B27954F00CA3535 /* ExpressAvailableProvider.swift */,
+				B05FF3162B2C2D9A00F71338 /* ExpressAsset.swift */,
 			);
 			path = Express;
 			sourceTree = "<group>";
@@ -8773,6 +8776,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EF4661C52923B42A00346B6C /* SwappingApprovedDataModel.swift in Sources */,
+				B05FF3172B2C2D9A00F71338 /* ExpressAsset.swift in Sources */,
 				EF5FE5CF2B2729EE00C2DEA4 /* CEXExpressProviderManager.swift in Sources */,
 				EF04C5512AFBEF4E00D8853B /* CommonExpressAPIProvider.swift in Sources */,
 				EFA9854B294775B500D1FCB3 /* SwappingPreviewData.swift in Sources */,

--- a/TangemSwapping/Models/Express/ExpressAsset.swift
+++ b/TangemSwapping/Models/Express/ExpressAsset.swift
@@ -1,0 +1,14 @@
+//
+//  ExpressAsset.swift
+//  TangemSwapping
+//
+//  Created by Andrew Son on 15/12/23.
+//  Copyright © 2023 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+public struct ExpressAsset {
+    public let currency: ExpressCurrency
+    public let isExchangeable: Bool
+}

--- a/TangemSwapping/Services/ExpressAPIProvider/CommonExpressAPIProvider.swift
+++ b/TangemSwapping/Services/ExpressAPIProvider/CommonExpressAPIProvider.swift
@@ -23,16 +23,15 @@ class CommonExpressAPIProvider {
 extension CommonExpressAPIProvider: ExpressAPIProvider {
     /// Requests from Express API `exchangeAvailable` state for currencies included in filter
     /// - Returns: All `ExpressCurrency` that available to exchange specified by filter
-    func assets(with filter: [ExpressCurrency]) async throws -> [ExpressCurrency] {
+    func assets(with filter: [ExpressCurrency]) async throws -> [ExpressAsset] {
         let tokens = filter.map(expressAPIMapper.mapToDTOCurrency(currency:))
         let request = ExpressDTO.Assets.Request(tokensList: tokens)
         let response = try await expressAPIService.assets(request: request)
-        let assets: [ExpressCurrency] = response.compactMap {
-            guard $0.exchangeAvailable else {
-                return nil
-            }
-
-            return ExpressCurrency(response: $0)
+        let assets: [ExpressAsset] = response.map {
+            return ExpressAsset(
+                currency: ExpressCurrency(response: $0),
+                isExchangeable: $0.exchangeAvailable
+            )
         }
         return assets
     }

--- a/TangemSwapping/Services/ExpressAPIProvider/ExpressAPIProvider.swift
+++ b/TangemSwapping/Services/ExpressAPIProvider/ExpressAPIProvider.swift
@@ -11,7 +11,7 @@ import Foundation
 public protocol ExpressAPIProvider {
     /// Requests from Express API `exchangeAvailable` state for currencies included in filter
     /// - Returns: All `ExpressCurrency` that available to exchange specified by filter
-    func assets(with filter: [ExpressCurrency]) async throws -> [ExpressCurrency]
+    func assets(with filter: [ExpressCurrency]) async throws -> [ExpressAsset]
     func pairs(from: [ExpressCurrency], to: [ExpressCurrency]) async throws -> [ExpressPair]
 
     func providers() async throws -> [ExpressProvider]


### PR DESCRIPTION
Не обновлялось возможность обменять токены из-за того что я до этого сделал фильтрацию только достыпных для обмена монет. Можно было, конечно делать сет на удаление токенов из словаря, но так все же проще, вернуть `ExpressAsset` и через него передавать  инфу о доступности обмена.

Так же подчистил фильтрацию в `WalletModel`, потому что через раз реагировали не выбранные кошельки на главной и не обновляли контекстное меню