### PR TITLE
IOS-5837 Expand `SendDecimalNumberTextField` tappable area 

### DIFF
--- a/Tangem/Common/UI/SendGroupedNumberTextField/FocusedDecimalNumberTextField.swift
+++ b/Tangem/Common/UI/SendGroupedNumberTextField/FocusedDecimalNumberTextField.swift
@@ -14,12 +14,15 @@ import SwiftUI
 struct FocusedDecimalNumberTextField<ToolbarButton: View>: View {
     @Binding private var decimalValue: DecimalNumberTextField.DecimalValue?
     @FocusState private var isInputActive: Bool
+    @State private var textFieldSize: CGSize = .zero
     private let toolbarButton: () -> ToolbarButton
 
+    private var shouldFocusOnAppear: Bool = true
     private var maximumFractionDigits: Int
     private var placeholderColor: Color = Colors.Text.disabled
     private var textColor: Color = Colors.Text.primary1
     private var font: Font = Fonts.Regular.title1
+    private var alignment: Alignment = .leading
     private var suffix: String? = nil
     private var suffixColor: Color {
         switch decimalValue {
@@ -41,16 +44,28 @@ struct FocusedDecimalNumberTextField<ToolbarButton: View>: View {
     }
 
     var body: some View {
-        HStack(alignment: .bottom, spacing: 8) {
-            textField
+        ZStack(alignment: alignment) {
+            HStack(alignment: .center, spacing: 8) {
+                textField
 
-            if let suffix {
-                Text(suffix)
-                    .style(font, color: suffixColor)
-                    .onTapGesture {
-                        isInputActive = true
-                    }
+                if let suffix {
+                    Text(suffix)
+                        .style(font, color: suffixColor)
+                        .onTapGesture {
+                            isInputActive = true
+                        }
+                }
             }
+            .readGeometry(\.frame.size, bindTo: $textFieldSize)
+
+            // Expand the tappable area
+            Color.clear
+                .frame(maxWidth: .infinity)
+                .contentShape(Rectangle())
+                .frame(height: textFieldSize.height)
+                .onTapGesture {
+                    isInputActive = true
+                }
         }
         .lineLimit(1)
     }
@@ -80,7 +95,9 @@ struct FocusedDecimalNumberTextField<ToolbarButton: View>: View {
             }
         }
         .onAppear {
-            isInputActive = true
+            if shouldFocusOnAppear {
+                isInputActive = true
+            }
         }
     }
 }
@@ -100,6 +117,14 @@ extension FocusedDecimalNumberTextField: Setupable {
     func suffix(_ suffix: String?) -> Self {
         map { $0.suffix = suffix }
     }
+
+    func alignment(_ alignment: Alignment) -> Self {
+        map { $0.alignment = alignment }
+    }
+
+    func shouldFocusOnAppear(_ shouldFocusOnAppear: Bool) -> Self {
+        map { $0.shouldFocusOnAppear = shouldFocusOnAppear }
+    }
 }
 
 @available(iOS 15.0, *)
@@ -109,8 +134,14 @@ struct FocusedNumberTextField_Previews: PreviewProvider {
     static var previews: some View {
         StatefulPreviewWrapper(decimalValue) { decimalValue in
             FocusedDecimalNumberTextField(decimalValue: decimalValue, maximumFractionDigits: 8) {}
+                .suffix("USDT")
+                .alignment(.center)
+                .padding()
+                .background(Colors.Background.action)
+                .padding()
         }
+        .frame(maxWidth: .infinity)
         .padding()
-        .border(Color.purple)
+        .background(Colors.Background.tertiary)
     }
 }

--- a/Tangem/Common/UI/SendGroupedNumberTextField/SendDecimalNumberTextField.swift
+++ b/Tangem/Common/UI/SendGroupedNumberTextField/SendDecimalNumberTextField.swift
@@ -12,10 +12,12 @@ import SwiftUI
 struct SendDecimalNumberTextField: View {
     @Binding private var decimalValue: DecimalNumberTextField.DecimalValue?
 
+    private var shouldFocusOnAppear: Bool = true
     private var maximumFractionDigits: Int
     private var maxAmountAction: (() -> Void)?
     private var suffix: String? = nil
     private var font: Font = Fonts.Regular.title1
+    private var alignment: Alignment = .leading
 
     init(decimalValue: Binding<DecimalNumberTextField.DecimalValue?>, maximumFractionDigits: Int) {
         _decimalValue = decimalValue
@@ -35,6 +37,8 @@ struct SendDecimalNumberTextField: View {
             .maximumFractionDigits(maximumFractionDigits)
             .font(font)
             .suffix(suffix)
+            .alignment(alignment)
+            .shouldFocusOnAppear(shouldFocusOnAppear)
         } else {
             DecimalNumberTextField(
                 decimalValue: $decimalValue,
@@ -63,6 +67,14 @@ extension SendDecimalNumberTextField: Setupable {
 
     func font(_ font: Font) -> Self {
         map { $0.font = font }
+    }
+
+    func alignment(_ alignment: Alignment) -> Self {
+        map { $0.alignment = alignment }
+    }
+
+    func shouldFocusOnAppear(_ shouldFocusOnAppear: Bool) -> Self {
+        map { $0.shouldFocusOnAppear = shouldFocusOnAppear }
     }
 }
 
@@ -93,6 +105,7 @@ struct SendDecimalNumberTextField_Previews: PreviewProvider {
                 SendDecimalNumberTextField(decimalValue: $decimalValue, maximumFractionDigits: 8)
                     .suffix("USDT")
                     .font(Fonts.Regular.body)
+                    .alignment(.leading)
                     .padding()
                     .background(Colors.Background.action)
             }

--- a/Tangem/Modules/Send/Amount/SendAmountView.swift
+++ b/Tangem/Modules/Send/Amount/SendAmountView.swift
@@ -39,6 +39,7 @@ struct SendAmountView: View {
                         decimalValue: $viewModel.amount,
                         maximumFractionDigits: viewModel.amountFractionDigits
                     )
+                    .alignment(.center)
                     .suffix(viewModel.useFiatCalculation ? viewModel.fiatCurrencyCode : viewModel.cryptoCurrencyCode)
                     .padding(.top, 16)
 

--- a/Tangem/Modules/Send/Fee/SendCustomFeeInputField.swift
+++ b/Tangem/Modules/Send/Fee/SendCustomFeeInputField.swift
@@ -23,6 +23,7 @@ struct SendCustomFeeInputField: View {
                         decimalValue: $viewModel.amount,
                         maximumFractionDigits: viewModel.fractionDigits
                     )
+                    .shouldFocusOnAppear(false)
                     .suffix("WEI")
                     .font(Fonts.Regular.subheadline)
 


### PR DESCRIPTION
Увеличил место для включения установки фокуса
Добавил флаг для отключения автофокуса при `onAppear`

![Screenshot 2024-02-05 at 09 07 20](https://github.com/tangem/tangem-app-ios/assets/25799680/204141c8-3083-45da-94c3-fe7742850c78)
![IMG_3577](https://github.com/tangem/tangem-app-ios/assets/25799680/0404b33d-3acb-49b4-a6b2-43e159aa1c89)
![IMG_3578](https://github.com/tangem/tangem-app-ios/assets/25799680/11cd242e-2d5c-43b0-908c-2b1cfee98293)
