### PR TITLE
IOS-6863: WC handle staled JWT

### DIFF
--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/Utilities/WalletConnectV2DefaultSocketFactory.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/Utilities/WalletConnectV2DefaultSocketFactory.swift
@@ -13,11 +13,11 @@ class WalletConnectV2DefaultSocketFactory: WebSocketFactory {
     /// `create(with url: URL)` is called from internal entities of WalletConnectSwiftV2 lib
     /// but we also need to have access to `WebSocket` to be able to get current connection status
     /// otherwise continuation issues may occur during new session connection
-    private(set) var lastCreatetSocket: WebSocket?
+    private(set) var lastCreatedSocket: WebSocket?
 
     func create(with url: URL) -> WebSocketConnecting {
         let socket = WebSocket(url: url)
-        lastCreatetSocket = socket
+        lastCreatedSocket = socket
         return socket
     }
 }

--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
@@ -138,7 +138,7 @@ final class WalletConnectV2Service {
     }
 
     private func checkSocketConnection() async -> Bool {
-        guard let socket = factory.lastCreatetSocket else {
+        guard let socket = factory.lastCreatedSocket else {
             return false
         }
 


### PR DESCRIPTION
Какая проблема была:
При сворачивании приложения, оно могло не выгружаться довольно долго, а в ссылке на подключение содержится JWT, которых хранит дату протухания ссылки. Токен валиден только 1 день. В результате спустя сутки из сокета прилетала ошибка `Error Domain=NSURLErrorDomain Code=-1011 "There was a bad response from the server."`, а в UI показывалась ошибка 8021, что сокет не подключен. Приложение продолжало пытаться переподключиться и спамило дофига бесполезных сообщений в лог.

пришлось захардкодить номер ошибки, чтобы при этой ошибке сообщать либе, что была проблема подключения и она пересоздавала ссылку с новым JWT. 
В либе нет функционала, дающего возможность извне пересоздавать этот токен и обновлять ссылку в сокете.