### PR TITLE
IOS-6718: Rounded corners for single token list

### DIFF
--- a/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentView.swift
+++ b/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentView.swift
@@ -99,7 +99,8 @@ struct MultiWalletMainContentView: View {
                         let isLastItem = sectionIndex == viewModel.sections.count - 1 && itemIndex == section.items.count - 1
 
                         if isFirstItem {
-                            TokenItemView(viewModel: item, cornerRadius: cornerRadius, roundedCornersVerticalEdge: .topEdge)
+                            let isSingleItem = section.items.count == 1
+                            TokenItemView(viewModel: item, cornerRadius: cornerRadius, roundedCornersVerticalEdge: isSingleItem ? .all : .topEdge)
                         } else if isLastItem {
                             TokenItemView(viewModel: item, cornerRadius: cornerRadius, roundedCornersVerticalEdge: .bottomEdge)
                         } else {

--- a/Tangem/UIComponents/TokenItemView/TokenItemView.swift
+++ b/Tangem/UIComponents/TokenItemView/TokenItemView.swift
@@ -176,6 +176,13 @@ extension TokenItemView {
                 bottomLeadingRadius: cornerRadius,
                 bottomTrailingRadius: cornerRadius
             )
+        case .all:
+            roundedCornersConfiguration = RoundedCornersConfiguration(
+                topLeadingRadius: cornerRadius,
+                bottomLeadingRadius: cornerRadius,
+                bottomTrailingRadius: cornerRadius,
+                topTrailingRadius: cornerRadius
+            )
         case .none:
             roundedCornersConfiguration = nil
         }
@@ -199,6 +206,7 @@ extension TokenItemView {
     enum RoundedCornersVerticalEdge {
         case topEdge
         case bottomEdge
+        case all
     }
 
     private struct RoundedCornersConfiguration {


### PR DESCRIPTION
Не было закругления у ячейки токена, когда он всего 1 в списке. [IOS-6718](https://tangem.atlassian.net/browse/IOS-6718).

Добавил закругление

https://github.com/tangem/tangem-app-ios/assets/24321494/72faef59-bc3d-4e2b-af97-6937040e3240




[IOS-6718]: https://tangem.atlassian.net/browse/IOS-6718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ