### PR TITLE
IOS-6468: Wrong button titles

### DIFF
--- a/Tangem/Modules/Onboarding/Twins/TwinsOnboardingViewModel.swift
+++ b/Tangem/Modules/Onboarding/Twins/TwinsOnboardingViewModel.swift
@@ -85,9 +85,9 @@ class TwinsOnboardingViewModel: OnboardingTopupViewModel<TwinsOnboardingStep, On
         if twinCardSeries.number != 1 {
             switch currentStep {
             case .first, .third:
-                return TwinsOnboardingStep.second.mainButtonTitle
+                return TwinsOnboardingStep.second.supplementButtonTitle
             case .second:
-                return TwinsOnboardingStep.first.mainButtonTitle
+                return TwinsOnboardingStep.first.supplementButtonTitle
             default:
                 break
             }


### PR DESCRIPTION
неправильную текстовку заюзал на кнопке. В итоге была только иконка, но не было текстовки
https://tangem.atlassian.net/browse/IOS-6468


<img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/401abfbc-bad0-41fa-88b0-55feddb9fd40"><img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/b5ed41dd-38e7-48fe-8f21-85bfdb0e5da5"><img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/66023084-c985-4015-97f1-625d3e599514">
