### PR TITLE
IOS-5775: Custom token contract adress mismatch

### DIFF
--- a/Tangem/Modules/AddCustomToken/AddCustomTokenViewModel.swift
+++ b/Tangem/Modules/AddCustomToken/AddCustomTokenViewModel.swift
@@ -373,6 +373,7 @@ final class AddCustomTokenViewModel: ObservableObject, Identifiable {
             decimals = "\(token.decimalCount)"
             symbol = token.symbol
             name = token.name
+            contractAddress = token.contractAddress
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                 UIApplication.shared.endEditing()

--- a/Tangem/Modules/LegacyTokenList/AddCustomToken/LegacyAddCustomTokenViewModel.swift
+++ b/Tangem/Modules/LegacyTokenList/AddCustomToken/LegacyAddCustomTokenViewModel.swift
@@ -386,6 +386,7 @@ class LegacyAddCustomTokenViewModel: ObservableObject {
             decimals = "\(token.decimalCount)"
             symbol = token.symbol
             name = token.name
+            contractAddress = token.contractAddress
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                 UIApplication.shared.endEditing()


### PR DESCRIPTION
[IOS-5775](https://tangem.atlassian.net/browse/IOS-5775)

Баг не связан с вичейном и воспроизводится для всех сетей.

Условия для воспроизведения:
1. Пользователь добавляет кастомный токен по адресу контракта
2. Этот токен есть в выдаче ручки `api.tangem-tech.com/v1/coins`
3. Адрес контракта, который использует пользователь - отличается регистром от адреса контракта, который отдает ручка (`0x0000000000000000000000000000456E65726779` и `0x0000000000000000000000000000456e65726779` как пример из таски)

Можно пофиксить этот баг по разному (например делая в локальном сторейдже при удалении токена поиск по адресу контракта без учета регистра), но мне кажется, что корректнее использовать бек как source of truth и брать актуальную инфу (в частности адрес контракта в правильном регистре) с него.

[IOS-5775]: https://tangem.atlassian.net/browse/IOS-5775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ