### PR TITLE
IOS-6545 [Crash] Update Publisher+Async.swift

### DIFF
--- a/TangemFoundation/Extensions/Combine/Publisher+Async.swift
+++ b/TangemFoundation/Extensions/Combine/Publisher+Async.swift
@@ -12,6 +12,7 @@ import Foundation
 public extension Publisher {
     func async() async throws -> Output {
         var didSendValue = false
+        var didSendContinuation = false
         let cancellableWrapper = CancellableWrapper()
 
         return try await withTaskCancellationHandler {
@@ -25,6 +26,11 @@ public extension Publisher {
 
                 cancellableWrapper.value = first()
                     .handleEvents(receiveCancel: {
+                        guard !didSendContinuation || !didSendValue else {
+                            Swift.print("Publisher.Async() Received a cancellation after the completion was sent")
+                            return
+                        }
+
                         // We don't get a cancel error when cancelling a publisher, so we need
                         // to handle if the publisher was cancelled from the
                         // `withTaskCancellationHandler` here.
@@ -35,9 +41,11 @@ public extension Publisher {
                         } else if !didSendValue {
                             continuation.resume(throwing: AsyncError.valueWasNotEmittedBeforeCompletion)
                         }
+
+                        didSendContinuation = true
                     } receiveValue: { value in
                         didSendValue = true
-                        continuation.resume(with: .success(value))
+                        continuation.resume(returning: value)
                     }
             }
         } onCancel: {


### PR DESCRIPTION
Иногда бывает что уже после `completion` приходит эвент `cancel`
Ничего лучше не придумал, как добавить еще один флаг