### PR TITLE
IOS-6337 Add unsupported apps

### DIFF
--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
@@ -510,7 +510,11 @@ final class WalletConnectV2Service {
 public typealias WalletConnectV2URI = WalletConnectURI
 
 private struct DApps {
-    private let unsupportedList: [String] = ["dydx.exchange"]
+    private let unsupportedList: [String] = [
+        "dydx.exchange",
+        "pro.apex.exchange",
+        "services.dfx.swiss",
+    ]
 
     func isSupported(_ dAppURL: String) -> Bool {
         for dApp in unsupportedList {


### PR DESCRIPTION
Пока исключил dapp из поддерживаемых. Как работает обьяснил.

Ревью обязательно от @Andoran90 