### PR TITLE
IOS-6170: [Crashlytics] [New Fatal Issue] [Tangem] MultiWalletMainContentViewModel.swift - closure #2 in MultiWalletMainContentViewModel.bind()

### DIFF
--- a/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentViewModel.swift
+++ b/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentViewModel.swift
@@ -63,6 +63,10 @@ final class MultiWalletMainContentViewModel: ObservableObject {
     private var canManageTokens: Bool { userWalletModel.config.hasFeature(.multiCurrency) }
 
     private var cachedTokenItemViewModels: [ObjectIdentifier: TokenItemViewModel] = [:]
+    private let tokenItemViewModelsCachingQueue = DispatchQueue(
+        label: "com.tangem.MultiWalletMainContentViewModel.tokenItemViewModelsCachingQueue",
+        qos: .userInitiated
+    )
 
     private let mappingQueue = DispatchQueue(
         label: "com.tangem.MultiWalletMainContentViewModel.mappingQueue",
@@ -140,7 +144,7 @@ final class MultiWalletMainContentViewModel: ObservableObject {
 
         let sectionsPublisher = organizedTokensSectionsPublisher
             .withWeakCaptureOf(self)
-            .receive(on: DispatchQueue.main)
+            .receive(on: tokenItemViewModelsCachingQueue)
             .map { viewModel, sections in
                 return viewModel.convertToSections(sections)
             }
@@ -153,7 +157,7 @@ final class MultiWalletMainContentViewModel: ObservableObject {
 
         organizedTokensSectionsPublisher
             .withWeakCaptureOf(self)
-            .receive(on: DispatchQueue.main)
+            .receive(on: tokenItemViewModelsCachingQueue)
             .sink { viewModel, sections in
                 viewModel.removeOldCachedTokenViewModels(sections)
             }

--- a/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentViewModel.swift
+++ b/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentViewModel.swift
@@ -140,6 +140,7 @@ final class MultiWalletMainContentViewModel: ObservableObject {
 
         let sectionsPublisher = organizedTokensSectionsPublisher
             .withWeakCaptureOf(self)
+            .receive(on: DispatchQueue.main)
             .map { viewModel, sections in
                 return viewModel.convertToSections(sections)
             }
@@ -152,6 +153,7 @@ final class MultiWalletMainContentViewModel: ObservableObject {
 
         organizedTokensSectionsPublisher
             .withWeakCaptureOf(self)
+            .receive(on: DispatchQueue.main)
             .sink { viewModel, sections in
                 viewModel.removeOldCachedTokenViewModels(sections)
             }


### PR DESCRIPTION
https://tangem.atlassian.net/browse/IOS-6170

Похоже что `convertToSections` и `removeOldCachedTokenViewModels` одновременно пытались изменить проперти `cachedTokenItemViewModels` у вьюмедели с разных потоков