### PR TITLE
IOS-6585: Add support for `amount/value/uint256` QR params with either a comma or dot floating number separator

### DIFF
--- a/Tangem/App/Services/QRCodeParser/QRCodeParser.swift
+++ b/Tangem/App/Services/QRCodeParser/QRCodeParser.swift
@@ -39,8 +39,8 @@ struct QRCodeParser {
             switch parameterName {
             case .amount:
                 // According to BIP-0021, the value is specified in decimals. No conversion needed
-                if let amount = makeAmount(with: parameterValue) {
-                    result.amount = amount
+                if let decimalValue = parseDecimal(parameterValue) {
+                    result.amount = makeAmount(with: decimalValue)
                     result.amountText = parameterValue
                 }
             case .message, .memo:
@@ -61,7 +61,7 @@ struct QRCodeParser {
                 result.destination = parameterValue
             case .value, .uint256:
                 // According to ERC-681, the value is specified in the atomic unit (i.e. wei). Converting it to decimals
-                if let valueInSmallestDenomination = Decimal(stringValue: parameterValue) {
+                if let valueInSmallestDenomination = parseDecimal(parameterValue) {
                     let value = valueInSmallestDenomination / pow(Decimal(10), decimalCount)
                     result.amount = makeAmount(with: value)
                     result.amountText = value.stringValue
@@ -115,12 +115,21 @@ struct QRCodeParser {
             }
     }
 
-    private func makeAmount(with parameterValue: String) -> Amount? {
-        guard let value = Decimal(stringValue: parameterValue) else {
+    private func parseDecimal(_ stringValue: String) -> Decimal? {
+        let decimalSeparator = Constants.decimalParsingLocale.decimalSeparator ?? "."
+        let normalizedStringValue = stringValue.replacingOccurrences(of: ",", with: decimalSeparator)
+
+        // If the normalized string contains more than one separators (i.e. it can be divided into 3 or more parts),
+        // like '1,234,567.89' or '1.234.567,89' - it violates both BIP-0021 and ERC-681 and can't be parsed reliably.
+        // In this case, we consider the given string to be malformed, and we stop the decimal number parsing routine
+        guard
+            normalizedStringValue.split(separator: decimalSeparator.first!).count < 3,
+            let value = Decimal(string: normalizedStringValue, locale: Constants.decimalParsingLocale)
+        else {
             return nil
         }
 
-        return makeAmount(with: value)
+        return value
     }
 
     private func makeAmount(with value: Decimal) -> Amount {
@@ -150,6 +159,9 @@ private extension QRCodeParser {
             "/",
             "?",
         ]
+
+        /// Locale for string literals parsing.
+        static let decimalParsingLocale = Locale(identifier: "en_US_POSIX")
     }
 
     /// We don't care about other params from ERC-681, like `gasLimit`, `gasPrice` and so on.

--- a/TangemTests/QRCodeParserTests.swift
+++ b/TangemTests/QRCodeParserTests.swift
@@ -175,7 +175,7 @@ final class QRCodeParserTests: XCTestCase {
 
         testPositiveCase(
             code: "ethereum:0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7/transfer?address=0xc00f86ab93cd0bd3a60213583d0fe35aaa1ace23",
-            destination: "0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7",
+            destination: nil, // the contract address doesn't match (since it's a coin, not a token), therefore the parsed destination should be nil
             amount: nil,
             amountText: nil,
             memo: nil,

--- a/TangemTests/QRCodeParserTests.swift
+++ b/TangemTests/QRCodeParserTests.swift
@@ -83,7 +83,9 @@ final class QRCodeParserTests: XCTestCase {
             code: "bc1pw83rs5s75na2g7ec8yqgekr3ae209ye7ck2ftakjnh8tv3xzw8ls6wgt62?someArgument=someValue&amount=1234,56789",
             destination: "bc1pw83rs5s75na2g7ec8yqgekr3ae209ye7ck2ftakjnh8tv3xzw8ls6wgt62",
             amount: Amount(with: blockchain, type: .coin, value: try XCTUnwrap(Decimal(stringValue: "1234.56789"))),
-            amountText: "1234.56789",
+            // Legacy send (uses `amountText`) works with both '.' and ',' decimal separators without issues,
+            // so no additional normalization is needed for the `amountText` string
+            amountText: "1234,56789",
             memo: nil,
             parser: parser
         )

--- a/TangemTests/QRCodeParserTests.swift
+++ b/TangemTests/QRCodeParserTests.swift
@@ -68,11 +68,42 @@ final class QRCodeParserTests: XCTestCase {
             parser: parser
         )
 
+        // '.' decimal separator
         testPositiveCase(
             code: "bc1pw83rs5s75na2g7ec8yqgekr3ae209ye7ck2ftakjnh8tv3xzw8ls6wgt62?someArgument=someValue&amount=1234.56789",
             destination: "bc1pw83rs5s75na2g7ec8yqgekr3ae209ye7ck2ftakjnh8tv3xzw8ls6wgt62",
             amount: Amount(with: blockchain, type: .coin, value: try XCTUnwrap(Decimal(stringValue: "1234.56789"))),
             amountText: "1234.56789",
+            memo: nil,
+            parser: parser
+        )
+
+        // ',' decimal separator
+        testPositiveCase(
+            code: "bc1pw83rs5s75na2g7ec8yqgekr3ae209ye7ck2ftakjnh8tv3xzw8ls6wgt62?someArgument=someValue&amount=1234,56789",
+            destination: "bc1pw83rs5s75na2g7ec8yqgekr3ae209ye7ck2ftakjnh8tv3xzw8ls6wgt62",
+            amount: Amount(with: blockchain, type: .coin, value: try XCTUnwrap(Decimal(stringValue: "1234.56789"))),
+            amountText: "1234.56789",
+            memo: nil,
+            parser: parser
+        )
+
+        // We don't support mixed decimal separators and digit group separators like '1,234,567.89' or '1.234.567,89'
+        testPositiveCase(
+            code: "bc1pw83rs5s75na2g7ec8yqgekr3ae209ye7ck2ftakjnh8tv3xzw8ls6wgt62?someArgument=someValue&amount=1.234,56789",
+            destination: "bc1pw83rs5s75na2g7ec8yqgekr3ae209ye7ck2ftakjnh8tv3xzw8ls6wgt62",
+            amount: nil,
+            amountText: nil,
+            memo: nil,
+            parser: parser
+        )
+
+        // We don't support mixed decimal separators and digit group separators like '1,234,567.89' or '1.234.567,89'
+        testPositiveCase(
+            code: "bc1pw83rs5s75na2g7ec8yqgekr3ae209ye7ck2ftakjnh8tv3xzw8ls6wgt62?someArgument=someValue&amount=1,234.56789",
+            destination: "bc1pw83rs5s75na2g7ec8yqgekr3ae209ye7ck2ftakjnh8tv3xzw8ls6wgt62",
+            amount: nil,
+            amountText: nil,
             memo: nil,
             parser: parser
         )
@@ -193,6 +224,7 @@ final class QRCodeParserTests: XCTestCase {
             parser: parser
         )
 
+        // '.' decimal separator
         testPositiveCase(
             code: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb?someArgument=someValue&value=1.88e10",
             destination: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
@@ -206,6 +238,21 @@ final class QRCodeParserTests: XCTestCase {
             parser: parser
         )
 
+        // ',' decimal separator
+        testPositiveCase(
+            code: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb?someArgument=someValue&value=1,88e10",
+            destination: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
+            amount: Amount(
+                with: blockchain,
+                type: .coin,
+                value: try XCTUnwrap(Decimal(stringValue: "0.0000000188")) //  = 1.88 * 10^10 / 10^18, 18 is the number of decimals for Ethereum
+            ),
+            amountText: "0.0000000188",
+            memo: nil,
+            parser: parser
+        )
+
+        // '.' decimal separator
         testPositiveCase(
             code: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb?someArgument=someValue&value=1.68E11",
             destination: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
@@ -215,6 +262,40 @@ final class QRCodeParserTests: XCTestCase {
                 value: try XCTUnwrap(Decimal(stringValue: "0.000000168")) //  = 1.68 * 10^11 / 10^18, 18 is the number of decimals for Ethereum
             ),
             amountText: "0.000000168",
+            memo: nil,
+            parser: parser
+        )
+
+        // ',' decimal separator
+        testPositiveCase(
+            code: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb?someArgument=someValue&value=1,68E11",
+            destination: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
+            amount: Amount(
+                with: blockchain,
+                type: .coin,
+                value: try XCTUnwrap(Decimal(stringValue: "0.000000168")) //  = 1.68 * 10^11 / 10^18, 18 is the number of decimals for Ethereum
+            ),
+            amountText: "0.000000168",
+            memo: nil,
+            parser: parser
+        )
+
+        // We don't support mixed decimal separators and digit group separators like '1,234,567.89' or '1.234.567,89'
+        testPositiveCase(
+            code: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb?someArgument=someValue&value=1.222,91E11",
+            destination: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
+            amount: nil,
+            amountText: nil,
+            memo: nil,
+            parser: parser
+        )
+
+        // We don't support mixed decimal separators and digit group separators like '1,234,567.89' or '1.234.567,89'
+        testPositiveCase(
+            code: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb?someArgument=someValue&value=1,222.91E11",
+            destination: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
+            amount: nil,
+            amountText: nil,
             memo: nil,
             parser: parser
         )
@@ -354,6 +435,7 @@ final class QRCodeParserTests: XCTestCase {
             parser: parser
         )
 
+        // '.' decimal separator
         testPositiveCase(
             code: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb?someArgument=someValue&value=1.88e10",
             destination: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
@@ -367,6 +449,21 @@ final class QRCodeParserTests: XCTestCase {
             parser: parser
         )
 
+        // ',' decimal separator
+        testPositiveCase(
+            code: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb?someArgument=someValue&value=1,88e10",
+            destination: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
+            amount: Amount(
+                with: blockchain,
+                type: .token(value: exampleToken),
+                value: try XCTUnwrap(Decimal(stringValue: "1880")) //  = 1.88 * 10^10 / 10^7, 7 is the number of decimals for `exampleToken`
+            ),
+            amountText: "1880",
+            memo: nil,
+            parser: parser
+        )
+
+        // '.' decimal separator
         testPositiveCase(
             code: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb?someArgument=someValue&value=1.68E11",
             destination: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
@@ -376,6 +473,40 @@ final class QRCodeParserTests: XCTestCase {
                 value: try XCTUnwrap(Decimal(stringValue: "16800")) //  = 1.68 * 10^11 / 10^7, 7 is the number of decimals for `exampleToken`
             ),
             amountText: "16800",
+            memo: nil,
+            parser: parser
+        )
+
+        // ',' decimal separator
+        testPositiveCase(
+            code: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb?someArgument=someValue&value=1,68E11",
+            destination: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
+            amount: Amount(
+                with: blockchain,
+                type: .token(value: exampleToken),
+                value: try XCTUnwrap(Decimal(stringValue: "16800")) //  = 1.68 * 10^11 / 10^7, 7 is the number of decimals for `exampleToken`
+            ),
+            amountText: "16800",
+            memo: nil,
+            parser: parser
+        )
+
+        // We don't support mixed decimal separators and digit group separators like '1,234,567.89' or '1.234.567,89'
+        testPositiveCase(
+            code: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb?someArgument=someValue&value=1.222,91E11",
+            destination: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
+            amount: nil,
+            amountText: nil,
+            memo: nil,
+            parser: parser
+        )
+
+        // We don't support mixed decimal separators and digit group separators like '1,234,567.89' or '1.234.567,89'
+        testPositiveCase(
+            code: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb?someArgument=someValue&value=1,222.91E11",
+            destination: "0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb",
+            amount: nil,
+            amountText: nil,
             memo: nil,
             parser: parser
         )


### PR DESCRIPTION
[IOS-6585](https://tangem.atlassian.net/browse/IOS-6585)

[IOS-6585]: https://tangem.atlassian.net/browse/IOS-6585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ