### PR TITLE
IOS-5505: Delete tx record when opens bottom sheet

### DIFF
--- a/Tangem/App/Services/ExpressDestinationService/CommonExpressDestinationService.swift
+++ b/Tangem/App/Services/ExpressDestinationService/CommonExpressDestinationService.swift
@@ -74,7 +74,7 @@ extension CommonExpressDestinationService: ExpressDestinationService {
 
 private extension CommonExpressDestinationService {
     func isLastTransactionWith(walletModel: WalletModel) -> Bool {
-        let transactions = pendingTransactionRepository.allExpressTransactions
+        let transactions = pendingTransactionRepository.transactions
         let lastCurrency = transactions.last?.destinationTokenTxInfo.tokenItem.expressCurrency
 
         return walletModel.expressCurrency == lastCurrency

--- a/Tangem/App/Services/ExpressPendingTransactionRepository/ExpressPendingTransactionRecord.swift
+++ b/Tangem/App/Services/ExpressPendingTransactionRepository/ExpressPendingTransactionRecord.swift
@@ -22,6 +22,8 @@ struct ExpressPendingTransactionRecord: Codable, Equatable {
     let externalTxId: String?
     let externalTxURL: String?
 
+    // Flag for hide transaction from UI. But keep saving in the storage
+    var isHidden: Bool
     var transactionStatus: PendingExpressTransactionStatus
 
     var fee: Decimal {

--- a/Tangem/App/Services/ExpressPendingTransactionRepository/ExpressPendingTransactionRepository.swift
+++ b/Tangem/App/Services/ExpressPendingTransactionRepository/ExpressPendingTransactionRepository.swift
@@ -11,11 +11,12 @@ import Combine
 import TangemSwapping
 
 protocol ExpressPendingTransactionRepository: AnyObject {
-    var allExpressTransactions: [ExpressPendingTransactionRecord] { get }
-    var pendingCEXTransactionsPublisher: AnyPublisher<[ExpressPendingTransactionRecord], Never> { get }
+    var transactions: [ExpressPendingTransactionRecord] { get }
+    var transactionsPublisher: AnyPublisher<[ExpressPendingTransactionRecord], Never> { get }
 
     func updateItems(_ items: [ExpressPendingTransactionRecord])
     func swapTransactionDidSend(_ txData: SentExpressTransactionData, userWalletId: String)
+    func hideSwapTransaction(with id: String)
 }
 
 private struct ExpressPendingTransactionRepositoryKey: InjectionKey {

--- a/Tangem/App/Utilities/Express/PendingExpressTransactionsConverter.swift
+++ b/Tangem/App/Utilities/Express/PendingExpressTransactionsConverter.swift
@@ -19,7 +19,7 @@ struct PendingExpressTransactionsConverter {
             let destinationTokenItem = record.destinationTokenTxInfo.tokenItem
             let state: PendingExpressTransactionView.State
             switch $0.transactionRecord.transactionStatus {
-            case .awaitingDeposit, .confirming, .exchanging, .sendingToUser, .done, .refunded:
+            case .awaitingDeposit, .confirming, .exchanging, .sendingToUser, .done, .refunded, .expired:
                 state = .inProgress
             case .failed:
                 state = .error

--- a/Tangem/App/Utilities/Express/PendingExpressTransactionsConverter.swift
+++ b/Tangem/App/Utilities/Express/PendingExpressTransactionsConverter.swift
@@ -19,9 +19,7 @@ struct PendingExpressTransactionsConverter {
             let destinationTokenItem = record.destinationTokenTxInfo.tokenItem
             let state: PendingExpressTransactionView.State
             switch $0.transactionRecord.transactionStatus {
-            case .done, .refunded:
-                return nil
-            case .awaitingDeposit, .confirming, .exchanging, .sendingToUser:
+            case .awaitingDeposit, .confirming, .exchanging, .sendingToUser, .done, .refunded:
                 state = .inProgress
             case .failed:
                 state = .error

--- a/Tangem/Modules/TokenDetails/ExpressBottomSheet/PendingExpressTxStatusBottomSheetView.swift
+++ b/Tangem/Modules/TokenDetails/ExpressBottomSheet/PendingExpressTxStatusBottomSheetView.swift
@@ -215,6 +215,7 @@ struct ExpressPendingTxStatusBottomSheetView_Preview: PreviewProvider {
             date: Date(),
             externalTxId: "a34883e049a416",
             externalTxURL: "https://changenow.io/exchange/txs/a34883e049a416",
+            isHidden: false,
             transactionStatus: .awaitingDeposit
         )
         let pendingTransaction = factory.buildPendingExpressTransaction(currentExpressStatus: .sending, for: record)

--- a/Tangem/Modules/TokenDetails/ExpressBottomSheet/PendingExpressTxStatusBottomSheetViewModel.swift
+++ b/Tangem/Modules/TokenDetails/ExpressBottomSheet/PendingExpressTxStatusBottomSheetViewModel.swift
@@ -169,6 +169,9 @@ class PendingExpressTxStatusBottomSheetViewModel: ObservableObject, Identifiable
                     return
                 }
 
+                if !pendingTx.transactionRecord.transactionStatus.isTransactionInProgress {
+                    viewModel.pendingTransactionsManager.removeTransaction(with: pendingTx.transactionRecord.expressTransactionId)
+                }
                 viewModel.updateUI(with: pendingTx, delay: Constants.notificationAnimationDelay)
             }
     }

--- a/Tangem/Modules/TokenDetails/ExpressBottomSheet/PendingExpressTxStatusBottomSheetViewModel.swift
+++ b/Tangem/Modules/TokenDetails/ExpressBottomSheet/PendingExpressTxStatusBottomSheetViewModel.swift
@@ -170,8 +170,9 @@ class PendingExpressTxStatusBottomSheetViewModel: ObservableObject, Identifiable
                 }
 
                 if !pendingTx.transactionRecord.transactionStatus.isTransactionInProgress {
-                    viewModel.pendingTransactionsManager.removeTransaction(with: pendingTx.transactionRecord.expressTransactionId)
+                    viewModel.pendingTransactionsManager.hideTransaction(with: pendingTx.transactionRecord.expressTransactionId)
                 }
+
                 viewModel.updateUI(with: pendingTx, delay: Constants.notificationAnimationDelay)
             }
     }


### PR DESCRIPTION
Плашка в деталке токена должна висеть до тех пор, пока пользователь не откроет боттом щит. В менеджере выглядит как хак, но пока не придумал лучший вариант, как разделять на 2 массива транзакций, которые прошли и которые ещё в процессе, запрашивать статус только по тем что в процессе и потом мержить не теряя очередность транзакций