### PR TITLE
IOS-5859 wc error analytics updates

### DIFF
--- a/Tangem/App/Services/Analytics/Analytics+ParameterKey.swift
+++ b/Tangem/App/Services/Analytics/Analytics+ParameterKey.swift
@@ -13,7 +13,7 @@ extension Analytics {
         case blockchain
         case firmware = "Firmware"
         case action
-        case errorDescription = "error_description"
+        case errorDescription = "Error Description"
         case errorCode = "Error Code"
         case newSecOption = "new_security_option"
         case errorKey = "Tangem SDK error key"

--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
@@ -451,8 +451,16 @@ final class WalletConnectV2Service {
         if let error {
             params[.validation] = Analytics.ParameterValue.fail.rawValue
             params[.errorCode] = "\(error.code)"
+            let errorDescription: String
+            if case .unknown(let externalErrorMessage) = error {
+                errorDescription = externalErrorMessage
+            } else {
+                errorDescription = error.errorDescription ?? "No error description"
+            }
+            params[.errorDescription] = errorDescription
         } else {
             params[.validation] = Analytics.ParameterValue.success.rawValue
+            params[.errorCode] = "0"
         }
 
         Analytics.log(event: .requestHandled, params: params)


### PR DESCRIPTION
* Добавил 0 код ошибки для WC ошибок, чтобы лучше группировались они. 
* Для кейса `unknown` вытаскивается ошибка, которую перехватили из библиотеки, чтобы не было текста, который мы показываем пользователям + локализации.
* Леша попросил ещё поменять ключевик с `error_description` -> `Error Description`, он согласен на то что некоторое время аналитика из-за этого поедет и будет кривой.


![image](https://github.com/tangem/tangem-app-ios/assets/24321494/a66ea452-9d1a-446d-b80b-f5eccc474923)

![image](https://github.com/tangem/tangem-app-ios/assets/24321494/07015392-a9e4-4e73-aaca-d2c9c00b2b15)
