### PR TITLE
IOS-6119: WC check socket state before pairing

### DIFF
--- a/Tangem/App/Services/Analytics/Debug/Analytics+WalletConnectDebugEvent.swift
+++ b/Tangem/App/Services/Analytics/Debug/Analytics+WalletConnectDebugEvent.swift
@@ -12,8 +12,9 @@ extension Analytics {
     enum WalletConnectDebugEvent {
         case webSocketConnected
         case webSocketDisconnected(closeCode: String, connectionState: String)
-        case webSocketReceiveText
-        case webSocketConnectionError(error: Error)
+        case webSocketReceiveText(connectionState: String)
+        case webSocketConnectionError(source: ConnectionErrorSource, error: Error)
+        case webSocketConnectionTimeout
         case attemptingToOpenSession(url: String)
         case receiveSessionProposal(name: String, dAppURL: String)
         case receiveRequestFromDApp(method: String)
@@ -37,6 +38,8 @@ extension Analytics.WalletConnectDebugEvent: AnalyticsDebugEvent {
             suffix = webSocketPrefix + "receive text"
         case .webSocketConnectionError:
             suffix = webSocketPrefix + "receive connection error"
+        case .webSocketConnectionTimeout:
+            suffix = webSocketPrefix + "not connected and timeout for reconnection"
         case .attemptingToOpenSession:
             suffix = "Attempting to open new session"
         case .receiveSessionProposal:
@@ -56,15 +59,22 @@ extension Analytics.WalletConnectDebugEvent: AnalyticsDebugEvent {
 
     var analyticsParams: [String: Any] {
         switch self {
-        case .webSocketConnected, .webSocketReceiveText, .attemptingToWriteMessageMultipleTimes:
+        case .webSocketConnected, .attemptingToWriteMessageMultipleTimes, .webSocketConnectionTimeout:
             return [:]
+        case .webSocketReceiveText(let connectionState):
+            return [
+                ParamKey.webSocketState.rawValue: connectionState,
+            ]
         case .webSocketDisconnected(let closeCode, let connectionState):
             return [
                 ParamKey.webSocketCloseCode.rawValue: closeCode,
                 ParamKey.webSocketState.rawValue: connectionState,
             ]
-        case .webSocketConnectionError(let error):
-            return [ParamKey.webSocketConnectionError.rawValue: error.localizedDescription]
+        case .webSocketConnectionError(let source, let error):
+            return [
+                ParamKey.connectionErrorSource.rawValue: source.rawValue,
+                ParamKey.webSocketConnectionError.rawValue: error.localizedDescription,
+            ]
         case .attemptingToOpenSession(let url):
             return [ParamKey.dAppPairingURL.rawValue: url]
         case .receiveSessionProposal(let name, let dAppURL):
@@ -88,6 +98,15 @@ extension Analytics.WalletConnectDebugEvent: AnalyticsDebugEvent {
     }
 }
 
+extension Analytics.WalletConnectDebugEvent {
+    enum ConnectionErrorSource: String {
+        case send
+        case receive
+        case pingPong
+        case webSocketConnectionDelegate
+    }
+}
+
 private extension Analytics.WalletConnectDebugEvent {
     enum ParamKey: String {
         case webSocketCloseCode
@@ -99,5 +118,6 @@ private extension Analytics.WalletConnectDebugEvent {
         case requestMethod
         case errorShownToTheUser
         case connectionSetupMessage
+        case connectionErrorSource
     }
 }

--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/Models/WalletConnectV2Error.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/Models/WalletConnectV2Error.swift
@@ -29,6 +29,8 @@ enum WalletConnectV2Error: LocalizedError {
     case userWalletIsLocked
     case pairClientError(String)
     case symmetricKeyForTopicNotFound
+    case socketIsNotConnected
+    case socketConnectionTimeout
 
     case unknown(String)
 
@@ -54,6 +56,8 @@ enum WalletConnectV2Error: LocalizedError {
         case .userWalletIsLocked: return 8018
         case .pairClientError: return 8019
         case .symmetricKeyForTopicNotFound: return 8020
+        case .socketIsNotConnected: return 8021
+        case .socketConnectionTimeout: return 8022
 
         case .unknown: return 8999
         }

--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/Utilities/WalletConnectV2DefaultSocketFactory.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/Utilities/WalletConnectV2DefaultSocketFactory.swift
@@ -9,9 +9,16 @@
 import Foundation
 import WalletConnectSwiftV2
 
-struct WalletConnectV2DefaultSocketFactory: WebSocketFactory {
+class WalletConnectV2DefaultSocketFactory: WebSocketFactory {
+    /// `create(with url: URL)` is called from internal entities of WalletConnectSwiftV2 lib
+    /// but we also need to have access to `WebSocket` to be able to get current connection status
+    /// otherwise continuation issues may occur during new session connection
+    private(set) var lastCreatetSocket: WebSocket?
+
     func create(with url: URL) -> WebSocketConnecting {
-        WebSocket(url: url)
+        let socket = WebSocket(url: url)
+        lastCreatetSocket = socket
+        return socket
     }
 }
 

--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
@@ -133,7 +133,40 @@ final class WalletConnectV2Service {
         }
     }
 
+    private func checkSocketConnection() async -> Bool {
+        guard let socket = factory.lastCreatetSocket else {
+            return false
+        }
+
+        if socket.currentState == .connected {
+            return true
+        }
+
+        do {
+            let newState = try await socket.statePublisher
+                .filter { $0 == .connected }
+                .eraseError()
+                .timeout(.seconds(10), scheduler: DispatchQueue.main, customError: {
+                    WalletConnectV2Error.socketConnectionTimeout
+                })
+                .eraseToAnyPublisher()
+                .async()
+
+            return newState == .connected
+        } catch {
+            log("Failed to get new connection state.\nError: \(error)")
+            return false
+        }
+    }
+
     private func pairClient(with url: WalletConnectURI) async {
+        guard await checkSocketConnection() else {
+            Analytics.debugLog(eventInfo: Analytics.WalletConnectDebugEvent.webSocketConnectionTimeout)
+            displayErrorUI(WalletConnectV2Error.socketIsNotConnected)
+            canEstablishNewSessionSubject.send(true)
+            return
+        }
+
         log("Trying to pair client: \(url)")
         do {
             try await pairApi.pair(uri: url)

--- a/Tangem/Common/WebSocket/WebSocketConnectionDelegate.swift
+++ b/Tangem/Common/WebSocket/WebSocketConnectionDelegate.swift
@@ -37,6 +37,7 @@ extension WebSocket {
 
         func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
             if let error {
+                Analytics.debugLog(eventInfo: Analytics.WalletConnectDebugEvent.webSocketConnectionError(source: .webSocketConnectionDelegate, error: error))
                 eventHandler(.connnectionError(error))
             } else {
                 // Possibly not really necessary since connection closure would likely have been reported


### PR DESCRIPTION
Правка [отсюда](https://github.com/tangem/tangem-app-ios/pull/2959) только без поднятия версии либы и добавления инфы про группы.

Протестил те же самые кейсы, 6 попыток подключения после обрыва соединения сокет подключения и норм, приходит запрос на сессию и подключается норм. С запросами на подпись транзакций тоже норм