### PR TITLE
IOS-6378: Skip backup intro page wallet 2.0

### DIFF
--- a/Tangem/Modules/Onboarding/OnboardingStepsBuilders/WalletOnboardingStepsBuilder.swift
+++ b/Tangem/Modules/Onboarding/OnboardingStepsBuilders/WalletOnboardingStepsBuilder.swift
@@ -41,7 +41,9 @@ struct WalletOnboardingStepsBuilder {
 
         var steps: [WalletOnboardingStep] = []
 
-        steps.append(.backupIntro)
+        if canSkipBackup {
+            steps.append(.backupIntro)
+        }
 
         if hasWallets, !backupService.primaryCardIsSet {
             steps.append(.scanPrimaryCard)


### PR DESCRIPTION
Во время правок по дизайну, появился косячок, что карточки с новыми прошивками могут пропускать бэкап, нашел в дизе, что появилось новое требование, что новые карточки не должны показывать в принципе экран с кнопкой пропуска бэкапа

[IOS-6378](https://tangem.atlassian.net/browse/IOS-6378)

[IOS-6378]: https://tangem.atlassian.net/browse/IOS-6378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ