### PR TITLE
Remove deprecated code

### DIFF
--- a/Tangem/App/ServicesManager.swift
+++ b/Tangem/App/ServicesManager.swift
@@ -59,7 +59,6 @@ class ServicesManager {
     }
 
     private func configureAmplitude() {
-        Amplitude.instance().trackingSessionEvents = true
         Amplitude.instance().initializeApiKey(try! CommonKeysManager().amplitudeApiKey)
     }
 


### PR DESCRIPTION
Deprecated:    
Amplitude.instance().trackingSessionEvents = true

Use this API instead 
    Amplitude.instance().defaultTracking.sessions

But
  Enables/disables session tracking. Default to enabled.

Поэтому просто удалил