### PR TITLE
Reduce analytics events

### DIFF
--- a/Tangem/App/Services/Analytics/Analytics+EventLimit.swift
+++ b/Tangem/App/Services/Analytics/Analytics+EventLimit.swift
@@ -1,0 +1,40 @@
+//
+//  Analytics+EventLimit.swift
+//  Tangem
+//
+//  Created by Alexander Osokin on 25.03.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+extension Analytics {
+    enum EventLimit {
+        // One time per app session
+        case appSession
+        // One time per app session and per user wallet
+        case userWalletSession(userWalletId: UserWalletId)
+        // No limits
+        case unlimited
+    }
+}
+
+extension Analytics.EventLimit {
+    var isLimited: Bool {
+        switch self {
+        case .appSession, .userWalletSession:
+            return true
+        case .unlimited:
+            return false
+        }
+    }
+
+    var contextScope: AnalyticsContextScope {
+        switch self {
+        case .appSession, .unlimited:
+            return .common
+        case .userWalletSession(let userWalletId):
+            return .userWallet(userWalletId)
+        }
+    }
+}

--- a/Tangem/App/Services/Analytics/AnalyticsContext/AnalyticsContext.swift
+++ b/Tangem/App/Services/Analytics/AnalyticsContext/AnalyticsContext.swift
@@ -14,6 +14,7 @@ protocol AnalyticsContext {
     func setupContext(with: AnalyticsContextData)
 
     func clearContext()
+    func clearSession()
 
     func value(forKey: AnalyticsStorageKey, scope: AnalyticsContextScope) -> Any?
     func set(value: Any, forKey storageKey: AnalyticsStorageKey, scope: AnalyticsContextScope)

--- a/Tangem/App/Services/Analytics/AnalyticsContext/AnalyticsContextData.swift
+++ b/Tangem/App/Services/Analytics/AnalyticsContext/AnalyticsContextData.swift
@@ -10,7 +10,6 @@ import Foundation
 import TangemSdk
 
 struct AnalyticsContextData {
-    let id: String?
     let productType: Analytics.ProductType
     let batchId: String
     let firmware: String
@@ -27,21 +26,10 @@ struct AnalyticsContextData {
 }
 
 extension AnalyticsContextData {
-    init(card: CardDTO, productType: Analytics.ProductType, userWalletId: Data?, embeddedEntry: StorageEntry?) {
-        id = userWalletId?.sha256().hexString
+    init(card: CardDTO, productType: Analytics.ProductType, embeddedEntry: StorageEntry?) {
         self.productType = productType
         batchId = card.batchId
         firmware = card.firmwareVersion.stringValue
         baseCurrency = embeddedEntry?.tokens.first?.symbol ?? embeddedEntry?.blockchainNetwork.blockchain.currencySymbol
-    }
-
-    func copy(with userWalletId: Data) -> Self {
-        return .init(
-            id: userWalletId.sha256().hexString,
-            productType: productType,
-            batchId: batchId,
-            firmware: firmware,
-            baseCurrency: baseCurrency
-        )
     }
 }

--- a/Tangem/App/Services/Analytics/AnalyticsContext/AnalyticsContextScope.swift
+++ b/Tangem/App/Services/Analytics/AnalyticsContext/AnalyticsContextScope.swift
@@ -10,5 +10,5 @@ import Foundation
 
 enum AnalyticsContextScope {
     case common
-    case userWallet
+    case userWallet(UserWalletId)
 }

--- a/Tangem/App/Services/Analytics/AnalyticsContext/CommonAnalyticsContext.swift
+++ b/Tangem/App/Services/Analytics/AnalyticsContext/CommonAnalyticsContext.swift
@@ -23,6 +23,10 @@ class CommonAnalyticsContext: AnalyticsContext {
         contextData = nil
     }
 
+    func clearSession() {
+        analyticsStorage.clearSessionStorage()
+    }
+
     func value(forKey: AnalyticsStorageKey, scope: AnalyticsContextScope) -> Any? {
         guard let id = makeId(for: scope) else { return nil }
 
@@ -43,8 +47,8 @@ class CommonAnalyticsContext: AnalyticsContext {
 
     private func makeId(for scope: AnalyticsContextScope) -> String? {
         switch scope {
-        case .userWallet:
-            return contextData?.id
+        case .userWallet(let userWalletId):
+            return userWalletId.stringValue
         case .common:
             return Constants.commonContextId
         }
@@ -63,6 +67,10 @@ private extension CommonAnalyticsContext {
 
 private class AnalyticsStorage {
     private var tempStorage: [String: Any] = [:]
+
+    func clearSessionStorage() {
+        tempStorage = [:]
+    }
 
     func value(_ storageKey: AnalyticsStorageKey, id: String) -> Any? {
         let rawKey = makeRawKey(from: storageKey, id: id)

--- a/Tangem/App/Services/Analytics/AnalyticsStorageKey.swift
+++ b/Tangem/App/Services/Analytics/AnalyticsStorageKey.swift
@@ -11,12 +11,13 @@ import Foundation
 enum AnalyticsStorageKey: String {
     case hasPositiveBalance
     case scanSource
+    case limitedEvents
 
     var isPermanent: Bool {
         switch self {
         case .hasPositiveBalance:
             return true
-        case .scanSource:
+        case .scanSource, .limitedEvents:
             return false
         }
     }

--- a/Tangem/App/Services/TotalBalanceProvider/TotalBalanceProvider.swift
+++ b/Tangem/App/Services/TotalBalanceProvider/TotalBalanceProvider.swift
@@ -14,6 +14,7 @@ import BlockchainSdk
 class TotalBalanceProvider {
     @Injected(\.tangemApiService) private var tangemApiService: TangemApiService
 
+    private let userWalletId: UserWalletId
     private let walletModelsManager: WalletModelsManager
     private let derivationManager: DerivationManager?
 
@@ -23,9 +24,11 @@ class TotalBalanceProvider {
     private var updateSubscription: AnyCancellable?
 
     init(
+        userWalletId: UserWalletId,
         walletModelsManager: WalletModelsManager,
         derivationManager: DerivationManager?
     ) {
+        self.userWalletId = userWalletId
         self.walletModelsManager = walletModelsManager
         self.derivationManager = derivationManager
 
@@ -159,7 +162,7 @@ private extension TotalBalanceProvider {
 
         // It is also empty when derivation is missing
         if let balance, !hasEntriesWithoutDerivation {
-            Analytics.logTopUpIfNeeded(balance: balance)
+            Analytics.logTopUpIfNeeded(balance: balance, for: userWalletId)
         }
 
         Analytics.log(
@@ -170,7 +173,8 @@ private extension TotalBalanceProvider {
                     hasError: hasError,
                     balance: balance
                 ),
-            ]
+            ],
+            limit: .userWalletSession(userWalletId: userWalletId)
         )
 
         let mainCoinModels = walletModels.filter { $0.isMainToken }
@@ -192,7 +196,8 @@ private extension TotalBalanceProvider {
                 params: [
                     .token: trackedModel.blockchainNetwork.blockchain.currencySymbol,
                     .state: balanceValue > 0 ? Analytics.ParameterValue.full.rawValue : Analytics.ParameterValue.empty.rawValue,
-                ]
+                ],
+                limit: .userWalletSession(userWalletId: userWalletId)
             )
         }
 

--- a/Tangem/App/Services/UserWalletRepository/CommonUserWalletRepository.swift
+++ b/Tangem/App/Services/UserWalletRepository/CommonUserWalletRepository.swift
@@ -397,6 +397,7 @@ class CommonUserWalletRepository: UserWalletRepository {
         discardSensitiveData()
 
         resetServices()
+        analyticsContext.clearSession()
 
         sendEvent(.locked(reason: reason))
     }
@@ -420,11 +421,9 @@ class CommonUserWalletRepository: UserWalletRepository {
     // we can initialize it right after scan for more accurate analytics
     func initializeAnalyticsContext(with cardInfo: CardInfo) {
         let config = UserWalletConfigFactory(cardInfo).makeConfig()
-        let userWalletId = config.userWalletIdSeed.map { UserWalletId(with: $0).value }
         let contextData = AnalyticsContextData(
             card: cardInfo.card,
             productType: config.productType,
-            userWalletId: userWalletId,
             embeddedEntry: config.embeddedBlockchain
         )
 

--- a/Tangem/App/Services/UserWalletRepository/LockedUserWallet.swift
+++ b/Tangem/App/Services/UserWalletRepository/LockedUserWallet.swift
@@ -98,7 +98,6 @@ extension LockedUserWallet: AnalyticsContextDataProvider {
         let baseCurrency = embeddedEntry?.tokens.first?.symbol ?? embeddedEntry?.blockchainNetwork.blockchain.currencySymbol
 
         return AnalyticsContextData(
-            id: nil,
             productType: config.productType,
             batchId: cardInfo.card.batchId,
             firmware: cardInfo.card.firmwareVersion.stringValue,

--- a/Tangem/App/ViewModels/CardViewModel.swift
+++ b/Tangem/App/ViewModels/CardViewModel.swift
@@ -94,6 +94,7 @@ class CardViewModel: Identifiable, ObservableObject {
     let userWalletId: UserWalletId
 
     lazy var totalBalanceProvider: TotalBalanceProviding = TotalBalanceProvider(
+        userWalletId: userWalletId,
         walletModelsManager: walletModelsManager,
         derivationManager: derivationManager
     )
@@ -398,7 +399,6 @@ extension CardViewModel: AnalyticsContextDataProvider {
         return AnalyticsContextData(
             card: card,
             productType: config.productType,
-            userWalletId: userWalletId.value,
             embeddedEntry: config.embeddedBlockchain
         )
     }

--- a/Tangem/Modules/Onboarding/BaseModels/OnboardingTopupViewModel.swift
+++ b/Tangem/Modules/Onboarding/BaseModels/OnboardingTopupViewModel.swift
@@ -69,7 +69,9 @@ class OnboardingTopupViewModel<Step: OnboardingStep, Coordinator: OnboardingTopu
                     if shouldGoToNextStep,
                        !walletModel.isEmptyIncludingPendingIncomingTxs,
                        !walletModel.isZeroAmount {
-                        Analytics.logTopUpIfNeeded(balance: walletModel.fiatValue ?? 0)
+                        if let userWalletId = viewModel.cardModel?.userWalletId {
+                            Analytics.logTopUpIfNeeded(balance: walletModel.fiatValue ?? 0, for: userWalletId)
+                        }
                         viewModel.goToNextStep()
                         viewModel.walletModelUpdateCancellable = nil
                         return

--- a/Tangem/Modules/Onboarding/BaseModels/OnboardingViewModel.swift
+++ b/Tangem/Modules/Onboarding/BaseModels/OnboardingViewModel.swift
@@ -166,7 +166,7 @@ class OnboardingViewModel<Step: OnboardingStep, Coordinator: OnboardingRoutable>
 
         userWalletRepository.initializeServices(for: userWallet, cardInfo: userWallet.cardInfo)
 
-        Analytics.logTopUpIfNeeded(balance: 0)
+        Analytics.logTopUpIfNeeded(balance: 0, for: userWallet.userWalletId)
 
         cardModel = userWallet
     }

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -997,6 +997,7 @@
 		DC858A3928AA48B000D58EE7 /* CardEmailDataFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC858A3828AA48B000D58EE7 /* CardEmailDataFactory.swift */; };
 		DC8B159D2B681FE500DBBE9E /* PendingExpressTxStatusRoutable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8B159C2B681FE500DBBE9E /* PendingExpressTxStatusRoutable.swift */; };
 		DC8B159F2B69616B00DBBE9E /* DismissSafariActionURLHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8B159E2B69616B00DBBE9E /* DismissSafariActionURLHelper.swift */; };
+		DC8D72142BB1967D0077F241 /* Analytics+EventLimit.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8D72132BB1967D0077F241 /* Analytics+EventLimit.swift */; };
 		DC9A4A2D2AB4ADD30031C7C2 /* UserCodeRecovering.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9A4A2C2AB4ADD30031C7C2 /* UserCodeRecovering.swift */; };
 		DC9A4A302AB4AE320031C7C2 /* UserCodeRecoveringCardInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9A4A2F2AB4AE320031C7C2 /* UserCodeRecoveringCardInteractor.swift */; };
 		DCAB57FE295ECA55005D0F4A /* SendError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCAB57FD295ECA55005D0F4A /* SendError.swift */; };
@@ -2459,6 +2460,7 @@
 		DC858A3828AA48B000D58EE7 /* CardEmailDataFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardEmailDataFactory.swift; sourceTree = "<group>"; };
 		DC8B159C2B681FE500DBBE9E /* PendingExpressTxStatusRoutable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingExpressTxStatusRoutable.swift; sourceTree = "<group>"; };
 		DC8B159E2B69616B00DBBE9E /* DismissSafariActionURLHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissSafariActionURLHelper.swift; sourceTree = "<group>"; };
+		DC8D72132BB1967D0077F241 /* Analytics+EventLimit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Analytics+EventLimit.swift"; sourceTree = "<group>"; };
 		DC9A4A2C2AB4ADD30031C7C2 /* UserCodeRecovering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCodeRecovering.swift; sourceTree = "<group>"; };
 		DC9A4A2F2AB4AE320031C7C2 /* UserCodeRecoveringCardInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCodeRecoveringCardInteractor.swift; sourceTree = "<group>"; };
 		DCAB57FD295ECA55005D0F4A /* SendError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendError.swift; sourceTree = "<group>"; };
@@ -4736,6 +4738,7 @@
 				DCBC94502993FE9A0050BC35 /* Analytics+AnalyticsSystem.swift */,
 				DCBC94562993FF330050BC35 /* Analytics+ProductType.swift */,
 				DCE402B72A31E69100D40C77 /* Analytics+DestinationAddressSource.swift */,
+				DC8D72132BB1967D0077F241 /* Analytics+EventLimit.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -8941,6 +8944,7 @@
 				B09E518A298104670042998A /* DeprecationServicing.swift in Sources */,
 				B0C4A1D32671F3FC00DCB921 /* TestnetBuyCryptoService.swift in Sources */,
 				B6E932C22A2F2D860068D466 /* OrganizeTokensView.swift in Sources */,
+				DC8D72142BB1967D0077F241 /* Analytics+EventLimit.swift in Sources */,
 				B030B4DB2A8CE1DA0023DB8B /* LockedWalletMainContentView.swift in Sources */,
 				B0C4F77D26F0BFF90086D815 /* OnboardingMessagesView.swift in Sources */,
 				65469D3A28AA64520092138F /* ResizableSheetView.swift in Sources */,


### PR DESCRIPTION
Теперь события в аналитику можно ограничивать:
- по сессии приложения (один раз независимо от userWallet)
- один раз для каждого userWallet

Сессия заканчивается с разлогином

Заодно заметил, что событие topUp может быть потеряно, если залогиниться после поподнения при выбранном другом кошельке из-за редизайна, поэтому его тоже перевел на эти рельсы. Предзаписанные события не должны потеряться. По сути теперь для таких событий userwalletid передаетсят не из абстрактного контекста, а через точку вызова