### PR TITLE
IOS-6871: Fix travala duplication

### DIFF
--- a/Tangem/App/Services/NotificationManagers/UserWalletNotifications/UserWalletNotificationManager.swift
+++ b/Tangem/App/Services/NotificationManagers/UserWalletNotifications/UserWalletNotificationManager.swift
@@ -121,6 +121,10 @@ final class UserWalletNotificationManager {
                 return
             }
 
+            if Task.isCancelled {
+                return
+            }
+
             let factory = BannerPromotionNotificationFactory()
             let button = factory.buildNotificationButton(actionType: .bookNow(promotionLink: promotionLink)) { [weak self] id, action in
                 var parameters = BannerNotificationEvent.travala(description: "").analyticsParams
@@ -136,11 +140,15 @@ final class UserWalletNotificationManager {
                 dismissAction: dismissAction
             )
 
-            guard !notificationInputsSubject.value.contains(where: { $0.id == input.id }) else {
-                return
-            }
-
             await runOnMain {
+                if Task.isCancelled {
+                    return
+                }
+
+                guard !self.notificationInputsSubject.value.contains(where: { $0.id == input.id }) else {
+                    return
+                }
+
                 self.notificationInputsSubject.value.insert(input, at: 0)
             }
         }


### PR DESCRIPTION
В общем проблема была в том, что проверка на наличие оповещения находится за пределами переключения на основной потом + не было проверки на то отменен ли таск или нет, это происходило только в самом начале, что в целом не особо целесообразно, т.к. если есть ресурсы, то таска сразу стартует и проверка будет ложно положительной (таска не отменена).

Добавил:
* дополнительную проверку сразу после получения информации о промо, самое норм место для проверки, т.к. происходит сразу после сетевого запроса
* проверку на отмену таски при переключении на основной поток, т.к. задачи передаваемые на основной поток не сразу выполняются, а только со следующего прогона, так что может получиться ситуация, что два запроса почти одновременно прошли, запланировали добавление оповещения. Очень маловероятно, я бы сказал что близко к 0.
* перенес поиск оповещения на главный поток, не так много будет оповещений, так что это не будет проблемой выполнить на основном потоке.

В идеале бы добавить лок на отправку оповещений и, наверное, обновить подход к изначальному сетапу оповещений, но пока что нет идей как это сделать, ну и вряд ли это будет быстро, не в рамках багофикса это исправлять.
