### PR TITLE
IOS-5396: Fix Note cards not appearing

### DIFF
--- a/Tangem/App/Services/UserTokenListManager/CommonUserTokenListManager.swift
+++ b/Tangem/App/Services/UserTokenListManager/CommonUserTokenListManager.swift
@@ -136,8 +136,8 @@ extension CommonUserTokenListManager: UserTokenListManager {
 private extension CommonUserTokenListManager {
     func notifyAboutTokenListUpdates(with userTokenList: StoredUserTokenList? = nil) {
         let updatedUserTokenList = userTokenList ?? tokenItemsRepository.getList()
-        userTokensListSubject.send(updatedUserTokenList)
         DispatchQueue.main.async {
+            self.userTokensListSubject.send(updatedUserTokenList)
             if !self.initialized, self.tokenItemsRepository.containsFile {
                 self.initializedSubject.send(true)
             }

--- a/Tangem/App/Services/UserTokenListManager/CommonUserTokenListManager.swift
+++ b/Tangem/App/Services/UserTokenListManager/CommonUserTokenListManager.swift
@@ -75,7 +75,6 @@ extension CommonUserTokenListManager: UserTokenListManager {
     var userTokensPublisher: AnyPublisher<[StorageEntry], Never> {
         let converter = StorageEntryConverter()
         return userTokensListSubject
-            .receive(on: DispatchQueue.main)
             .map { converter.convertToStorageEntries($0.entries) }
             .eraseToAnyPublisher()
     }
@@ -86,7 +85,6 @@ extension CommonUserTokenListManager: UserTokenListManager {
 
     var userTokensListPublisher: AnyPublisher<StoredUserTokenList, Never> {
         userTokensListSubject
-            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
 

--- a/Tangem/Modules/OrganizeTokens/ListHeader/OrganizeTokensHeaderViewModel.swift
+++ b/Tangem/Modules/OrganizeTokens/ListHeader/OrganizeTokensHeaderViewModel.swift
@@ -60,12 +60,14 @@ final class OrganizeTokensHeaderViewModel: ObservableObject {
         optionsProviding
             .groupingOption
             .map(\.isGrouped)
+            .receive(on: DispatchQueue.main)
             .assign(to: \.isGroupingEnabled, on: self, ownership: .weak)
             .store(in: &bag)
 
         optionsProviding
             .sortingOption
             .map(\.isSorted)
+            .receive(on: DispatchQueue.main)
             .assign(to: \.isSortByBalanceEnabled, on: self, ownership: .weak)
             .store(in: &bag)
 

--- a/Tangem/Modules/OrganizeTokens/ListHeader/OrganizeTokensHeaderViewModel.swift
+++ b/Tangem/Modules/OrganizeTokens/ListHeader/OrganizeTokensHeaderViewModel.swift
@@ -60,14 +60,12 @@ final class OrganizeTokensHeaderViewModel: ObservableObject {
         optionsProviding
             .groupingOption
             .map(\.isGrouped)
-            .receive(on: DispatchQueue.main)
             .assign(to: \.isGroupingEnabled, on: self, ownership: .weak)
             .store(in: &bag)
 
         optionsProviding
             .sortingOption
             .map(\.isSorted)
-            .receive(on: DispatchQueue.main)
             .assign(to: \.isSortByBalanceEnabled, on: self, ownership: .weak)
             .store(in: &bag)
 


### PR DESCRIPTION
Проблема была в том, что перед тем как отправить значение скипался текущий цикл основного потока и передача списка токена откладывалась на следующий, в итоге главная создавалась, а там `WalletModel` ещё не была создана, в итоге при логине в приложение все одновалютные карточки (Note, Twin и т.д.) не могли создать главный экран и оставались пустыми.

Потыкал по органайз, менедж токенс, все вроде норм отрабатывает (публикация нового списка токенов и нового листа с токенами)