### PR TITLE
IOS-6404 visa prod token info

### DIFF
--- a/TangemVisa/BridgeInteractor/CommonBridgeInteractor.swift
+++ b/TangemVisa/BridgeInteractor/CommonBridgeInteractor.swift
@@ -19,7 +19,7 @@ struct CommonBridgeInteractor {
     init(evmSmartContractInteractor: EVMSmartContractInteractor, paymentAccount: String, logger: InternalLogger) {
         self.evmSmartContractInteractor = evmSmartContractInteractor
         self.paymentAccount = paymentAccount
-        decimalCount = VisaUtilities().visaBlockchain.decimalCount
+        decimalCount = VisaUtilities().visaToken.decimalCount
         self.logger = logger
     }
 }

--- a/TangemVisa/Utilities/LimitsResponseParser.swift
+++ b/TangemVisa/Utilities/LimitsResponseParser.swift
@@ -52,7 +52,7 @@ struct LimitsResponseParser {
         let timeIntervalWhenLimitEnds = EthereumUtils.parseEthereumDecimal(limitItems.removeLast(), decimalsCount: 0)
         let dueDate = Date(timeIntervalSince1970: timeIntervalWhenLimitEnds?.doubleValue ?? 0)
 
-        let decimalCount = VisaUtilities().visaBlockchain.decimalCount
+        let decimalCount = VisaUtilities().visaToken.decimalCount
         var values = limitItems.map { EthereumUtils.parseEthereumDecimal($0, decimalsCount: decimalCount) }
 
         guard values.count == amountsCount else {

--- a/TangemVisa/Utilities/VisaUtilities.swift
+++ b/TangemVisa/Utilities/VisaUtilities.swift
@@ -13,7 +13,7 @@ public struct VisaUtilities {
     public init() {}
 
     public var visaToken: Token {
-        testnetUSDTtoken
+        visaBlockchain.isTestnet ? testnetUSDTtoken : usdtToken
     }
 
     public var visaBlockchain: Blockchain {
@@ -23,7 +23,11 @@ public struct VisaUtilities {
 
 internal extension VisaUtilities {
     var registryAddress: String {
-        "0x3f4ae01073d1a9d5a92315fe118e57d1cdec7c44"
+        if visaBlockchain.isTestnet {
+            return "0x3f4ae01073d1a9d5a92315fe118e57d1cdec7c44"
+        }
+
+        return "0xa7299243262087462a040c743ab6c8649ebcc1fe"
     }
 }
 
@@ -34,6 +38,16 @@ private extension VisaUtilities {
             symbol: "USDT",
             contractAddress: "0x1A826Dfe31421151b3E7F2e4887a00070999150f",
             decimalCount: 18,
+            id: "tether"
+        )
+    }
+
+    private var usdtToken: Token {
+        .init(
+            name: "Tether",
+            symbol: "USDT",
+            contractAddress: "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
+            decimalCount: 6,
             id: "tether"
         )
     }


### PR DESCRIPTION
Надо было добавить информацию по продовскому токену (USDT) и ещё выяснилось, что неправильно форматировалось значение, инфа бралась по блокчеину, а не по токену.

В будущем планируется загружать информацию по токену из `PaymentAccount`, но сейчас это не нужно, можно захардкодить