### PR TITLE
IOS-5396: Return of the main thread switching

### DIFF
--- a/Tangem/App/Services/UserTokenListManager/CommonUserTokenListManager.swift
+++ b/Tangem/App/Services/UserTokenListManager/CommonUserTokenListManager.swift
@@ -136,8 +136,9 @@ extension CommonUserTokenListManager: UserTokenListManager {
 private extension CommonUserTokenListManager {
     func notifyAboutTokenListUpdates(with userTokenList: StoredUserTokenList? = nil) {
         let updatedUserTokenList = userTokenList ?? tokenItemsRepository.getList()
+        userTokensListSubject.send(updatedUserTokenList)
+
         DispatchQueue.main.async {
-            self.userTokensListSubject.send(updatedUserTokenList)
             if !self.initialized, self.tokenItemsRepository.containsFile {
                 self.initializedSubject.send(true)
             }

--- a/Tangem/Modules/ManageTokens/TokenList/ManageTokensViewModel.swift
+++ b/Tangem/Modules/ManageTokens/TokenList/ManageTokensViewModel.swift
@@ -116,6 +116,7 @@ private extension ManageTokensViewModel {
             .map { $0.userTokenListManager.userTokensPublisher }
 
         Publishers.MergeMany(userTokensPublishers)
+            .receive(on: DispatchQueue.main)
             .receiveValue { [weak self] value in
                 guard let self = self else { return }
 

--- a/Tangem/Modules/OrganizeTokens/ListHeader/OrganizeTokensHeaderViewModel.swift
+++ b/Tangem/Modules/OrganizeTokens/ListHeader/OrganizeTokensHeaderViewModel.swift
@@ -60,12 +60,14 @@ final class OrganizeTokensHeaderViewModel: ObservableObject {
         optionsProviding
             .groupingOption
             .map(\.isGrouped)
+            .receive(on: DispatchQueue.main)
             .assign(to: \.isGroupingEnabled, on: self, ownership: .weak)
             .store(in: &bag)
 
         optionsProviding
             .sortingOption
             .map(\.isSorted)
+            .receive(on: DispatchQueue.main)
             .assign(to: \.isSortByBalanceEnabled, on: self, ownership: .weak)
             .store(in: &bag)
 


### PR DESCRIPTION
В общем, сделал так как хотел в начале, потому что появилась проблема, что из-за переключения потоков информация, которая должна сразу обновляться не обновлялась сразу и если надо обновить список токенов и сразу по новому списку отправить запрос, это сделать не получится, потому что надо ждать, пока в следующем цикле основного потока произойдет обновление. Добавил в двух местах где надо было переключения на основной поток, надо пересмотреть всю эту логику, возможно имеет смысл при обновлении списка возвращать обновленный список, а не через подписки рассчитывать на что-то.