### PR TITLE
IOS-6157 Fix fee calculation crash

### DIFF
--- a/Tangem/App/Services/WalletConnect/Utilities/WalletConnectEthTransactionBuilder.swift
+++ b/Tangem/App/Services/WalletConnect/Utilities/WalletConnectEthTransactionBuilder.swift
@@ -69,7 +69,7 @@ extension CommonWalletConnectEthTransactionBuilder: WalletConnectEthTransactionB
         async let gasPrice = getGasPrice(for: wcTransaction, using: gasLoader)
         async let gasLimit = getGasLimit(for: wcTransaction, with: valueAmount, using: gasLoader)
 
-        let feeValue = try await Decimal(gasLimit * gasPrice) / blockchain.decimalValue
+        let feeValue = try await Decimal(gasLimit) * Decimal(gasPrice) / blockchain.decimalValue
         let gasAmount = Amount(with: blockchain, value: feeValue)
         let feeParameters = try await EthereumFeeParameters(gasLimit: BigUInt(gasLimit), gasPrice: BigUInt(gasPrice))
         let fee = Fee(gasAmount, parameters: feeParameters)


### PR DESCRIPTION
Сначала конвертируем в Decimal, потом перемножаем чтобы избежать Int overflow