### PR TITLE
IOS-6406 Remove animations in the `SendDecimalNumberTextField.swift`

### DIFF
--- a/Tangem/Common/UI/SendDecimalNumberTextField/DecimalNumberTextField.swift
+++ b/Tangem/Common/UI/SendDecimalNumberTextField/DecimalNumberTextField.swift
@@ -36,6 +36,7 @@ struct DecimalNumberTextField: View {
                 .frame(width: size.width)
         }
         .lineLimit(1)
+        .animation(.none, value: size.width)
     }
 
     private var textField: some View {


### PR DESCRIPTION
Из за анимации появлялись троеточия, сейчас все ок