### PR TITLE
IOS-5926 ptr not work iOS 15

### DIFF
--- a/Tangem/Common/UI/RefreshableScrollView.swift
+++ b/Tangem/Common/UI/RefreshableScrollView.swift
@@ -11,10 +11,8 @@ import SwiftUI
 typealias RefreshCompletionHandler = () -> Void
 typealias OnRefresh = (_ completionHandler: @escaping RefreshCompletionHandler) -> Void
 
-// TODO: Will be deleted in IOS-5885
 /// Author: The SwiftUI Lab.
 /// Full article: https://swiftui-lab.com/scrollview-pull-to-refresh/.
-@available(*, deprecated, message: "Will be removed in IOS-5885. Place `refreshable` modifier with async func instead of this view")
 struct RefreshableScrollView<Content: View>: View {
     let onRefresh: OnRefresh
     let content: Content
@@ -28,11 +26,15 @@ struct RefreshableScrollView<Content: View>: View {
     }
 
     var body: some View {
-        ScrollView(.vertical, showsIndicators: false) {
-            content
-        }
-        .refreshable {
-            await refreshAsync()
+        if #available(iOS 16, *) {
+            ScrollView(.vertical, showsIndicators: false) {
+                content
+            }
+            .refreshable {
+                await refreshAsync()
+            }
+        } else {
+            RefreshableScrollViewCompat(onRefresh: onRefresh, content: content)
         }
     }
 
@@ -43,6 +45,195 @@ struct RefreshableScrollView<Content: View>: View {
                 continuation.resume()
             }
         }
+    }
+}
+
+@available(iOS, obsoleted: 16, message: "iOS 15 doesn't fully support refreshable for ScrollView. Can be removed after update min OS version to 16 (IOS-5885)")
+private struct RefreshableScrollViewCompat<Content: View>: View {
+    @State private var previousScrollOffset: CGFloat = 0
+    @State private var scrollOffset: CGFloat = 0
+    @State private var frozen: Bool = false
+    @State private var rotation: Angle = .degrees(0)
+    @State private var alpha: Double = 0
+    @State private var refreshing: Bool = false
+    var threshold: CGFloat = 100
+    let onRefresh: OnRefresh
+    let content: Content
+
+    var body: some View {
+        VStack {
+            ScrollView(.vertical, showsIndicators: false) {
+                ZStack(alignment: .top) {
+                    MovingView()
+
+                    VStack {
+                        content
+                    }
+                    .alignmentGuide(
+                        .top,
+                        computeValue: { _ in (refreshing && frozen) ? -threshold : 0.0 }
+                    )
+
+                    SymbolView(
+                        height: threshold,
+                        loading: refreshing,
+                        frozen: frozen,
+                        rotation: rotation,
+                        alpha: alpha
+                    )
+                }
+            }
+            .background(FixedView())
+            .onPreferenceChange(RefreshableKeyTypes.PrefKey.self) { values in
+                refreshLogic(values: values)
+            }
+        }
+    }
+
+    private func refreshLogic(values: [RefreshableKeyTypes.PrefData]) {
+        // `DispatchQueue.main.async` used here to allow publishing changes during view update
+        DispatchQueue.main.async {
+            // Calculating scroll offset
+            let movingBounds = values.first { $0.vType == .movingView }?.bounds ?? .zero
+            let fixedBounds = values.first { $0.vType == .fixedView }?.bounds ?? .zero
+
+            scrollOffset = movingBounds.minY - fixedBounds.minY
+
+            rotation = symbolRotation(scrollOffset)
+            alpha = symbolAlpha(scrollOffset)
+
+            // Crossing the threshold on the way down, we start the refresh process
+            if !refreshing, scrollOffset > threshold, previousScrollOffset <= threshold {
+                refreshing = true
+
+                // The consumer of this view may and most likely will change view hierarchy in `onRefresh` closure,
+                // which in turn will interfere with view hierarchy changes made by changing our `frozen`/`refreshing`
+                // state variables.
+                // To prevent it, we're notifying the consumer of this view about triggered pull-to-refresh with some delay.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    onRefresh {
+                        withAnimation {
+                            refreshing = false
+                        }
+                    }
+                }
+            }
+            if refreshing {
+                // Crossing the threshold on the way up, we add a space at the top of the scrollview
+                if previousScrollOffset > threshold, scrollOffset < previousScrollOffset {
+                    frozen = true
+                }
+            } else {
+                // Removing the space at the top of the scroll view
+                frozen = false
+            }
+
+            // Updating last scroll offset
+            previousScrollOffset = scrollOffset
+        }
+    }
+
+    private func symbolAnimationProgress(_ scrollOffset: CGFloat) -> Double {
+        // We will begin rotation, only after we have passed
+        // 60% of the way of reaching the threshold.
+        let h = Double(threshold)
+        let d = Double(scrollOffset)
+        let v = max(min(d - (h * 0.6), h * 0.4), 0)
+        return v / (h * 0.4)
+    }
+
+    private func symbolRotation(_ scrollOffset: CGFloat) -> Angle {
+        return .degrees(180 * symbolAnimationProgress(scrollOffset))
+    }
+
+    private func symbolAlpha(_ scrollOffset: Double) -> Double {
+        return symbolAnimationProgress(scrollOffset)
+    }
+
+    private struct SymbolView: View {
+        var height: CGFloat
+        var loading: Bool
+        var frozen: Bool
+        var rotation: Angle
+        var alpha: Double
+        var body: some View {
+            Group {
+                if loading { // If loading, show the activity control
+                    VStack {
+                        Spacer()
+                        ProgressView()
+                        Spacer()
+                    }.frame(height: height).fixedSize()
+                        .offset(y: -height + (loading && frozen ? height : 0.0))
+                } else {
+                    Image(systemName: "arrow.down") // If not loading, show the arrow
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: height * 0.25, height: height * 0.25).fixedSize()
+                        .padding(height * 0.375)
+                        .rotationEffect(rotation)
+                        .opacity(alpha)
+                        .offset(y: -height + (loading && frozen ? +height : 0.0))
+                }
+            }
+        }
+    }
+
+    private struct MovingView: View {
+        var body: some View {
+            GeometryReader { proxy in
+                Color.clear
+                    .preference(
+                        key: RefreshableKeyTypes.PrefKey.self,
+                        value: [
+                            RefreshableKeyTypes.PrefData(
+                                vType: .movingView,
+                                bounds: proxy.frame(in: .global)
+                            ),
+                        ]
+                    )
+            }.frame(height: 0)
+        }
+    }
+
+    private struct FixedView: View {
+        var body: some View {
+            GeometryReader { proxy in
+                Color.clear
+                    .preference(
+                        key: RefreshableKeyTypes.PrefKey.self,
+                        value: [
+                            RefreshableKeyTypes.PrefData(
+                                vType: .fixedView,
+                                bounds: proxy.frame(in: .global)
+                            ),
+                        ]
+                    )
+            }
+        }
+    }
+}
+
+@available(iOS, obsoleted: 16, message: "iOS 15 doesn't fully support refreshable for ScrollView. Can be removed after update min OS version to 16 (IOS-5885)")
+private enum RefreshableKeyTypes {
+    enum ViewType: Int {
+        case movingView
+        case fixedView
+    }
+
+    fileprivate struct PrefData: Equatable {
+        let vType: ViewType
+        let bounds: CGRect
+    }
+
+    fileprivate struct PrefKey: PreferenceKey {
+        static var defaultValue: [PrefData] = []
+
+        static func reduce(value: inout [PrefData], nextValue: () -> [PrefData]) {
+            value.append(contentsOf: nextValue())
+        }
+
+        typealias Value = [PrefData]
     }
 }
 

--- a/Tangem/Common/UI/RefreshableScrollView.swift
+++ b/Tangem/Common/UI/RefreshableScrollView.swift
@@ -56,6 +56,9 @@ private struct RefreshableScrollViewCompat<Content: View>: View {
     @State private var rotation: Angle = .degrees(0)
     @State private var alpha: Double = 0
     @State private var refreshing: Bool = false
+
+    private let coordinateSpaceName = UUID()
+
     var threshold: CGFloat = 100
     let onRefresh: OnRefresh
     let content: Content
@@ -63,17 +66,7 @@ private struct RefreshableScrollViewCompat<Content: View>: View {
     var body: some View {
         VStack {
             ScrollView(.vertical, showsIndicators: false) {
-                ZStack(alignment: .top) {
-                    MovingView()
-
-                    VStack {
-                        content
-                    }
-                    .alignmentGuide(
-                        .top,
-                        computeValue: { _ in (refreshing && frozen) ? -threshold : 0.0 }
-                    )
-
+                VStack(spacing: 0) {
                     SymbolView(
                         height: threshold,
                         loading: refreshing,
@@ -81,65 +74,79 @@ private struct RefreshableScrollViewCompat<Content: View>: View {
                         rotation: rotation,
                         alpha: alpha
                     )
+
+                    content
+                }
+                .offset(y: -threshold + ((refreshing && frozen) ? threshold : 0.0))
+                .readContentOffset(inCoordinateSpace: .named(coordinateSpaceName)) { value in
+                    refreshLogic(offset: value)
                 }
             }
-            .background(FixedView())
-            .onPreferenceChange(RefreshableKeyTypes.PrefKey.self) { values in
-                refreshLogic(values: values)
-            }
+            .coordinateSpace(name: coordinateSpaceName)
         }
     }
 
-    private func refreshLogic(values: [RefreshableKeyTypes.PrefData]) {
-        // `DispatchQueue.main.async` used here to allow publishing changes during view update
-        DispatchQueue.main.async {
-            // Calculating scroll offset
-            let movingBounds = values.first { $0.vType == .movingView }?.bounds ?? .zero
-            let fixedBounds = values.first { $0.vType == .fixedView }?.bounds ?? .zero
+    private struct SymbolView: View {
+        var height: CGFloat
+        var loading: Bool
+        var frozen: Bool
+        var rotation: Angle
+        var alpha: Double
+        var body: some View {
+            ZStack {
+                VStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+                .opacity(loading ? 1.0 : 0.0)
 
-            scrollOffset = movingBounds.minY - fixedBounds.minY
+                Image(systemName: "arrow.down") // If not loading, show the arrow
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: height * 0.25, height: height * 0.25)
+                    .padding(height * 0.375)
+                    .rotationEffect(rotation)
+                    .opacity(loading ? 0 : alpha)
+            }
+            .frame(height: height)
+        }
+    }
 
-            rotation = symbolRotation(scrollOffset)
-            alpha = symbolAlpha(scrollOffset)
+    private func refreshLogic(offset: CGPoint) {
+        scrollOffset = -offset.y
 
-            // Crossing the threshold on the way down, we start the refresh process
-            if !refreshing, scrollOffset > threshold, previousScrollOffset <= threshold {
-                refreshing = true
+        rotation = symbolRotation(scrollOffset)
+        alpha = symbolAlpha(scrollOffset)
 
-                // The consumer of this view may and most likely will change view hierarchy in `onRefresh` closure,
-                // which in turn will interfere with view hierarchy changes made by changing our `frozen`/`refreshing`
-                // state variables.
-                // To prevent it, we're notifying the consumer of this view about triggered pull-to-refresh with some delay.
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    onRefresh {
-                        withAnimation {
-                            refreshing = false
-                        }
+        // Crossing the threshold on the way down, we start the refresh process
+        if !refreshing, scrollOffset > threshold, previousScrollOffset <= threshold {
+            refreshing = true
+
+            // The consumer of this view may and most likely will change view hierarchy in `onRefresh` closure,
+            // which in turn will interfere with view hierarchy changes made by changing our `frozen`/`refreshing`
+            // state variables.
+            // To prevent it, we're notifying the consumer of this view about triggered pull-to-refresh with some delay.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                onRefresh {
+                    withAnimation {
+                        refreshing = false
                     }
                 }
             }
-            if refreshing {
-                // Crossing the threshold on the way up, we add a space at the top of the scrollview
-                if previousScrollOffset > threshold, scrollOffset < previousScrollOffset {
-                    frozen = true
-                }
-            } else {
-                // Removing the space at the top of the scroll view
-                frozen = false
-            }
-
-            // Updating last scroll offset
-            previousScrollOffset = scrollOffset
         }
-    }
+        if refreshing {
+            // Crossing the threshold on the way up, we add a space at the top of the scrollview
+            if previousScrollOffset > threshold, scrollOffset < previousScrollOffset {
+                frozen = true
+            }
+        } else {
+            // Removing the space at the top of the scroll view
+            frozen = false
+        }
 
-    private func symbolAnimationProgress(_ scrollOffset: CGFloat) -> Double {
-        // We will begin rotation, only after we have passed
-        // 60% of the way of reaching the threshold.
-        let h = Double(threshold)
-        let d = Double(scrollOffset)
-        let v = max(min(d - (h * 0.6), h * 0.4), 0)
-        return v / (h * 0.4)
+        // Updating last scroll offset
+        previousScrollOffset = scrollOffset
     }
 
     private func symbolRotation(_ scrollOffset: CGFloat) -> Angle {
@@ -150,90 +157,13 @@ private struct RefreshableScrollViewCompat<Content: View>: View {
         return symbolAnimationProgress(scrollOffset)
     }
 
-    private struct SymbolView: View {
-        var height: CGFloat
-        var loading: Bool
-        var frozen: Bool
-        var rotation: Angle
-        var alpha: Double
-        var body: some View {
-            Group {
-                if loading { // If loading, show the activity control
-                    VStack {
-                        Spacer()
-                        ProgressView()
-                        Spacer()
-                    }.frame(height: height).fixedSize()
-                        .offset(y: -height + (loading && frozen ? height : 0.0))
-                } else {
-                    Image(systemName: "arrow.down") // If not loading, show the arrow
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: height * 0.25, height: height * 0.25).fixedSize()
-                        .padding(height * 0.375)
-                        .rotationEffect(rotation)
-                        .opacity(alpha)
-                        .offset(y: -height + (loading && frozen ? +height : 0.0))
-                }
-            }
-        }
-    }
-
-    private struct MovingView: View {
-        var body: some View {
-            GeometryReader { proxy in
-                Color.clear
-                    .preference(
-                        key: RefreshableKeyTypes.PrefKey.self,
-                        value: [
-                            RefreshableKeyTypes.PrefData(
-                                vType: .movingView,
-                                bounds: proxy.frame(in: .global)
-                            ),
-                        ]
-                    )
-            }.frame(height: 0)
-        }
-    }
-
-    private struct FixedView: View {
-        var body: some View {
-            GeometryReader { proxy in
-                Color.clear
-                    .preference(
-                        key: RefreshableKeyTypes.PrefKey.self,
-                        value: [
-                            RefreshableKeyTypes.PrefData(
-                                vType: .fixedView,
-                                bounds: proxy.frame(in: .global)
-                            ),
-                        ]
-                    )
-            }
-        }
-    }
-}
-
-@available(iOS, obsoleted: 16, message: "iOS 15 doesn't fully support refreshable for ScrollView. Can be removed after update min OS version to 16 (IOS-5885)")
-private enum RefreshableKeyTypes {
-    enum ViewType: Int {
-        case movingView
-        case fixedView
-    }
-
-    fileprivate struct PrefData: Equatable {
-        let vType: ViewType
-        let bounds: CGRect
-    }
-
-    fileprivate struct PrefKey: PreferenceKey {
-        static var defaultValue: [PrefData] = []
-
-        static func reduce(value: inout [PrefData], nextValue: () -> [PrefData]) {
-            value.append(contentsOf: nextValue())
-        }
-
-        typealias Value = [PrefData]
+    private func symbolAnimationProgress(_ scrollOffset: CGFloat) -> Double {
+        // We will begin rotation, only after we have passed
+        // 60% of the way of reaching the threshold.
+        let h = Double(threshold)
+        let d = Double(scrollOffset)
+        let v = max(min(d - (h * 0.6), h * 0.4), 0)
+        return v / (h * 0.4)
     }
 }
 

--- a/Tangem/Modules/Main/MainHeaderView/MainHeaderView.swift
+++ b/Tangem/Modules/Main/MainHeaderView/MainHeaderView.swift
@@ -19,9 +19,9 @@ struct MainHeaderView: View {
     @State private var balanceTextSize: CGSize = .zero
 
     var body: some View {
-        HStack(alignment: .bottom, spacing: 0) {
-            let contentSettings = contentSettings(containerWidth: containerSize.width)
+        let contentSettings = contentSettings(containerWidth: containerSize.width)
 
+        return HStack(alignment: .bottom, spacing: 0) {
             VStack(alignment: .leading, spacing: 0) {
                 titleView
 
@@ -54,8 +54,9 @@ struct MainHeaderView: View {
             }
             .lineLimit(1)
             .padding(.vertical, 12)
-
-            if contentSettings.shouldShowTrailingContent {
+        }
+        .background(alignment: .bottom, content: {
+            HStack {
                 Spacer(minLength: horizontalSpacing)
 
                 // A transparent 1px image is used to preserve the structural identity of the view,
@@ -66,7 +67,8 @@ struct MainHeaderView: View {
                 Image(viewModel.cardImage?.name ?? Assets.clearColor1px.name)
                     .frame(size: imageSize)
             }
-        }
+            .hidden(!contentSettings.shouldShowTrailingContent)
+        })
         .readGeometry(\.size, bindTo: $containerSize)
         .padding(.horizontal, 14)
         .background(Colors.Background.primary)


### PR DESCRIPTION
Пришлось переделать разметку, из-за того что `ZStack` внутри `ScrollView` начинал тупить и заголовок карточки на главной не растягивался до нужного размера, в итоге заголовок отжирал размер у контента (текстовки в блоке истории транзакции обрезались до 1 строки, а заголовок растягивался на эту же величину, вообще хз какого хрена...). Это первая проблема. 

на 16 оси с новым `refreshable` модификатором

https://github.com/tangem/tangem-app-ios/assets/24321494/697ab228-8cfc-4c9e-8a9a-26d029725665

Вторая проблема - внезапное появление изображения карточек при скане новой карты. Это опять же происходило из-за смены разметки в заголовке. При переезде с `NSAttributedString` на `AttributedString` пропала возможность ручками посчитать размер заголовка, пришлось добавить невидимую вьюху, которая считает ширину баланса и обновляет стейт. В общем сделал в виде бэкграунд вьюхи и меняю прозрачность, тогда разметка всегда одинаковая и все норм.

на 16 оси со старой реализацией `PTR`.

https://github.com/tangem/tangem-app-ios/assets/24321494/52c6f89b-2a78-469c-8c74-deb5ccd6c8c7

@m3g0byt3 посмотри, пожалуйста,  на 15 оси нормально ли работает ПТР + сканирование новой карточки с изображением.

Из известных глитчей:
1. для мультивалюток при старой реализации PTR иногда происходит `прыгание` списка токенов, такое же как прыгание кнопок в деталке токена. Пока что нет идей как править.
2. при увеличенных шрифтах пока грузится баланс заголовок показывается в неправильном размере, а после отображения баланса обновляется на правильный. Это проблема со скелетоном, завел задачку [IOS-5978](https://tangem.atlassian.net/browse/IOS-5978)


[IOS-5978]: https://tangem.atlassian.net/browse/IOS-5978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ