### PR TITLE
IOS-5284 Fix for custom token exist validation

### DIFF
--- a/Tangem/Modules/LegacyTokenList/AddCustomToken/LegacyAddCustomTokenViewModel.swift
+++ b/Tangem/Modules/LegacyTokenList/AddCustomToken/LegacyAddCustomTokenViewModel.swift
@@ -104,6 +104,18 @@ class LegacyAddCustomTokenViewModel: ObservableObject {
             didChangeBlockchain()
         }
         .store(in: &bag)
+
+        // It is necessary to ensure that the steps of validating the existence of a token are not lost, since the validation includes a check for these fields (Line - 243)
+        Publishers.CombineLatest3(
+            $name.removeDuplicates(),
+            $symbol.removeDuplicates(),
+            $decimals.removeDuplicates()
+        )
+        .debounce(for: 0.1, scheduler: RunLoop.main)
+        .sink { [weak self] _ in
+            self?.validate()
+        }
+        .store(in: &bag)
     }
 
     func createToken() {


### PR DESCRIPTION
Баг заключался в следующем:

Когда вводили уже добавленный кастомный токен, кнопка не была заблокирована, и добавление как будто бы проходило, но по факту добавления не происходило, что правильно.

Кнопка была не активна, потому что в методе валидации, была проверка на TokenItem exist которая зависела в свою очередь от Symbol, Decimal, Name

И при вводе этих полей, вариация заново не стартовала.

Решил сделать в лоб, повесил проверку на паблишеры, все равно легаси ...