### PR TITLE
IOS-6866 Use shouldKeepParent: false when compressing logs

### DIFF
--- a/Tangem/App/Email/DataCollectors.swift
+++ b/Tangem/App/Email/DataCollectors.swift
@@ -14,7 +14,7 @@ protocol EmailDataCollector: LogFileProvider {}
 
 extension EmailDataCollector {
     var fileName: String {
-        "infoLogs.txt"
+        LogFilesNames.infoLogs
     }
 
     func prepareLogFile() -> URL {

--- a/Tangem/App/Email/LogFileProvider.swift
+++ b/Tangem/App/Email/LogFileProvider.swift
@@ -13,3 +13,8 @@ protocol LogFileProvider {
     var logData: Data? { get }
     func prepareLogFile() -> URL
 }
+
+enum LogFilesNames {
+    static let infoLogs = "infoLogs.txt"
+    static let scanLogs = "scanLogs.txt"
+}

--- a/Tangem/App/Email/MailView.swift
+++ b/Tangem/App/Email/MailView.swift
@@ -74,7 +74,7 @@ struct MailView: UIViewControllerRepresentable {
             let destinationURL = fileManager.temporaryDirectory.appendingPathComponent(archiveName, conformingTo: .zip)
             do {
                 try? fileManager.removeItem(at: destinationURL)
-                try fileManager.zipItem(at: originalURL, to: destinationURL, compressionMethod: .deflate)
+                try fileManager.zipItem(at: originalURL, to: destinationURL, shouldKeepParent: false, compressionMethod: .deflate)
                 let data = try Data(contentsOf: destinationURL)
                 vc.addAttachmentData(data, mimeType: "application/zip", fileName: archiveName)
             } catch {

--- a/Tangem/App/Email/MailView.swift
+++ b/Tangem/App/Email/MailView.swift
@@ -68,19 +68,16 @@ struct MailView: UIViewControllerRepresentable {
         vc.setMessageBody(messageBody, isHTML: false)
 
         let logFiles = viewModel.logsComposer.getLogFiles()
-        let fileManager = FileManager.default
+
         logFiles.forEach { originalURL in
-            let archiveName = originalURL.appendingPathExtension(for: .zip).lastPathComponent
-            let destinationURL = fileManager.temporaryDirectory.appendingPathComponent(archiveName, conformingTo: .zip)
+            guard originalURL.lastPathComponent != LogFilesNames.infoLogs else {
+                attachPlainTextData(at: originalURL, to: vc)
+                return
+            }
             do {
-                try? fileManager.removeItem(at: destinationURL)
-                try fileManager.zipItem(at: originalURL, to: destinationURL, shouldKeepParent: false, compressionMethod: .deflate)
-                let data = try Data(contentsOf: destinationURL)
-                vc.addAttachmentData(data, mimeType: "application/zip", fileName: archiveName)
+                try attachZipData(at: originalURL, to: vc)
             } catch {
-                if let data = try? Data(contentsOf: originalURL) {
-                    vc.addAttachmentData(data, mimeType: "text/plain", fileName: originalURL.lastPathComponent)
-                }
+                attachPlainTextData(at: originalURL, to: vc)
             }
         }
 
@@ -91,6 +88,22 @@ struct MailView: UIViewControllerRepresentable {
         _ uiViewController: UIViewController,
         context: UIViewControllerRepresentableContext<MailView>
     ) {}
+
+    private func attachPlainTextData(at url: URL, to viewController: MFMailComposeViewController) {
+        if let data = try? Data(contentsOf: url) {
+            viewController.addAttachmentData(data, mimeType: "text/plain", fileName: url.lastPathComponent)
+        }
+    }
+
+    private func attachZipData(at url: URL, to viewController: MFMailComposeViewController) throws {
+        let fileManager = FileManager.default
+        let archiveName = url.appendingPathExtension(for: .zip).lastPathComponent
+        let destinationURL = fileManager.temporaryDirectory.appendingPathComponent(archiveName, conformingTo: .zip)
+        try? fileManager.removeItem(at: destinationURL)
+        try fileManager.zipItem(at: url, to: destinationURL, shouldKeepParent: false, compressionMethod: .deflate)
+        let data = try Data(contentsOf: destinationURL)
+        viewController.addAttachmentData(data, mimeType: "application/zip", fileName: archiveName)
+    }
 }
 
 private struct MailViewPlaceholder: View {

--- a/Tangem/App/Utilities/FileLogger.swift
+++ b/Tangem/App/Utilities/FileLogger.swift
@@ -72,7 +72,7 @@ class FileLogger: TangemSdkLogger {
 
 extension FileLogger: LogFileProvider {
     var fileName: String {
-        "scanLogs.txt"
+        LogFilesNames.scanLogs
     }
 
     var logData: Data? {


### PR DESCRIPTION
Не архивируем infoLogs.txt, также убираем лишнюю вложенность в архиве scanLogs, в распакованном архиве будет только файл логов, а не файл внутри папки. 