### PR TITLE
IOS-6505: Use Ethereum L2 specific logic for all supported Ethereum L2s

### DIFF
--- a/Tangem/App/Services/ExchangeService/MercuryoService.swift
+++ b/Tangem/App/Services/ExchangeService/MercuryoService.swift
@@ -272,7 +272,7 @@ private extension Blockchain {
              .taraxa,
              .radiant:
             // Did you get a compilation error here? If so, check whether the network is supported at https://api.mercuryo.io/v1.6/lib/currencies
-            return nil // TODO: Andrey Fedorov - Add proper network ids (IOS-6506)
+            return nil
         }
     }
 }

--- a/Tangem/Common/Extensions/Blockchain+.swift
+++ b/Tangem/Common/Extensions/Blockchain+.swift
@@ -65,6 +65,8 @@ extension Set<Blockchain> {
 }
 
 extension Blockchain {
+    /// Provides a more descriptive display name for the fee currency (ETH) for some Ethereum L2s,
+    /// for example: `'Optimistic Ethereum (ETH)'` instead of just `'ETH'`
     var feeDisplayName: String {
         switch self {
         case .arbitrum,
@@ -74,8 +76,6 @@ extension Blockchain {
              .zkSync,
              .polygonZkEVM,
              .base:
-            // TODO: Andrey Fedorov - Add other L2s here (IOS-6505)
-            // Provides a more descriptive display name for the fee currency (ETH) for some Ethereum L2s
             return displayName + " (\(currencySymbol))"
         default:
             return currencySymbol

--- a/Tangem/Common/Extensions/Blockchain+.swift
+++ b/Tangem/Common/Extensions/Blockchain+.swift
@@ -69,6 +69,10 @@ extension Blockchain {
         switch self {
         case .arbitrum,
              .optimism,
+             .aurora,
+             .manta,
+             .zkSync,
+             .polygonZkEVM,
              .base:
             // TODO: Andrey Fedorov - Add other L2s here (IOS-6505)
             // Provides a more descriptive display name for the fee currency (ETH) for some Ethereum L2s

--- a/TangemFoundation/Helpers/ThreadSafeContainer/ThreadSafeContainer.swift
+++ b/TangemFoundation/Helpers/ThreadSafeContainer/ThreadSafeContainer.swift
@@ -8,11 +8,8 @@
 
 import Foundation
 
-// TODO: Andrey Fedorov - Move into `Core`/`Common`/`Utils`/etc module (IOS-4029)
-
 /// Provides `multiple readers - single writer` semantics for underlying `value`.
 /// It's most useful with Swift native collections like `Array`, `Dictionary`, etc.
-///
 @dynamicMemberLookup
 public final class ThreadSafeContainer<Value> {
     public subscript<T>(dynamicMember keyPath: KeyPath<Value, T>) -> T {


### PR DESCRIPTION
[IOS-6505](https://tangem.atlassian.net/browse/IOS-6505)

Прошелся по всем недавно добавленным EVM и добавил эту логику только для тех, которые L2 и используют ETH как fee

[IOS-6506]: https://tangem.atlassian.net/browse/IOS-6506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[IOS-6505]: https://tangem.atlassian.net/browse/IOS-6505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ