### PR TITLE
IOS-5454: Fix appear anims for notifs TokenDetails

### DIFF
--- a/Tangem/Modules/TokenDetails/TokenDetailsCoordinator.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsCoordinator.swift
@@ -74,7 +74,6 @@ class TokenDetailsCoordinator: CoordinatorObject {
             coordinator: self,
             tokenRouter: tokenRouter
         )
-        notificationManager.setupManager(with: tokenDetailsViewModel)
     }
 }
 

--- a/Tangem/Modules/TokenDetails/TokenDetailsView.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsView.swift
@@ -40,7 +40,7 @@ struct TokenDetailsView: View {
 
                 ForEach(viewModel.tokenNotificationInputs) { input in
                     NotificationView(input: input)
-                        .transition(viewModel.shouldShowNotificationsWithAnimation ? .notificationTransition : .identity)
+                        .transition(.notificationTransition)
                 }
 
                 if viewModel.isMarketPriceAvailable {
@@ -85,7 +85,6 @@ struct TokenDetailsView: View {
         .background(Colors.Background.secondary.edgesIgnoringSafeArea(.all))
         .ignoresSafeArea(.keyboard)
         .onAppear(perform: viewModel.onAppear)
-        .onDidAppear(viewModel.onDidAppear)
         .alert(item: $viewModel.alert) { $0.alert }
         .actionSheet(item: $viewModel.actionSheet) { $0.sheet }
         .coordinateSpace(name: coorditateSpaceName)

--- a/Tangem/Modules/TokenDetails/TokenDetailsViewModel.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsViewModel.swift
@@ -17,7 +17,6 @@ final class TokenDetailsViewModel: SingleTokenBaseViewModel, ObservableObject {
 
     @Published private var balance: LoadingValue<BalanceInfo> = .loading
     @Published var actionSheet: ActionSheetBinder?
-    @Published var shouldShowNotificationsWithAnimation: Bool = false
     @Published var pendingExpressTransactions: [PendingExpressTransactionView.Info] = []
 
     private(set) var balanceWithButtonsModel: BalanceWithButtonsViewModel!
@@ -70,6 +69,7 @@ final class TokenDetailsViewModel: SingleTokenBaseViewModel, ObservableObject {
             notificationManager: notificationManager,
             tokenRouter: tokenRouter
         )
+        notificationManager.setupManager(with: self)
         balanceWithButtonsModel = .init(balanceProvider: self, buttonsProvider: self)
 
         prepareSelf()
@@ -81,10 +81,6 @@ final class TokenDetailsViewModel: SingleTokenBaseViewModel, ObservableObject {
 
     func onAppear() {
         Analytics.log(event: .detailsScreenOpened, params: [Analytics.ParameterKey.token: tokenItem.currencySymbol])
-    }
-
-    func onDidAppear() {
-        shouldShowNotificationsWithAnimation = true
     }
 
     override func didTapNotificationButton(with id: NotificationViewId, action: NotificationButtonActionType) {


### PR DESCRIPTION
Оповещения и баннер появлялись без анимации, скачком. Поменял порядок инициализации менеджера, и убрал ненужные флаги из-за которых происходили глитчи. Проверил на 17.1.1 и 14.6

https://github.com/tangem/tangem-app-ios/assets/24321494/64c1dc19-3b5f-48b3-9c7a-e48a0a6f7cdd

https://github.com/tangem/tangem-app-ios/assets/24321494/f9a0147d-6ed3-4903-a151-03a7d84ab2e5

