### PR TITLE
IOS-6338: Add pending tx to list only if same amount type

### DIFF
--- a/Tangem/App/ViewModels/WalletModel/WalletModel.swift
+++ b/Tangem/App/ViewModels/WalletModel/WalletModel.swift
@@ -141,11 +141,11 @@ class WalletModel {
     }
 
     var pendingTransactions: [PendingTransactionRecord] {
-        wallet.pendingTransactions.filter { !$0.isDummy }
+        wallet.pendingTransactions.filter { !$0.isDummy && $0.amount.type == amountType }
     }
 
     var incomingPendingTransactions: [PendingTransactionRecord] {
-        wallet.pendingTransactions.filter { $0.isIncoming }
+        wallet.pendingTransactions.filter { $0.isIncoming && $0.amount.type == amountType }
     }
 
     var outgoingPendingTransactions: [PendingTransactionRecord] {


### PR DESCRIPTION
Не было фильтрации что транзакция именно этой монеты/токена, поэтому все транзакции добавлялись в список истории транзакций. Добавил такую же проверку и для входящих транзакций, чтобы лучше определять пустой баланс или нет. Кстати, надо будет удалить `outgoingPendingTransactions` вроде нигде не используется