### PR TITLE
IOS-6324 Show fiat/crypto the same way on Amount and Summary

### DIFF
--- a/Tangem/Modules/Send/Finish/SendFinishView.swift
+++ b/Tangem/Modules/Send/Finish/SendFinishView.swift
@@ -141,6 +141,6 @@ struct SendFinishView_Previews: PreviewProvider {
     )
 
     static var previews: some View {
-        SendFinishView(namespace: namespace, viewModel: SendFinishViewModel(input: SendFinishViewModelInputMock(), walletInfo: walletInfo)!)
+        SendFinishView(namespace: namespace, viewModel: SendFinishViewModel(input: SendFinishViewModelInputMock(), useFiatCalculation: false, walletInfo: walletInfo)!)
     }
 }

--- a/Tangem/Modules/Send/Finish/SendFinishViewModel.swift
+++ b/Tangem/Modules/Send/Finish/SendFinishViewModel.swift
@@ -35,7 +35,7 @@ class SendFinishViewModel: ObservableObject {
 
     private let transactionURL: URL
 
-    init?(input: SendFinishViewModelInput, walletInfo: SendWalletInfo) {
+    init?(input: SendFinishViewModelInput, useFiatCalculation: Bool, walletInfo: SendWalletInfo) {
         guard
             let destinationText = input.destinationText,
             let transactionTime = input.transactionTime,
@@ -56,7 +56,7 @@ class SendFinishViewModel: ObservableObject {
             address: destinationText,
             additionalField: input.additionalField
         )
-        amountSummaryViewData = sectionViewModelFactory.makeAmountViewData(from: input.userInputAmountValue)
+        amountSummaryViewData = sectionViewModelFactory.makeAmountViewData(from: input.userInputAmountValue, useFiatCalculation: useFiatCalculation)
         feeSummaryViewData = sectionViewModelFactory.makeFeeViewData(from: input.feeValue)
 
         let formatter = DateFormatter()

--- a/Tangem/Modules/Send/SendSummarySectionViewModelFactory.swift
+++ b/Tangem/Modules/Send/SendSummarySectionViewModelFactory.swift
@@ -43,22 +43,26 @@ struct SendSummarySectionViewModelFactory {
         return destinationViewTypes
     }
 
-    func makeAmountViewData(from amount: Amount?) -> SendAmountSummaryViewData? {
+    func makeAmountViewData(from amount: Amount?, useFiatCalculation: Bool) -> SendAmountSummaryViewData? {
         guard let amount else { return nil }
 
-        let formattedAmount = amount.description
+        let amountCryptoFormatted = amount.description
 
-        let amountFiat: String
+        let amountFiatFormatted: String
         if let currencyId,
            let fiatValue = BalanceConverter().convertToFiat(value: amount.value, from: currencyId) {
-            amountFiat = BalanceFormatter().formatFiatBalance(fiatValue)
+            amountFiatFormatted = BalanceFormatter().formatFiatBalance(fiatValue)
         } else {
-            amountFiat = AppConstants.dashSign
+            amountFiatFormatted = AppConstants.dashSign
         }
+
+        let amountFormatted = useFiatCalculation ? amountFiatFormatted : amountCryptoFormatted
+        let amountAlternativeFormatted = useFiatCalculation ? amountCryptoFormatted : amountFiatFormatted
+
         return SendAmountSummaryViewData(
             title: Localization.sendAmountLabel,
-            amount: formattedAmount,
-            amountFiat: amountFiat,
+            amount: amountFormatted,
+            amountAlternative: amountAlternativeFormatted,
             tokenIconInfo: tokenIconInfo
         )
     }

--- a/Tangem/Modules/Send/SendViewModel.swift
+++ b/Tangem/Modules/Send/SendViewModel.swift
@@ -200,7 +200,12 @@ final class SendViewModel: ObservableObject {
         sendAmountViewModel = SendAmountViewModel(input: sendModel, walletInfo: walletInfo)
         sendDestinationViewModel = SendDestinationViewModel(input: sendModel)
         sendFeeViewModel = SendFeeViewModel(input: sendModel, notificationManager: notificationManager, walletInfo: walletInfo)
-        sendSummaryViewModel = SendSummaryViewModel(input: sendModel, notificationManager: notificationManager, walletInfo: walletInfo)
+        sendSummaryViewModel = SendSummaryViewModel(
+            input: sendModel, 
+            useFiatCalculation: sendAmountViewModel.$useFiatCalculation.eraseToAnyPublisher(),
+            notificationManager: notificationManager,
+            walletInfo: walletInfo
+        )
 
         sendFeeViewModel.router = coordinator
         sendSummaryViewModel.router = self
@@ -406,7 +411,11 @@ final class SendViewModel: ObservableObject {
     }
 
     private func openFinishPage() {
-        guard let sendFinishViewModel = SendFinishViewModel(input: sendModel, walletInfo: walletInfo) else {
+        guard let sendFinishViewModel = SendFinishViewModel(
+            input: sendModel,
+            useFiatCalculation: sendAmountViewModel.useFiatCalculation,
+            walletInfo: walletInfo
+        ) else {
             assertionFailure("WHY?")
             return
         }

--- a/Tangem/Modules/Send/Summary/SendAmountSummaryView.swift
+++ b/Tangem/Modules/Send/Summary/SendAmountSummaryView.swift
@@ -33,7 +33,7 @@ struct SendAmountSummaryView: View {
                     .frame(maxWidth: .infinity)
                     .matchedGeometryEffectOptional(id: amountCryptoNamespaceId, in: namespace)
 
-                Text(data.amountFiat)
+                Text(data.amountAlternative)
                     .style(Fonts.Regular.footnote, color: Colors.Text.tertiary)
                     .matchedGeometryEffectOptional(id: amountFiatNamespaceId, in: namespace)
             }
@@ -70,7 +70,7 @@ extension SendAmountSummaryView: Setupable {
                 SendAmountSummaryViewData(
                     title: Localization.sendAmountLabel,
                     amount: "100.00 USDT",
-                    amountFiat: "99.98$",
+                    amountAlternative: "99.98$",
                     tokenIconInfo: .init(
                         name: "tether",
                         blockchainIconName: "ethereum.fill",
@@ -89,7 +89,7 @@ extension SendAmountSummaryView: Setupable {
             SendAmountSummaryViewData(
                 title: Localization.sendAmountLabel,
                 amount: "100 000 000 000 000 000 000 000 000 000 000.00 SOL",
-                amountFiat: "999 999 999 999 999 999 999 999 999 999 999 999 999.98$",
+                amountAlternative: "999 999 999 999 999 999 999 999 999 999 999 999 999.98$",
                 tokenIconInfo: .init(
                     name: "optimism",
                     blockchainIconName: nil,

--- a/Tangem/Modules/Send/Summary/SendAmountSummaryViewData.swift
+++ b/Tangem/Modules/Send/Summary/SendAmountSummaryViewData.swift
@@ -13,6 +13,6 @@ struct SendAmountSummaryViewData: Identifiable {
 
     let title: String
     let amount: String
-    let amountFiat: String
+    let amountAlternative: String
     let tokenIconInfo: TokenIconInfo
 }

--- a/Tangem/Modules/Send/Summary/SendSummaryView.swift
+++ b/Tangem/Modules/Send/Summary/SendSummaryView.swift
@@ -153,6 +153,6 @@ struct SendSummaryView_Previews: PreviewProvider {
     )
 
     static var previews: some View {
-        SendSummaryView(namespace: namespace, viewModel: SendSummaryViewModel(input: SendSummaryViewModelInputMock(), notificationManager: FakeSendNotificationManager(), walletInfo: walletInfo))
+        SendSummaryView(namespace: namespace, viewModel: SendSummaryViewModel(input: SendSummaryViewModelInputMock(), useFiatCalculation: .just(output: false), notificationManager: FakeSendNotificationManager(), walletInfo: walletInfo))
     }
 }


### PR DESCRIPTION
Нужна ваша помощь

На экране саммари и финиша надо теперь показывать фиат и крипту в том же порядке что и на экране суммы

Я два варианта вижу — в лоб передавать useFiatCalculation из адаптера напрямую в модели саммари/финиша, но получается в обход input. Можно затолкать этот флаг в SendModel и тогда он станет частью input'а, но тогда модель будет знать о фиате. Можно SendViewModel сделать input-ом и транслировать все значения из SendModel: SendModel -> SendViewModel (Input) -> SendSummaryViewModel, но тогда будет дублирование свойств.

Можно сделать так чтобы SendModel отдавала уже готовые amountFormatted / amountAlternativeFormatted, можно сделать так чтобы она их брала из адаптера, но тогда тоже получается модель знает о каких-то альтернативных суммах