### PR TITLE
IOS-6256 Pulsechain crash

### DIFF
--- a/Tangem/App/Services/ExpressFeeProvider/CommonExpressFeeProvider.swift
+++ b/Tangem/App/Services/ExpressFeeProvider/CommonExpressFeeProvider.swift
@@ -38,7 +38,7 @@ extension CommonExpressFeeProvider: ExpressFeeProvider {
 
             let gasLimit = parameters.gasLimit * BigUInt(112) / BigUInt(100)
             let feeValue = gasLimit * parameters.gasPrice
-            let fee = Decimal(Int(feeValue)) / wallet.tokenItem.blockchain.decimalValue
+            let fee = feeValue.decimal ?? Decimal(Int(feeValue)) / wallet.tokenItem.blockchain.decimalValue
             let amount = Amount(with: wallet.tokenItem.blockchain, value: fee)
             return Fee(amount, parameters: EthereumFeeParameters(gasLimit: gasLimit, gasPrice: parameters.gasPrice))
         }


### PR DESCRIPTION
Еще в одном месте используем кастомный BigInt -> Decimal конвертер чтобы избежать переполнения Int. Судя по коду это последнее такое место.