### PR TITLE
iOS-5101: Fix empty token list on start

### DIFF
--- a/Tangem/App/Services/UserTokenListManager/CommonUserTokenListManager.swift
+++ b/Tangem/App/Services/UserTokenListManager/CommonUserTokenListManager.swift
@@ -138,10 +138,8 @@ private extension CommonUserTokenListManager {
         let updatedUserTokenList = userTokenList ?? tokenItemsRepository.getList()
         userTokensListSubject.send(updatedUserTokenList)
 
-        DispatchQueue.main.async {
-            if !self.initialized, self.tokenItemsRepository.containsFile {
-                self.initializedSubject.send(true)
-            }
+        if !initialized, tokenItemsRepository.containsFile {
+            initializedSubject.send(true)
         }
     }
 

--- a/Tangem/App/Services/UserTokenListManager/CommonUserTokenListManager.swift
+++ b/Tangem/App/Services/UserTokenListManager/CommonUserTokenListManager.swift
@@ -49,7 +49,7 @@ class CommonUserTokenListManager {
         self.hasTokenSynchronization = hasTokenSynchronization
         self.defaultBlockchains = defaultBlockchains
         tokenItemsRepository = CommonTokenItemsRepository(key: userWalletId.hexString)
-        initializedSubject = .init(tokenItemsRepository.containsFile)
+        initializedSubject = CurrentValueSubject(tokenItemsRepository.containsFile)
         userTokensListSubject = CurrentValueSubject(tokenItemsRepository.getList())
 
         removeInvalidTokens()

--- a/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentViewModel.swift
+++ b/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentViewModel.swift
@@ -146,8 +146,6 @@ final class MultiWalletMainContentViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .share(replay: 1)
 
-        subscribeToTokenListSync(with: sectionsPublisher)
-
         sectionsPublisher
             .assign(to: \.sections, on: self, ownership: .weak)
             .store(in: &bag)
@@ -189,6 +187,8 @@ final class MultiWalletMainContentViewModel: ObservableObject {
             notificationsPublisher1: $notificationInputs,
             notificationsPublisher2: $tokensNotificationInputs
         )
+
+        subscribeToTokenListSync(with: sectionsPublisher)
     }
 
     private func convertToSections(


### PR DESCRIPTION
[IOS-5101](https://tangem.atlassian.net/browse/IOS-5101)

До

https://github.com/tangem/tangem-app-ios/assets/21194149/b2cdaac3-39a8-4ed7-93b9-fd76639ab19e

После

https://github.com/tangem/tangem-app-ios/assets/21194149/87fc82f6-8065-4b85-b37f-6eed746806c9

----

У бага две косвенные причины:
1. Скрытие лоадера по условию `TokenItemsRepository.containsFile == true`
2. На удивление долгий маппинг моделей во вью-модели ячеек токенов в `MultiWalletMainContentViewModel.convertToSections(_:)`, даже на небольшом списке из 6 токенов на 13 pro это заняло 0.15 сек

Из-за комбинации этих двух факторов визуально заметно, что лоадер скрывается и вместо списка на короткое время (как раз на время маппинга в VM в пункте 2) отображается пустой экран, хотя токены на карте есть

---
Поэтому теперь условия скрытия лоадера два:
1. `TokenItemsRepository.containsFile == true`
2. Паблишер с VM списка токенов эмиттит значение

Погонял в разных сценариях:
- Карта с непустым списком токенов на беке
- Карта с пустым списком токенов на беке
- Карта с непустым списком токенов локально, нет сети
- Карта с пустым списком токенов локально, нет сети
- Новая карта без токенов

проблем не нашел

[IOS-5101]: https://tangem.atlassian.net/browse/IOS-5101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ