### PR TITLE
IOS-7021 Filter recents

### DIFF
--- a/Tangem/App/Services/TransactionHistoryRepository/CommonTransactionHistoryService.swift
+++ b/Tangem/App/Services/TransactionHistoryRepository/CommonTransactionHistoryService.swift
@@ -18,7 +18,7 @@ class CommonTransactionHistoryService {
     private let transactionHistoryProvider: TransactionHistoryProvider
 
     private var _state = CurrentValueSubject<TransactionHistoryServiceState, Never>(.initial)
-    private let pageSize: Int = 50
+    private let pageSize: Int = 100
     private var cancellable: AnyCancellable?
     private var storage: ThreadSafeContainer<[TransactionRecord]> = []
 

--- a/Tangem/App/Services/TransactionHistoryRepository/CommonTransactionHistoryService.swift
+++ b/Tangem/App/Services/TransactionHistoryRepository/CommonTransactionHistoryService.swift
@@ -84,8 +84,6 @@ private extension CommonTransactionHistoryService {
         AppLog.shared.debug("\(self) start loading")
         _state.send(.loading)
 
-        // Load 2 pages initially
-        let pageSize = items.isEmpty ? pageSize * 2 : pageSize
         let request = TransactionHistory.Request(address: address, amountType: tokenItem.amountType, limit: pageSize)
 
         cancellable = transactionHistoryProvider

--- a/Tangem/App/Services/TransactionHistoryRepository/CommonTransactionHistoryService.swift
+++ b/Tangem/App/Services/TransactionHistoryRepository/CommonTransactionHistoryService.swift
@@ -18,7 +18,7 @@ class CommonTransactionHistoryService {
     private let transactionHistoryProvider: TransactionHistoryProvider
 
     private var _state = CurrentValueSubject<TransactionHistoryServiceState, Never>(.initial)
-    private let pageSize: Int = 20
+    private let pageSize: Int = 50
     private var cancellable: AnyCancellable?
     private var storage: ThreadSafeContainer<[TransactionRecord]> = []
 
@@ -84,6 +84,8 @@ private extension CommonTransactionHistoryService {
         AppLog.shared.debug("\(self) start loading")
         _state.send(.loading)
 
+        // Load 2 pages initially
+        let pageSize = items.isEmpty ? pageSize * 2 : pageSize
         let request = TransactionHistory.Request(address: address, amountType: tokenItem.amountType, limit: pageSize)
 
         cancellable = transactionHistoryProvider

--- a/Tangem/App/Services/TransactionHistoryRepository/MultipleAddressTransactionHistoryService.swift
+++ b/Tangem/App/Services/TransactionHistoryRepository/MultipleAddressTransactionHistoryService.swift
@@ -137,8 +137,6 @@ private extension MultipleAddressTransactionHistoryService {
     }
 
     func loadTransactionHistory(address: String) throws -> LoadingPublisher {
-        // Load 2 pages initially
-        let pageSize = items.isEmpty ? pageSize * 2 : pageSize
         let request = TransactionHistory.Request(address: address, amountType: tokenItem.amountType, limit: pageSize)
 
         guard let provider = transactionHistoryProviders[address] else {

--- a/Tangem/App/Services/TransactionHistoryRepository/MultipleAddressTransactionHistoryService.swift
+++ b/Tangem/App/Services/TransactionHistoryRepository/MultipleAddressTransactionHistoryService.swift
@@ -18,7 +18,7 @@ class MultipleAddressTransactionHistoryService {
     private let transactionHistoryProviders: [String: TransactionHistoryProvider]
 
     private var _state = CurrentValueSubject<TransactionHistoryServiceState, Never>(.initial)
-    private let pageSize: Int = 20
+    private let pageSize: Int = 50
     private var cancellable: AnyCancellable?
     private var storage: ThreadSafeContainer<[TransactionRecord]> = []
 
@@ -137,6 +137,8 @@ private extension MultipleAddressTransactionHistoryService {
     }
 
     func loadTransactionHistory(address: String) throws -> LoadingPublisher {
+        // Load 2 pages initially
+        let pageSize = items.isEmpty ? pageSize * 2 : pageSize
         let request = TransactionHistory.Request(address: address, amountType: tokenItem.amountType, limit: pageSize)
 
         guard let provider = transactionHistoryProviders[address] else {

--- a/Tangem/App/Services/TransactionHistoryRepository/MultipleAddressTransactionHistoryService.swift
+++ b/Tangem/App/Services/TransactionHistoryRepository/MultipleAddressTransactionHistoryService.swift
@@ -18,7 +18,7 @@ class MultipleAddressTransactionHistoryService {
     private let transactionHistoryProviders: [String: TransactionHistoryProvider]
 
     private var _state = CurrentValueSubject<TransactionHistoryServiceState, Never>(.initial)
-    private let pageSize: Int = 50
+    private let pageSize: Int = 100
     private var cancellable: AnyCancellable?
     private var storage: ThreadSafeContainer<[TransactionRecord]> = []
 

--- a/Tangem/App/Utilities/TransactionHistoryMapper.swift
+++ b/Tangem/App/Utilities/TransactionHistoryMapper.swift
@@ -77,6 +77,7 @@ struct TransactionHistoryMapper {
 
     func mapSuggestedRecord(_ record: TransactionRecord) -> SendSuggestedDestinationTransactionRecord? {
         guard
+            record.isOutgoing,
             transactionType(from: record) == .transfer,
             case .user(let address) = interactionAddress(from: record)
         else {


### PR DESCRIPTION
- добавлена фильтрация транзакций в блоке recent. Теперь показываем только исходящие
- в андроиде грузили по 50, сделал у нас тоже 50
- договорились грузить 2 страницы на старте, не нашел как задавать количество страниц, поэтому сделал увеличение размера страницы в два раза, если список пустой