### PR TITLE
IOS-6241 Fix force backup

### DIFF
--- a/Tangem/Modules/Onboarding/OnboardingStepsBuilders/WalletOnboardingStepsBuilder.swift
+++ b/Tangem/Modules/Onboarding/OnboardingStepsBuilders/WalletOnboardingStepsBuilder.swift
@@ -88,7 +88,7 @@ extension WalletOnboardingStepsBuilder: OnboardingStepsBuilder {
         }
 
         if hasWallets {
-            let forceBackup = !canSkipBackup && !hasBackup
+            let forceBackup = !canSkipBackup && !hasBackup && canBackup // canBackup is false for cardLinked state
 
             if AppSettings.shared.cardsStartedActivation.contains(cardId) || forceBackup {
                 steps.append(contentsOf: backupSteps + userWalletSavingSteps + [.success])


### PR DESCRIPTION
Не хватало проверки, поэтому пограничный кейс cardLinked обрабатывался некорректно - при сканировании постоянно отображался шаг успеха в онбординге