### PR TITLE
IOS-6743: Recreate single token page when API loaded

### DIFF
--- a/Tangem/App/Services/APIListProvider/CommonAPIListProvider.swift
+++ b/Tangem/App/Services/APIListProvider/CommonAPIListProvider.swift
@@ -82,7 +82,6 @@ extension CommonAPIListProvider: APIListProvider {
     var apiListPublisher: AnyPublisher<APIList, Never> {
         apiListSubject
             .compactMap { $0 }
-            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
 }

--- a/Tangem/Modules/Main/MainCardPageBuilder/MainUserWalletPageBuilder.swift
+++ b/Tangem/Modules/Main/MainCardPageBuilder/MainUserWalletPageBuilder.swift
@@ -10,7 +10,7 @@ import Foundation
 import SwiftUI
 
 enum MainUserWalletPageBuilder: Identifiable {
-    case singleWallet(id: UserWalletId, headerModel: MainHeaderViewModel, bodyModel: SingleWalletMainContentViewModel)
+    case singleWallet(id: UserWalletId, headerModel: MainHeaderViewModel, bodyModel: SingleWalletMainContentViewModel?)
     case multiWallet(id: UserWalletId, headerModel: MainHeaderViewModel, bodyModel: MultiWalletMainContentViewModel)
     case lockedWallet(id: UserWalletId, headerModel: MainHeaderViewModel, bodyModel: LockedWalletMainContentViewModel)
     case visaWallet(id: UserWalletId, headerModel: MainHeaderViewModel, bodyModel: VisaWalletMainContentViewModel)
@@ -66,8 +66,13 @@ enum MainUserWalletPageBuilder: Identifiable {
     var body: some View {
         switch self {
         case .singleWallet(let id, _, let bodyModel):
-            SingleWalletMainContentView(viewModel: bodyModel)
-                .id(id)
+            if let bodyModel {
+                SingleWalletMainContentView(viewModel: bodyModel)
+                    .id(id)
+            } else {
+                LoadingSingleWalletMainContentView()
+                    .id(id)
+            }
         case .multiWallet(let id, _, let bodyModel):
             MultiWalletMainContentView(viewModel: bodyModel)
                 .id(id)
@@ -77,6 +82,15 @@ enum MainUserWalletPageBuilder: Identifiable {
         case .visaWallet(let id, _, let bodyModel):
             VisaWalletMainContentView(viewModel: bodyModel)
                 .id(id)
+        }
+    }
+
+    var missingBodyModel: Bool {
+        switch self {
+        case .singleWallet(_, _, let bodyModel):
+            return bodyModel == nil
+        case .multiWallet, .lockedWallet, .visaWallet:
+            return false
         }
     }
 
@@ -101,7 +115,7 @@ extension MainUserWalletPageBuilder: MainViewPage {
     func onPageAppear() {
         switch self {
         case .singleWallet(_, _, let bodyModel):
-            bodyModel.onPageAppear()
+            bodyModel?.onPageAppear()
         case .multiWallet(_, _, let bodyModel):
             bodyModel.onPageAppear()
         case .lockedWallet, .visaWallet:
@@ -112,7 +126,7 @@ extension MainUserWalletPageBuilder: MainViewPage {
     func onPageDisappear() {
         switch self {
         case .singleWallet(_, _, let bodyModel):
-            bodyModel.onPageDisappear()
+            bodyModel?.onPageDisappear()
         case .multiWallet(_, _, let bodyModel):
             bodyModel.onPageDisappear()
         case .lockedWallet, .visaWallet:

--- a/Tangem/Modules/Main/MainCardPageBuilder/MainUserWalletPageBuilderFactory.swift
+++ b/Tangem/Modules/Main/MainCardPageBuilder/MainUserWalletPageBuilderFactory.swift
@@ -15,7 +15,7 @@ protocol MainUserWalletPageBuilderFactory {
         lockedUserWalletDelegate: MainLockedUserWalletDelegate,
         singleWalletContentDelegate: SingleWalletMainContentDelegate,
         multiWalletContentDelegate: MultiWalletMainContentDelegate?
-    ) -> MainUserWalletPageBuilder?
+    ) -> MainUserWalletPageBuilder
 
     func createPages(
         from models: [UserWalletModel],
@@ -34,7 +34,7 @@ struct CommonMainUserWalletPageBuilderFactory: MainUserWalletPageBuilderFactory 
         lockedUserWalletDelegate: MainLockedUserWalletDelegate,
         singleWalletContentDelegate: SingleWalletMainContentDelegate,
         multiWalletContentDelegate: MultiWalletMainContentDelegate?
-    ) -> MainUserWalletPageBuilder? {
+    ) -> MainUserWalletPageBuilder {
         if model.config is VisaConfig {
             return createVisaPage(userWalletModel: model, lockedUserWalletDelegate: lockedUserWalletDelegate)
         }
@@ -115,7 +115,7 @@ struct CommonMainUserWalletPageBuilderFactory: MainUserWalletPageBuilderFactory 
         }
 
         guard let walletModel = model.walletModelsManager.walletModels.first else {
-            return nil
+            return .singleWallet(id: id, headerModel: headerModel, bodyModel: nil)
         }
 
         let singleWalletNotificationManager = SingleTokenNotificationManager(

--- a/Tangem/Modules/Main/SingleWalletMainContent/LoadingSingleWalletMainContent/LoadingSingleWalletMainContentView.swift
+++ b/Tangem/Modules/Main/SingleWalletMainContent/LoadingSingleWalletMainContent/LoadingSingleWalletMainContentView.swift
@@ -1,0 +1,46 @@
+//
+//  LoadingSingleWalletMainContentView.swift
+//  Tangem
+//
+//  Created by Andrew Son on 08/05/24.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import SwiftUI
+
+struct LoadingSingleWalletMainContentView: View {
+    private let viewModel = LoadingSingleWalletMainContentViewModel()
+    var body: some View {
+        VStack(spacing: 14) {
+            ScrollableButtonsView(
+                itemsHorizontalOffset: 16,
+                buttonsInfo: viewModel.buttonsInfo
+            )
+
+            HStack(spacing: 0) {
+                VStack(alignment: .leading, spacing: 8) {
+                    SkeletonView()
+                        .frame(size: .init(width: 52, height: 12))
+                        .cornerRadiusContinuous(3)
+
+                    SkeletonView()
+                        .frame(size: .init(width: 70, height: 12))
+                        .cornerRadiusContinuous(3)
+                }
+
+                Spacer()
+            }
+            .padding(.vertical, 6)
+            .defaultRoundedBackground(with: Colors.Background.primary)
+
+            TransactionsListView(
+                state: .loading,
+                exploreAction: {}, exploreTransactionAction: { _ in },
+                reloadButtonAction: {},
+                isReloadButtonBusy: false,
+                fetchMore: nil
+            )
+        }
+        .padding(.horizontal, 16)
+    }
+}

--- a/Tangem/Modules/Main/SingleWalletMainContent/LoadingSingleWalletMainContent/LoadingSingleWalletMainContentViewModel.swift
+++ b/Tangem/Modules/Main/SingleWalletMainContent/LoadingSingleWalletMainContent/LoadingSingleWalletMainContentViewModel.swift
@@ -1,0 +1,23 @@
+//
+//  LoadingSingleWalletMainContentViewModel.swift
+//  Tangem
+//
+//  Created by Andrew Son on 08/05/24.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+struct LoadingSingleWalletMainContentViewModel {
+    let buttonsInfo: [FixedSizeButtonWithIconInfo] = TokenActionListBuilder()
+        .buildActionsForLockedSingleWallet()
+        .map {
+            FixedSizeButtonWithIconInfo(
+                title: $0.title,
+                icon: $0.icon,
+                disabled: true,
+                style: .disabled,
+                action: {}
+            )
+        }
+}

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -539,6 +539,8 @@
 		B0F319002A739477009F131E /* FakeWalletManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F318FF2A739477009F131E /* FakeWalletManager.swift */; };
 		B0F319022A7394AA009F131E /* FakeUserWalletRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F319012A7394AA009F131E /* FakeUserWalletRepository.swift */; };
 		B0F319042A7394C2009F131E /* FakeUserWalletModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F319032A7394C2009F131E /* FakeUserWalletModel.swift */; };
+		B0F3391B2BEB4C7D00441688 /* LoadingSingleWalletMainContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F3391A2BEB4C7D00441688 /* LoadingSingleWalletMainContentView.swift */; };
+		B0F3391D2BEB4C9500441688 /* LoadingSingleWalletMainContentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F3391C2BEB4C9500441688 /* LoadingSingleWalletMainContentViewModel.swift */; };
 		B0F62C4825DE4ABE005C8BA0 /* EmailType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F62C4725DE4ABE005C8BA0 /* EmailType.swift */; };
 		B0F62C5025DE4EC9005C8BA0 /* MailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F62C4F25DE4EC9005C8BA0 /* MailView.swift */; };
 		B0F62C5525DE4F6B005C8BA0 /* DeviceInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F62C5425DE4F6B005C8BA0 /* DeviceInfoProvider.swift */; };
@@ -2095,6 +2097,8 @@
 		B0F319052A7394E2009F131E /* xrpNote.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = xrpNote.json; sourceTree = "<group>"; };
 		B0F319062A73951E009F131E /* wallet2.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = wallet2.json; sourceTree = "<group>"; };
 		B0F319072A73954E009F131E /* twinCard.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = twinCard.json; sourceTree = "<group>"; };
+		B0F3391A2BEB4C7D00441688 /* LoadingSingleWalletMainContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingSingleWalletMainContentView.swift; sourceTree = "<group>"; };
+		B0F3391C2BEB4C9500441688 /* LoadingSingleWalletMainContentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingSingleWalletMainContentViewModel.swift; sourceTree = "<group>"; };
 		B0F62C4725DE4ABE005C8BA0 /* EmailType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailType.swift; sourceTree = "<group>"; };
 		B0F62C4F25DE4EC9005C8BA0 /* MailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailView.swift; sourceTree = "<group>"; };
 		B0F62C5425DE4F6B005C8BA0 /* DeviceInfoProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceInfoProvider.swift; sourceTree = "<group>"; };
@@ -4362,6 +4366,7 @@
 		B06C085F2A73FCC400D982BC /* SingleWalletMainContent */ = {
 			isa = PBXGroup;
 			children = (
+				B0F339192BEB4C5900441688 /* LoadingSingleWalletMainContent */,
 				B06C08622A73FCDE00D982BC /* SingleWalletMainContentView.swift */,
 				B06C08632A73FCDE00D982BC /* SingleWalletMainContentViewModel.swift */,
 				DAC4F9EF2AC314E100BEBCF8 /* SingleWalletMainContentDelegate.swift */,
@@ -5110,6 +5115,15 @@
 				B67DC1EB2B7C4CB9008ACB0E /* FakeBlockchainDataStorage.swift */,
 			);
 			path = Fakes;
+			sourceTree = "<group>";
+		};
+		B0F339192BEB4C5900441688 /* LoadingSingleWalletMainContent */ = {
+			isa = PBXGroup;
+			children = (
+				B0F3391A2BEB4C7D00441688 /* LoadingSingleWalletMainContentView.swift */,
+				B0F3391C2BEB4C9500441688 /* LoadingSingleWalletMainContentViewModel.swift */,
+			);
+			path = LoadingSingleWalletMainContent;
 			sourceTree = "<group>";
 		};
 		B0F7D75A2A40486B007FEB2E /* Utilities */ = {
@@ -8830,6 +8844,7 @@
 				EF74F50E289BF5AE001034D2 /* Text+.swift in Sources */,
 				DAC53CF827BE63830027147D /* StoriesTangemLogo.swift in Sources */,
 				2D9409742B8614CB00F0A196 /* BottomScrollableSheetStateHandler.swift in Sources */,
+				B0F3391B2BEB4C7D00441688 /* LoadingSingleWalletMainContentView.swift in Sources */,
 				DC295B4C2861D7CF006CB7B6 /* WalletConnectCoordinator.swift in Sources */,
 				B6ACD00C2AD698E0005A6CA3 /* DragAndDropGesturePredicate.swift in Sources */,
 				DC0A5801282500460031BECC /* SellCryptoRequest.swift in Sources */,
@@ -9540,6 +9555,7 @@
 				B6E9A8C72A9A35B5005CF137 /* MainFooterViewModel.swift in Sources */,
 				B064284629BF451F00A8AA20 /* OnboardingSeedPhraseImportView.swift in Sources */,
 				2DBE29C32B3C4A8100109D5E /* DetentBottomSheetModifier.swift in Sources */,
+				B0F3391D2BEB4C9500441688 /* LoadingSingleWalletMainContentViewModel.swift in Sources */,
 				B6E9AEA92B0E3B0B003183C8 /* MainBottomSheetOverlayCoordinatorView.swift in Sources */,
 				B0F318FB2A739418009F131E /* WalletPublicKeyDerivationStubs.swift in Sources */,
 				65B4DEE02885334F001524CF /* View+LegacyBottomSheet.swift in Sources */,
@@ -10135,7 +10151,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = "$(inherited)";
-				CODE_SIGN_ENTITLEMENTS = "$ENTITLEMENTS_PATH";
+				CODE_SIGN_ENTITLEMENTS = $ENTITLEMENTS_PATH;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -10281,7 +10297,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = "$(inherited)";
-				CODE_SIGN_ENTITLEMENTS = "$ENTITLEMENTS_PATH";
+				CODE_SIGN_ENTITLEMENTS = $ENTITLEMENTS_PATH;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -12527,7 +12543,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = "$(inherited)";
-				CODE_SIGN_ENTITLEMENTS = "$ENTITLEMENTS_PATH";
+				CODE_SIGN_ENTITLEMENTS = $ENTITLEMENTS_PATH;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEPLOYMENT_POSTPROCESSING = NO;
@@ -12778,7 +12794,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = "$(inherited)";
-				CODE_SIGN_ENTITLEMENTS = "$ENTITLEMENTS_PATH";
+				CODE_SIGN_ENTITLEMENTS = $ENTITLEMENTS_PATH;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -14016,7 +14032,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = "$(inherited)";
-				CODE_SIGN_ENTITLEMENTS = "$ENTITLEMENTS_PATH";
+				CODE_SIGN_ENTITLEMENTS = $ENTITLEMENTS_PATH;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEPLOYMENT_POSTPROCESSING = NO;
@@ -14267,7 +14283,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = "$(inherited)";
-				CODE_SIGN_ENTITLEMENTS = "$ENTITLEMENTS_PATH";
+				CODE_SIGN_ENTITLEMENTS = $ENTITLEMENTS_PATH;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;


### PR DESCRIPTION
Из-за того что информация по апишкам теперь загружается с бэка, происходила небольшая задержка в создании `WalletModel`, как результат - экран для одновалютных карточек не создавался.

* наконец убрал опционал при возврате страницы из фабрики, уже не один раз стреляло что карточки пропадали по разным причинам, теперь есть дебажная проверка что количество экранов на главной должно быть столько же сколько и `UserWalletModel`
* добавил поиск таких страниц и подписку, чтобы они все разом пересоздались и не было нескольких апдейтов

https://github.com/tangem/tangem-app-ios/assets/24321494/d15e8673-e259-4106-a154-c667fabdf54f

