### PR TITLE
IOS-6700: Update hide token message

### DIFF
--- a/Tangem/Modules/LegacyTokenList/LegacyTokenListViewModel.swift
+++ b/Tangem/Modules/LegacyTokenList/LegacyTokenListViewModel.swift
@@ -332,6 +332,7 @@ private extension LegacyTokenListViewModel {
             let title = Localization.tokenDetailsUnableHideAlertTitle(tokenItem.blockchain.currencySymbol)
 
             let message = Localization.tokenDetailsUnableHideAlertMessage(
+                tokenItem.name,
                 tokenItem.blockchain.currencySymbol,
                 tokenItem.blockchain.displayName
             )

--- a/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentViewModel.swift
+++ b/Tangem/Modules/Main/MultiWalletMainContent/MultiWalletMainContentViewModel.swift
@@ -283,13 +283,13 @@ private extension MultiWalletMainContentViewModel {
         if userWalletModel.userTokensManager.canRemove(tokenItem) {
             showHideWarningAlert(tokenItem: tokenItem)
         } else {
-            showUnableToHideAlert(currencySymbol: tokenItem.currencySymbol, blockchainName: tokenItem.blockchain.displayName)
+            showUnableToHideAlert(name: tokenItem.name, currencySymbol: tokenItem.currencySymbol, blockchainName: tokenItem.blockchain.displayName)
         }
     }
 
     func showHideWarningAlert(tokenItem: TokenItem) {
         error = AlertBuilder.makeAlert(
-            title: Localization.tokenDetailsHideAlertTitle(tokenItem.currencySymbol),
+            title: Localization.tokenDetailsHideAlertTitle(tokenItem.name),
             message: Localization.tokenDetailsHideAlertMessage,
             primaryButton: .destructive(Text(Localization.tokenDetailsHideAlertHide)) { [weak self] in
                 self?.hideToken(tokenItem: tokenItem)
@@ -298,14 +298,15 @@ private extension MultiWalletMainContentViewModel {
         )
     }
 
-    func showUnableToHideAlert(currencySymbol: String, blockchainName: String) {
+    func showUnableToHideAlert(name: String, currencySymbol: String, blockchainName: String) {
         let message = Localization.tokenDetailsUnableHideAlertMessage(
+            name,
             currencySymbol,
             blockchainName
         )
 
         error = AlertBuilder.makeAlert(
-            title: Localization.tokenDetailsUnableHideAlertTitle(currencySymbol),
+            title: Localization.tokenDetailsUnableHideAlertTitle(name),
             message: message,
             primaryButton: .default(Text(Localization.commonOk))
         )

--- a/Tangem/Modules/ManageTokensNetworkSelector/ManageTokensNetworkSelectorAlertBuilder.swift
+++ b/Tangem/Modules/ManageTokensNetworkSelector/ManageTokensNetworkSelectorAlertBuilder.swift
@@ -34,6 +34,7 @@ struct ManageTokensNetworkSelectorAlertBuilder {
         let title = Localization.tokenDetailsUnableHideAlertTitle(tokenItem.blockchain.currencySymbol)
 
         let message = Localization.tokenDetailsUnableHideAlertMessage(
+            tokenItem.name,
             tokenItem.blockchain.currencySymbol,
             tokenItem.blockchain.displayName
         )

--- a/Tangem/Modules/TokenDetails/TokenDetailsViewModel.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsViewModel.swift
@@ -99,13 +99,15 @@ extension TokenDetailsViewModel {
     }
 
     private func showUnableToHideAlert() {
+        let tokenName = walletModel.tokenItem.name
         let message = Localization.tokenDetailsUnableHideAlertMessage(
+            tokenName,
             currencySymbol,
             blockchain.displayName
         )
 
         alert = AlertBuilder.makeAlert(
-            title: Localization.tokenDetailsUnableHideAlertTitle(currencySymbol),
+            title: Localization.tokenDetailsUnableHideAlertTitle(tokenName),
             message: message,
             primaryButton: .default(Text(Localization.commonOk))
         )
@@ -113,7 +115,7 @@ extension TokenDetailsViewModel {
 
     private func showHideWarningAlert() {
         alert = AlertBuilder.makeAlert(
-            title: Localization.tokenDetailsHideAlertTitle(currencySymbol),
+            title: Localization.tokenDetailsHideAlertTitle(walletModel.tokenItem.name),
             message: Localization.tokenDetailsHideAlertMessage,
             primaryButton: .destructive(Text(Localization.tokenDetailsHideAlertHide)) { [weak self] in
                 self?.hideToken()

--- a/Tangem/Resources/Localizations/de.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/de.lproj/Localizable.strings
@@ -547,7 +547,7 @@
 "token_details_hide_alert_title" = "Hide %@";
 "token_details_hide_token" = "Hide token";
 "token_details_token_type_subtitle" = "%1$@ token in %%image%% %2$@ network";
-"token_details_unable_hide_alert_message" = "The %1$@ token is the main currency on the %2$@ network and cannot be hidden as long as you have other tokens on this network in the list.";
+"token_details_unable_hide_alert_message" = "The %1$@ (%2$@) token is the main currency on the %3$@ network and cannot be hidden as long as you have other tokens on this network in the list";
 "token_details_unable_hide_alert_title" = "Unable to hide %@";
 "token_swap_changelly_promotion_message" = "Exchange this token for another at %1$@ service fees from February %2$@-%3$@.";
 "token_swap_changelly_promotion_title" = "Swap with Changelly, %@ fees";

--- a/Tangem/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/en.lproj/Localizable.strings
@@ -547,7 +547,7 @@
 "token_details_hide_alert_title" = "Hide %@";
 "token_details_hide_token" = "Hide token";
 "token_details_token_type_subtitle" = "%1$@ token in %%image%% %2$@ network";
-"token_details_unable_hide_alert_message" = "The %1$@ token is the main currency on the %2$@ network and cannot be hidden as long as you have other tokens on this network in the list.";
+"token_details_unable_hide_alert_message" = "The %1$@ (%2$@) token is the main currency on the %3$@ network and cannot be hidden as long as you have other tokens on this network in the list";
 "token_details_unable_hide_alert_title" = "Unable to hide %@";
 "token_swap_changelly_promotion_message" = "Exchange this token for another at %1$@ service fees from February %2$@-%3$@.";
 "token_swap_changelly_promotion_title" = "Swap with Changelly, %@ fees";

--- a/Tangem/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/fr.lproj/Localizable.strings
@@ -547,7 +547,7 @@
 "token_details_hide_alert_title" = "Hide %@";
 "token_details_hide_token" = "Hide token";
 "token_details_token_type_subtitle" = "%1$@ token in %%image%% %2$@ network";
-"token_details_unable_hide_alert_message" = "The %1$@ token is the main currency on the %2$@ network and cannot be hidden as long as you have other tokens on this network in the list.";
+"token_details_unable_hide_alert_message" = "The %1$@ (%2$@) token is the main currency on the %3$@ network and cannot be hidden as long as you have other tokens on this network in the list";
 "token_details_unable_hide_alert_title" = "Unable to hide %@";
 "token_swap_changelly_promotion_message" = "Exchange this token for another at %1$@ service fees from February %2$@-%3$@.";
 "token_swap_changelly_promotion_title" = "Swap with Changelly, %@ fees";

--- a/Tangem/Resources/Localizations/it.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/it.lproj/Localizable.strings
@@ -547,7 +547,7 @@
 "token_details_hide_alert_title" = "Hide %@";
 "token_details_hide_token" = "Hide token";
 "token_details_token_type_subtitle" = "%1$@ token in %%image%% %2$@ network";
-"token_details_unable_hide_alert_message" = "The %1$@ token is the main currency on the %2$@ network and cannot be hidden as long as you have other tokens on this network in the list.";
+"token_details_unable_hide_alert_message" = "The %1$@ (%2$@) token is the main currency on the %3$@ network and cannot be hidden as long as you have other tokens on this network in the list";
 "token_details_unable_hide_alert_title" = "Unable to hide %@";
 "token_swap_changelly_promotion_message" = "Exchange this token for another at %1$@ service fees from February %2$@-%3$@.";
 "token_swap_changelly_promotion_title" = "Swap with Changelly, %@ fees";

--- a/Tangem/Resources/Localizations/ru.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/ru.lproj/Localizable.strings
@@ -547,7 +547,7 @@
 "token_details_hide_alert_title" = "Скрыть %@";
 "token_details_hide_token" = "Скрыть токен";
 "token_details_token_type_subtitle" = "%1$@ токен в сети %%image%% %2$@";
-"token_details_unable_hide_alert_message" = "Токен %1$@ является основной валютой в сети %2$@ и не может быть скрыт до тех пор, пока у вас в списке есть другие токены этой сети.";
+"token_details_unable_hide_alert_message" = "Токен %1$@ (%2$@) является основной валютой в сети %3$@ и не может быть скрыт до тех пор, пока у вас в списке есть другие токены этой сети";
 "token_details_unable_hide_alert_title" = "Невозможно скрыть %@";
 "token_swap_changelly_promotion_message" = "Обменивайте этот токен на другие с %1$@ комиссии за обслуживание с %2$@ по %3$@ февраля.";
 "token_swap_changelly_promotion_title" = "Обмен с Changelly, %@ комиссии";

--- a/Tangem/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -547,7 +547,7 @@
 "token_details_hide_alert_title" = "隱藏 %@";
 "token_details_hide_token" = "隱藏代幣";
 "token_details_token_type_subtitle" = "%1$@ token in %%image%% %2$@ network";
-"token_details_unable_hide_alert_message" = "%1$@ 代幣是 %2$@ 網絡上的主要貨幣，只要列表中還有該網絡上的其他代幣，它就無法被隱藏。";
+"token_details_unable_hide_alert_message" = "%1$@ (%2$@) 代幣是 %3$@ 網絡上的主要貨幣，只要列表中還有該網絡上的其他代幣，它就無法被隱藏。";
 "token_details_unable_hide_alert_title" = "無法隱藏 %@";
 "token_swap_changelly_promotion_message" = "Exchange this token for another at %1$@ service fees from February %2$@-%3$@.";
 "token_swap_changelly_promotion_title" = "Swap with Changelly, %@ fees";


### PR DESCRIPTION
Раньше показывалось только название токена и для оптимизма (и некоторых других типа Арбитрума) получалось:
`Unable to hide ETH`
`The ETH token is the main currency on the Optimistic Ethereum network...`

<img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/f3971d47-0ab5-4ae1-91bf-58d5e532f34b"><img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/7b733062-a302-486e-a348-0a5706260a69">
<img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/8d5f1021-507c-4fd7-9c36-389474eac342"><img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/2a87436e-b52f-4a86-b0e6-5a47482c8f43">
<img width="300" src="https://github.com/tangem/tangem-app-ios/assets/24321494/572153e7-b048-438b-89b7-34f24bdccd6d">
