### PR TITLE
IOS-5976 [Express] Don't hide keyboard

### DIFF
--- a/Tangem/Common/Extensions/UIKit/UIResponder+.swift
+++ b/Tangem/Common/Extensions/UIKit/UIResponder+.swift
@@ -1,0 +1,24 @@
+//
+//  UIResponder+.swift
+//  Tangem
+//
+//  Created by Sergey Balashov on 21.02.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import UIKit
+
+extension UIResponder {
+    private weak static var currentFirstResponder: UIResponder?
+
+    public static var current: UIResponder? {
+        UIResponder.currentFirstResponder = nil
+        UIApplication.shared.sendAction(#selector(findFirstResponder(sender:)), to: nil, from: nil, for: nil)
+        return UIResponder.currentFirstResponder
+    }
+
+    @objc
+    private func findFirstResponder(sender: AnyObject) {
+        UIResponder.currentFirstResponder = self
+    }
+}

--- a/Tangem/Modules/ExpressView/ExpressCoordinator.swift
+++ b/Tangem/Modules/ExpressView/ExpressCoordinator.swift
@@ -61,17 +61,14 @@ extension ExpressCoordinator {
 
 extension ExpressCoordinator: ExpressRoutable {
     func presentSwappingTokenList(swapDirection: ExpressTokensListViewModel.SwapDirection) {
-        UIApplication.shared.endEditing()
         expressTokensListViewModel = factory.makeExpressTokensListViewModel(swapDirection: swapDirection, coordinator: self)
     }
 
     func presentFeeSelectorView() {
-        UIApplication.shared.endEditing()
         expressFeeSelectorViewModel = factory.makeExpressFeeSelectorViewModel(coordinator: self)
     }
 
     func presentApproveView() {
-        UIApplication.shared.endEditing()
         expressApproveViewModel = factory.makeExpressApproveViewModel(coordinator: self)
     }
 
@@ -95,7 +92,6 @@ extension ExpressCoordinator: ExpressRoutable {
     }
 
     func presentProviderSelectorView() {
-        UIApplication.shared.endEditing()
         expressProvidersSelectorViewModel = factory.makeExpressProvidersSelectorViewModel(coordinator: self)
     }
 

--- a/Tangem/UIComponents/BottomSheet/BottomSheetModifier.swift
+++ b/Tangem/UIComponents/BottomSheet/BottomSheetModifier.swift
@@ -84,7 +84,15 @@ struct BottomSheetModifier<Item: Identifiable, ContentView: View>: ViewModifier 
     }
 
     func hideController() {
-        controller?.dismiss(animated: false) {
+        // If we have a first responder
+        // Will be better to dismiss the UIViewController with animation
+        // Because it provides a good animation for opening the keyboard
+        // If we don't have a responder we have to dismiss the UIViewController without animation
+        // Because it provide a freeze screen in 0.2 seconds
+
+        let hasFirstResponder = UIResponder.current != nil
+
+        controller?.dismiss(animated: hasFirstResponder) {
             // We should deinit controller to avoid unnecessary call update(item:) method
             controller = nil
             item = nil

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -1015,6 +1015,7 @@
 		EF032C502955C59E006C1FF3 /* DefaultSelectableRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF032C4E2955C59E006C1FF3 /* DefaultSelectableRowViewModel.swift */; };
 		EF032C512955C59E006C1FF3 /* DefaultSelectableRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF032C4F2955C59E006C1FF3 /* DefaultSelectableRowView.swift */; };
 		EF032C532955C725006C1FF3 /* CheckIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF032C522955C725006C1FF3 /* CheckIconView.swift */; };
+		EF033B182B8631C700A71600 /* UIResponder+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF033B172B8631C700A71600 /* UIResponder+.swift */; };
 		EF07082C2A16474F0072AA0E /* FeeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF07082B2A16474F0072AA0E /* FeeFormatter.swift */; };
 		EF07082F2A16476F0072AA0E /* CommonFeeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF07082E2A16476F0072AA0E /* CommonFeeFormatter.swift */; };
 		EF08A0EF283D1914008BD923 /* Moya+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF08A0EE283D1914008BD923 /* Moya+.swift */; };
@@ -2460,6 +2461,7 @@
 		EF032C4E2955C59E006C1FF3 /* DefaultSelectableRowViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultSelectableRowViewModel.swift; sourceTree = "<group>"; };
 		EF032C4F2955C59E006C1FF3 /* DefaultSelectableRowView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultSelectableRowView.swift; sourceTree = "<group>"; };
 		EF032C522955C725006C1FF3 /* CheckIconView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CheckIconView.swift; sourceTree = "<group>"; };
+		EF033B172B8631C700A71600 /* UIResponder+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIResponder+.swift"; sourceTree = "<group>"; };
 		EF07082B2A16474F0072AA0E /* FeeFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeeFormatter.swift; sourceTree = "<group>"; };
 		EF07082E2A16476F0072AA0E /* CommonFeeFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonFeeFormatter.swift; sourceTree = "<group>"; };
 		EF08A0EE283D1914008BD923 /* Moya+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Moya+.swift"; sourceTree = "<group>"; };
@@ -4197,6 +4199,7 @@
 				B6176A792A5B743A0062C399 /* CGRect+.swift */,
 				B644EC262ACBF217007D9F4B /* UIPanGestureRecognizer+Value.swift */,
 				2D2ACE192B30FAA90004CBB6 /* PresentationConfigurationViewModifier.swift */,
+				EF033B172B8631C700A71600 /* UIResponder+.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -8995,6 +8998,7 @@
 				DA559C392B0261F400F59584 /* SendViewModel.swift in Sources */,
 				EF9E2A4E2B56A54400418559 /* ExpressModulesFactoryMock.swift in Sources */,
 				EF56B3D22A03AFDB002CCE27 /* DefaultMenuRowView.swift in Sources */,
+				EF033B182B8631C700A71600 /* UIResponder+.swift in Sources */,
 				DA559C422B0261F400F59584 /* SendStep.swift in Sources */,
 				2D5EBAA72ADD15EA00A25AC4 /* ManageTokensNetworkSelectorViewModel.swift in Sources */,
 				B04718FF2B4E7C3B00444734 /* VisaBalancesLimitsBottomSheetView.swift in Sources */,


### PR DESCRIPTION
Если просто убрать `endEditing()` То получается что клавиатура появляется без анимации. 

вот два видео сравнения:
https://github.com/tangem/tangem-app-ios/assets/25799680/f74e530c-f756-4ba4-9bfb-85d2e1f3dd00
https://github.com/tangem/tangem-app-ios/assets/25799680/af8f0942-8fb0-4176-bcb9-09f7a58c88e2