### PR TITLE
IOS-6984 Fix unlocking via onboarding

### DIFF
--- a/Tangem/App/Services/UserWalletRepository/CommonUserWalletRepository.swift
+++ b/Tangem/App/Services/UserWalletRepository/CommonUserWalletRepository.swift
@@ -420,10 +420,19 @@ class CommonUserWalletRepository: UserWalletRepository {
         scanPublisher(scanner)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] result in
-                guard
-                    let self,
-                    case .success(let userWalletModel) = result
-                else {
+                guard let self else {
+                    completion(result)
+                    return
+                }
+
+                // Scan new card via welcome screen with locked repository.
+                if case .onboarding = result, models.isEmpty, AppSettings.shared.saveUserWallets {
+                    loadModels()
+                    completion(result)
+                    return
+                }
+
+                guard case .success(let userWalletModel) = result else {
                     completion(result)
                     return
                 }


### PR DESCRIPTION
Если на экране велком вместо биометрии войти со сканом новой карты, то карточки исчезали из-за того, что не хэндлился этот кейс