### PR TITLE
IOS-6581: Crash: App launch crash

### DIFF
--- a/TangemFoundation/Extensions/Combine/Publisher+Async.swift
+++ b/TangemFoundation/Extensions/Combine/Publisher+Async.swift
@@ -29,6 +29,7 @@ public extension Publisher {
                         // to handle if the publisher was cancelled from the
                         // `withTaskCancellationHandler` here.
                         continuation.resume(throwing: CancellationError())
+                        didSendContinuation = true
                     }).sink { completion in
                         if case .failure(let error) = completion {
                             continuation.resume(throwing: error)


### PR DESCRIPTION
```
Crashed: com.apple.root.user-initiated-qos.cooperative
0  libswiftCore.dylib             0x398c0 _assertionFailure(_:_:file:line:flags:) + 264
1  libswift_Concurrency.dylib     0x5614 CheckedContinuation.resume(throwing:) + 476
2  TangemFoundation               0xe254 closure #1 in closure #1 in closure #1 in Publisher.async() + 32 (Publisher+Async.swift:32)
3  Combine                        0xe84c0 Publishers.HandleEvents.Inner.cancel() + 84
```

Скорее всего прилетело несколько `cancel`ов (несколько подписок/рейс кондишн/вложенность, что могло быть вызвано тем что приложение было свернуто). 

При возвращении ошибки в `continuation` из блока `handleEvents(receiveCancel:)` не выставляется флажок который должен блочить все потенциальные следующие вызовы `continuation.resume`, что и вызвало креш