### PR TITLE
IOS-6137: Add analytics events to request support

### DIFF
--- a/Tangem/App/Services/Analytics/Analytics+CardScanSource.swift
+++ b/Tangem/App/Services/Analytics/Analytics+CardScanSource.swift
@@ -31,13 +31,13 @@ extension Analytics {
         var cardWasScannedParameterValue: Analytics.ParameterValue {
             switch self {
             case .welcome:
-                return .scanSourceWelcome
+                return .introduction
             case .auth:
-                return .scanSourceAuth
+                return .signIn
             case .mainUnlock:
                 return .main
             case .settings:
-                return .scanSourceSettings
+                return .settings
             }
         }
     }

--- a/Tangem/App/Services/Analytics/Analytics+Event.swift
+++ b/Tangem/App/Services/Analytics/Analytics+Event.swift
@@ -19,7 +19,6 @@ extension Analytics {
         case requestSupport = "[Basic] Request Support"
         case buttonTokensList = "[Introduction Process] Button - Tokens List"
         case buttonBuyCards = "[Introduction Process] Button - Buy Cards"
-        case buttonRequestSupport = "[Introduction Process] Button - Request Support"
         case introductionProcessButtonScanCard = "[Introduction Process] Button - Scan Card"
         case introductionProcessOpened = "[Introduction Process] Introduction Process Screen Opened"
         case introductionProcessLearn = "[Introduction Process] Button - Learn"

--- a/Tangem/App/Services/Analytics/Analytics+ParameterValue.swift
+++ b/Tangem/App/Services/Analytics/Analytics+ParameterValue.swift
@@ -33,10 +33,10 @@ extension Analytics {
         case main = "Main"
         case token = "Token"
         case manageTokens = "Manage Tokens"
-
-        case scanSourceWelcome = "Introduction"
-        case scanSourceAuth = "Sign In"
-        case scanSourceSettings = "Settings"
+        case introduction = "Introduction"
+        case onboarding = "Onboarding"
+        case settings = "Settings"
+        case signIn = "Sign In"
 
         case transactionSourceSend = "Send"
         case transactionSourceSwap = "Swap"

--- a/Tangem/Modules/Auth/AuthViewModel.swift
+++ b/Tangem/Modules/Auth/AuthViewModel.swift
@@ -41,7 +41,7 @@ final class AuthViewModel: ObservableObject {
     }
 
     func requestSupport() {
-        Analytics.log(.buttonRequestSupport)
+        Analytics.log(.requestSupport, params: [.source: .signIn])
         failedCardScanTracker.resetCounter()
         openMail()
     }

--- a/Tangem/Modules/Details/DetailsViewModel.swift
+++ b/Tangem/Modules/Details/DetailsViewModel.swift
@@ -92,7 +92,7 @@ extension DetailsViewModel {
     }
 
     func openMail() {
-        Analytics.log(.requestSupport)
+        Analytics.log(.requestSupport, params: [.source: .settings])
 
         guard let emailConfig = userWalletModel.config.emailConfig else { return }
 
@@ -179,7 +179,7 @@ extension DetailsViewModel {
     }
 
     func requestSupport() {
-        Analytics.log(.buttonRequestSupport)
+        Analytics.log(.requestSupport, params: [.source: .settings])
         failedCardScanTracker.resetCounter()
         coordinator?.openMail(with: failedCardScanTracker, recipient: EmailConfig.default.recipient, emailType: .failedToScanCard)
     }

--- a/Tangem/Modules/Main/UnlockCardBottomSheet/UnlockUserWalletBottomSheetViewModel.swift
+++ b/Tangem/Modules/Main/UnlockCardBottomSheet/UnlockUserWalletBottomSheetViewModel.swift
@@ -73,7 +73,7 @@ class UnlockUserWalletBottomSheetViewModel: ObservableObject, Identifiable {
     }
 
     func requestSupport() {
-        Analytics.log(.buttonRequestSupport)
+        Analytics.log(.requestSupport, params: [.source: .main])
         failedCardScanTracker.resetCounter()
         delegate?.openMail(with: failedCardScanTracker, recipient: EmailConfig.default.recipient, emailType: .failedToScanCard)
     }

--- a/Tangem/Modules/Onboarding/BaseModels/OnboardingViewModel.swift
+++ b/Tangem/Modules/Onboarding/BaseModels/OnboardingViewModel.swift
@@ -370,7 +370,7 @@ extension OnboardingViewModel {
     }
 
     func openSupport() {
-        Analytics.log(.requestSupport)
+        Analytics.log(.requestSupport, params: [.source: .onboarding])
 
         // Hide keyboard on set pin screen
         UIApplication.shared.endEditing()

--- a/Tangem/Modules/Welcome/WelcomeViewModel.swift
+++ b/Tangem/Modules/Welcome/WelcomeViewModel.swift
@@ -44,7 +44,7 @@ class WelcomeViewModel: ObservableObject {
     }
 
     func requestSupport() {
-        Analytics.log(.buttonRequestSupport)
+        Analytics.log(.requestSupport, params: [.source: .introduction])
         failedCardScanTracker.resetCounter()
         openMail()
     }


### PR DESCRIPTION
Поменял названия параметров, т.к. это не просто `scanSource`, а показатель с какого экрана производилось действие. В начале назвал с суффиксом`...Screen`, но у нас уже есть просто `main`, `manageTokens`, поэтому не стал добавлять его.