### PR TITLE
IOS-6119 wc web socket write crash

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -50,7 +50,7 @@ target 'Tangem' do
   
   # Pods for Tangem
   pod 'Moya'
-  pod 'WalletConnectSwiftV2', :git => 'https://github.com/WalletConnect/WalletConnectSwiftV2', :tag => '1.8.4'
+  pod 'WalletConnectSwiftV2', :git => 'https://github.com/WalletConnect/WalletConnectSwiftV2', :tag => '1.13.0'
   pod 'Kingfisher', '~> 7.9.0'
 
   # Helpers

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -164,43 +164,43 @@ PODS:
   - SwiftyJSON (5.0.1)
   - TangemSdk (3.9.0)
   - TweetNacl (1.0.2)
-  - WalletConnectSwiftV2 (1.8.4):
-    - WalletConnectSwiftV2/WalletConnect (= 1.8.4)
-  - WalletConnectSwiftV2/Commons (1.8.4)
-  - WalletConnectSwiftV2/HTTPClient (1.8.4)
-  - WalletConnectSwiftV2/JSONRPC (1.8.4):
+  - WalletConnectSwiftV2 (1.13.0):
+    - WalletConnectSwiftV2/WalletConnect (= 1.13.0)
+  - WalletConnectSwiftV2/Commons (1.13.0)
+  - WalletConnectSwiftV2/HTTPClient (1.13.0)
+  - WalletConnectSwiftV2/JSONRPC (1.13.0):
     - WalletConnectSwiftV2/Commons
-  - WalletConnectSwiftV2/WalletConnect (1.8.4):
+  - WalletConnectSwiftV2/WalletConnect (1.13.0):
     - WalletConnectSwiftV2/WalletConnectAuth
     - WalletConnectSwiftV2/WalletConnectPush
     - WalletConnectSwiftV2/WalletConnectSign
     - WalletConnectSwiftV2/WalletConnectVerify
-  - WalletConnectSwiftV2/WalletConnectAuth (1.8.4):
+  - WalletConnectSwiftV2/WalletConnectAuth (1.13.0):
     - WalletConnectSwiftV2/WalletConnectPairing
     - WalletConnectSwiftV2/WalletConnectSigner
     - WalletConnectSwiftV2/WalletConnectVerify
-  - WalletConnectSwiftV2/WalletConnectJWT (1.8.4):
+  - WalletConnectSwiftV2/WalletConnectJWT (1.13.0):
     - WalletConnectSwiftV2/WalletConnectKMS
-  - WalletConnectSwiftV2/WalletConnectKMS (1.8.4):
+  - WalletConnectSwiftV2/WalletConnectKMS (1.13.0):
     - WalletConnectSwiftV2/WalletConnectUtils
-  - WalletConnectSwiftV2/WalletConnectNetworking (1.8.4):
+  - WalletConnectSwiftV2/WalletConnectNetworking (1.13.0):
     - WalletConnectSwiftV2/HTTPClient
     - WalletConnectSwiftV2/WalletConnectRelay
-  - WalletConnectSwiftV2/WalletConnectPairing (1.8.4):
+  - WalletConnectSwiftV2/WalletConnectPairing (1.13.0):
     - WalletConnectSwiftV2/WalletConnectNetworking
-  - WalletConnectSwiftV2/WalletConnectPush (1.8.4):
+  - WalletConnectSwiftV2/WalletConnectPush (1.13.0):
     - WalletConnectSwiftV2/WalletConnectJWT
     - WalletConnectSwiftV2/WalletConnectNetworking
-  - WalletConnectSwiftV2/WalletConnectRelay (1.8.4):
+  - WalletConnectSwiftV2/WalletConnectRelay (1.13.0):
     - WalletConnectSwiftV2/WalletConnectJWT
-  - WalletConnectSwiftV2/WalletConnectSign (1.8.4):
+  - WalletConnectSwiftV2/WalletConnectSign (1.13.0):
     - WalletConnectSwiftV2/WalletConnectPairing
     - WalletConnectSwiftV2/WalletConnectVerify
-  - WalletConnectSwiftV2/WalletConnectSigner (1.8.4):
+  - WalletConnectSwiftV2/WalletConnectSigner (1.13.0):
     - WalletConnectSwiftV2/WalletConnectNetworking
-  - WalletConnectSwiftV2/WalletConnectUtils (1.8.4):
+  - WalletConnectSwiftV2/WalletConnectUtils (1.13.0):
     - WalletConnectSwiftV2/JSONRPC
-  - WalletConnectSwiftV2/WalletConnectVerify (1.8.4):
+  - WalletConnectSwiftV2/WalletConnectVerify (1.13.0):
     - WalletConnectSwiftV2/WalletConnectNetworking
     - WalletConnectSwiftV2/WalletConnectUtils
 
@@ -220,7 +220,7 @@ DEPENDENCIES:
   - Moya
   - Solana.Swift (from `https://github.com/tangem/Solana.Swift`, tag `1.2.0-tangem1`)
   - TangemSdk (from `https://github.com/Tangem/tangem-sdk-ios.git`, tag `develop-284`)
-  - WalletConnectSwiftV2 (from `https://github.com/WalletConnect/WalletConnectSwiftV2`, tag `1.8.4`)
+  - WalletConnectSwiftV2 (from `https://github.com/WalletConnect/WalletConnectSwiftV2`, tag `1.13.0`)
 
 SPEC REPOS:
   trunk:
@@ -279,7 +279,7 @@ EXTERNAL SOURCES:
     :tag: develop-284
   WalletConnectSwiftV2:
     :git: https://github.com/WalletConnect/WalletConnectSwiftV2
-    :tag: 1.8.4
+    :tag: 1.13.0
 
 CHECKOUT OPTIONS:
   AlertToast:
@@ -302,7 +302,7 @@ CHECKOUT OPTIONS:
     :tag: develop-284
   WalletConnectSwiftV2:
     :git: https://github.com/WalletConnect/WalletConnectSwiftV2
-    :tag: 1.8.4
+    :tag: 1.13.0
 
 SPEC CHECKSUMS:
   Alamofire: d368e1ff8a298e6dde360e35a3e68e6c610e7204
@@ -344,8 +344,8 @@ SPEC CHECKSUMS:
   SwiftyJSON: 2f33a42c6fbc52764d96f13368585094bfd8aa5e
   TangemSdk: c141ae9d17337c53d892142e94247225d59b5c09
   TweetNacl: 3abf4d1d2082b0114e7a67410e300892448951e6
-  WalletConnectSwiftV2: c1c2c2fbd0495860baf71515be1b943f0c5dce0c
+  WalletConnectSwiftV2: d5d55295f9f0dec6f497e4ad408d673108b8fa1b
 
-PODFILE CHECKSUM: d4a3871245c0b5542fa9d2cb1f54e0c60e44b645
+PODFILE CHECKSUM: 804bde60b71996b02a39c9200fb433a7e67e7143
 
 COCOAPODS: 1.15.2

--- a/Tangem/App/Services/Analytics/Debug/Analytics+WalletConnectDebugEvent.swift
+++ b/Tangem/App/Services/Analytics/Debug/Analytics+WalletConnectDebugEvent.swift
@@ -14,6 +14,7 @@ extension Analytics {
         case webSocketDisconnected(closeCode: String, connectionState: String)
         case webSocketReceiveText(connectionState: String)
         case webSocketConnectionError(source: ConnectionErrorSource, error: Error)
+        case webSocketConnectionTimeout
         case attemptingToOpenSession(url: String)
         case receiveSessionProposal(name: String, dAppURL: String)
         case receiveRequestFromDApp(method: String)
@@ -37,6 +38,8 @@ extension Analytics.WalletConnectDebugEvent: AnalyticsDebugEvent {
             suffix = webSocketPrefix + "receive text"
         case .webSocketConnectionError:
             suffix = webSocketPrefix + "receive connection error"
+        case .webSocketConnectionTimeout:
+            suffix = webSocketPrefix + "not connected and timeout for reconnection"
         case .attemptingToOpenSession:
             suffix = "Attempting to open new session"
         case .receiveSessionProposal:
@@ -56,7 +59,7 @@ extension Analytics.WalletConnectDebugEvent: AnalyticsDebugEvent {
 
     var analyticsParams: [String: Any] {
         switch self {
-        case .webSocketConnected, .attemptingToWriteMessageMultipleTimes:
+        case .webSocketConnected, .attemptingToWriteMessageMultipleTimes, .webSocketConnectionTimeout:
             return [:]
         case .webSocketReceiveText(let connectionState):
             return [

--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/Models/WalletConnectV2Error.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/Models/WalletConnectV2Error.swift
@@ -29,6 +29,8 @@ enum WalletConnectV2Error: LocalizedError {
     case userWalletIsLocked
     case pairClientError(String)
     case symmetricKeyForTopicNotFound
+    case socketIsNotConnected
+    case socketConnectionTimeout
 
     case unknown(String)
 
@@ -54,6 +56,8 @@ enum WalletConnectV2Error: LocalizedError {
         case .userWalletIsLocked: return 8018
         case .pairClientError: return 8019
         case .symmetricKeyForTopicNotFound: return 8020
+        case .socketIsNotConnected: return 8021
+        case .socketConnectionTimeout: return 8022
 
         case .unknown: return 8999
         }

--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/Utilities/WalletConnectV2DefaultSocketFactory.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/Utilities/WalletConnectV2DefaultSocketFactory.swift
@@ -9,9 +9,16 @@
 import Foundation
 import WalletConnectSwiftV2
 
-struct WalletConnectV2DefaultSocketFactory: WebSocketFactory {
+class WalletConnectV2DefaultSocketFactory: WebSocketFactory {
+    /// `create(with url: URL)` is called from internal entities of WalletConnectSwiftV2 lib
+    /// but we also need to have access to `WebSocket` to be able to get current connection status
+    /// otherwise continuation issues may occur during new session connection
+    private(set) var lastCreatetSocket: WebSocket?
+
     func create(with url: URL) -> WebSocketConnecting {
-        WebSocket(url: url)
+        let socket = WebSocket(url: url)
+        lastCreatetSocket = socket
+        return socket
     }
 }
 

--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
@@ -56,8 +56,9 @@ final class WalletConnectV2Service {
         self.messageComposer = messageComposer
         self.wcHandlersService = wcHandlersService
 
+        let id = Bundle.main.object(forInfoDictionaryKey: "AppGroupId") as? String ?? ""
         Networking.configure(
-            groupIdentifier: "group.com.tangem.Tangem",
+            groupIdentifier: id,
             projectId: keysManager.walletConnectProjectId,
             socketFactory: factory,
             socketConnectionType: .automatic

--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
@@ -57,6 +57,7 @@ final class WalletConnectV2Service {
         self.wcHandlersService = wcHandlersService
 
         Networking.configure(
+            groupIdentifier: "group.com.tangem.Tangem",
             projectId: keysManager.walletConnectProjectId,
             socketFactory: factory,
             socketConnectionType: .automatic
@@ -65,7 +66,8 @@ final class WalletConnectV2Service {
             name: "Tangem iOS",
             description: "Tangem is a card-shaped self-custodial cold hardware wallet",
             url: "tangem.com",
-            icons: ["https://user-images.githubusercontent.com/24321494/124071202-72a00900-da58-11eb-935a-dcdab21de52b.png"]
+            icons: ["https://user-images.githubusercontent.com/24321494/124071202-72a00900-da58-11eb-935a-dcdab21de52b.png"],
+            redirect: .init(native: IncomingActionConstants.universalLinkScheme, universal: IncomingActionConstants.appTangemDomain)
         ))
 
         setupSessionSubscriptions()

--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
@@ -116,7 +116,7 @@ final class WalletConnectV2Service {
             default:
                 break
             }
-            AppLog.shared.error("🌈🌈🌈🌈[WC 2.0] Failed to disconnect session with topic: \(session.topic) with error: \(error)")
+            AppLog.shared.error("[WC 2.0] Failed to disconnect session with topic: \(session.topic) with error: \(error)")
         }
     }
 
@@ -129,7 +129,7 @@ final class WalletConnectV2Service {
                 do {
                     try await signApi.disconnect(topic: session.topic)
                 } catch {
-                    AppLog.shared.error("🌈🌈🌈🌈[WC 2.0] Failed to disconnect session while disconnecting all sessions for user wallet with id: \(userWalletId). Error: \(error)")
+                    AppLog.shared.error("[WC 2.0] Failed to disconnect session while disconnecting all sessions for user wallet with id: \(userWalletId). Error: \(error)")
                 }
             }
         }
@@ -176,7 +176,7 @@ final class WalletConnectV2Service {
             log("Established pair for \(url)")
         } catch {
             displayErrorUI(WalletConnectV2Error.pairClientError(error.localizedDescription))
-            AppLog.shared.error("🌈🌈🌈🌈[WC 2.0] Failed to connect to \(url) with error: \(error)")
+            AppLog.shared.error("[WC 2.0] Failed to connect to \(url) with error: \(error)")
 
             // Hack to delete the topic from the user default storage inside the WC 2.0 SDK
             await disconnect(topic: url.topic)
@@ -188,7 +188,7 @@ final class WalletConnectV2Service {
             try await pairApi.disconnect(topic: topic)
             log("Success disconnect/delete topic \(topic)")
         } catch {
-            AppLog.shared.error("🌈🌈🌈🌈[WC 2.0] Failed to disconnect/delete topic \(topic) with error: \(error)")
+            AppLog.shared.error("[WC 2.0] Failed to disconnect/delete topic \(topic) with error: \(error)")
         }
     }
 
@@ -307,7 +307,7 @@ final class WalletConnectV2Service {
         } catch let error as WalletConnectV2Error {
             displayErrorUI(error)
         } catch {
-            AppLog.shared.error("🌈🌈🌈🌈[WC 2.0] \(error)")
+            AppLog.shared.error("[WC 2.0] \(error)")
             displayErrorUI(.unknown(error.localizedDescription))
         }
         canEstablishNewSessionSubject.send(true)
@@ -361,7 +361,7 @@ final class WalletConnectV2Service {
             } catch {
                 let mappedError = WalletConnectV2ErrorMappingUtils().mapWCv2Error(error)
                 displayErrorUI(mappedError)
-                AppLog.shared.error("🌈🌈🌈🌈[WC 2.0] Failed to approve Session with error: \(error)")
+                AppLog.shared.error("[WC 2.0] Failed to approve Session with error: \(error)")
             }
         }
     }
@@ -372,7 +372,7 @@ final class WalletConnectV2Service {
                 try await self?.signApi.reject(proposalId: proposal.id, reason: .userRejected)
                 self?.log("User reject WC connection")
             } catch {
-                AppLog.shared.error("🌈🌈🌈🌈[WC 2.0] Failed to reject WC connection with error: \(error)")
+                AppLog.shared.error("[WC 2.0] Failed to reject WC connection with error: \(error)")
             }
             self?.canEstablishNewSessionSubject.send(true)
         }
@@ -506,7 +506,7 @@ final class WalletConnectV2Service {
     }
 
     private func log<T>(_ message: @autoclosure () -> T) {
-        AppLog.shared.debug("🌈🌈🌈🌈[WC 2.0] \(message())")
+        AppLog.shared.debug("[WC 2.0] \(message())")
     }
 }
 

--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
@@ -56,7 +56,7 @@ final class WalletConnectV2Service {
         self.messageComposer = messageComposer
         self.wcHandlersService = wcHandlersService
 
-        let id = Bundle.main.object(forInfoDictionaryKey: "AppGroupId") as? String ?? ""
+        let id: String = InfoDictionaryUtils.appGroupId.value() ?? ""
         Networking.configure(
             groupIdentifier: id,
             projectId: keysManager.walletConnectProjectId,

--- a/Tangem/App/Utilities/InfoDictionaryUtils.swift
+++ b/Tangem/App/Utilities/InfoDictionaryUtils.swift
@@ -14,6 +14,7 @@ enum InfoDictionaryUtils {
     case bundleVersion
     case bundleURLTypes
     case bundleURLSchemes
+    case appGroupId
 
     func value<T>() -> T? {
         let infoDictionary = Bundle.main.infoDictionary ?? [:]
@@ -32,6 +33,8 @@ enum InfoDictionaryUtils {
             }
 
             return dictionary.map { $0["CFBundleURLSchemes"] } as? T
+        case .appGroupId:
+            return infoDictionary["AppGroupId"] as? T
         }
     }
 }

--- a/Tangem/Common/WebSocket/WebSocket.swift
+++ b/Tangem/Common/WebSocket/WebSocket.swift
@@ -164,7 +164,7 @@ class WebSocket {
     }
 
     private func log(_ message: String) {
-        AppLog.shared.debug("🌈🌈🌈🌈[WebSocket] ✉️ Message: \(message)")
+        AppLog.shared.debug("[WebSocket] ✉️ Message: \(message)")
     }
 
     private func receive() {

--- a/Tangem/Common/WebSocket/WebSocketConnectionDelegate.swift
+++ b/Tangem/Common/WebSocket/WebSocketConnectionDelegate.swift
@@ -37,6 +37,7 @@ extension WebSocket {
 
         func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
             if let error {
+                Analytics.debugLog(eventInfo: Analytics.WalletConnectDebugEvent.webSocketConnectionError(source: .webSocketConnectionDelegate, error: error))
                 eventHandler(.connnectionError(error))
             } else {
                 // Possibly not really necessary since connection closure would likely have been reported

--- a/Tangem/Configurations/Info.plist
+++ b/Tangem/Configurations/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AppGroupId</key>
+	<string>$(APP_GROUP_ID)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -9552,6 +9552,7 @@
 			baseConfigurationReference = 83C19073F7139C98D3174EBC /* Pods-Tangem.debug(production).xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
+				APP_GROUP_ID = group.com.tangem.Tangem;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = "$(inherited)";
@@ -9700,6 +9701,7 @@
 			baseConfigurationReference = 1743C59E5AE1B71B43A60BAB /* Pods-Tangem.release(production).xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
+				APP_GROUP_ID = group.com.tangem.Tangem;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = "$(inherited)";
@@ -11002,6 +11004,7 @@
 			baseConfigurationReference = 1889AD3AB5211BF49ECA7193 /* Pods-Tangem.debug(beta).xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
+				APP_GROUP_ID = group.com.tangem.TangemBeta;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = "$(inherited)";
@@ -11255,6 +11258,7 @@
 			baseConfigurationReference = 7006DA107F6CFAA4488CED2E /* Pods-Tangem.release(beta).xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
+				APP_GROUP_ID = group.com.tangem.TangemBeta;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = "$(inherited)";
@@ -12495,6 +12499,7 @@
 			baseConfigurationReference = 7459A58EC58151DA8230EC9E /* Pods-Tangem.debug(alpha).xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
+				APP_GROUP_ID = group.com.tangem.TangemAlpha;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = "$(inherited)";
@@ -12748,6 +12753,7 @@
 			baseConfigurationReference = FD60E5E5AE36F05F60D9DD75 /* Pods-Tangem.release(alpha).xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
+				APP_GROUP_ID = group.com.tangem.TangemAlpha;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = "$(inherited)";


### PR DESCRIPTION
Очень долго пришлось искать как воспроизвести и исправить, но смысл такой:
1. Когда пользователь сворачивает приложение и приложение находится в бэкграунде и либа `WalletConnectSwiftV2` запрашивает у системы время на выполнение в бэкграунде и потом дергает `disconnect` у `WebSocket`
2. в этом время пользователь переходит в браузер, открывает дАпп и пытается подключиться через диплинку
3. приложение ещё не успело заблокироваться, поэтому пользователь сразу попадает внутрь и дергается функция установки соединения
4. либа пытается отправить сообщение, а сокет не подключен, она дергает `continuation` с ошибкой, что подключение недоступно
5. сокет соединение восстанавливается, в либе есть подписка на события обновления состояния соединения (подключен/не подключен), сообщение эммитится в паблишер и дергается еще раз `continuation`

в итоге краш. Он происходил не каждый раз, иногда с 3 или 4 раза, но его можно воспроизвести без особых сложностей.

Уменьшил задержку перед попыткой переподключения с 5 секунд на 1, чтобы по таймаутам успевать. Потыкал разные кейсы на 3х дАппах:
app.1inch.com, react-app.walletconnect.com и summer.fi

Обновил либу, добавил получение апп группы, вроде нормально последняя версия работает, надо будет куа полностью перепроверить WC.

Добавил несколько новых дебажных событий (в общем-то они и помогли воссоздать краш), на будущее.

вроде во все случаях нормально подключаются, бывают проблемы, что в приложение перекидывает, но ничего не происходит, но это из-за того что дАпп ничего не отправляет (пинг-понг в приложении норм идет) и после обновления страницы и повторной отправки запроса все тоже норм работает.