### PR TITLE
IOS-7084: Fix existential deposit handling in Express

### DIFF
--- a/Tangem/App/Services/ExpressInteractor/ExpressInteractor.swift
+++ b/Tangem/App/Services/ExpressInteractor/ExpressInteractor.swift
@@ -438,16 +438,12 @@ private extension ExpressInteractor {
         do {
             let transactionValidator = getSender().transactionValidator
             try await transactionValidator.validate(amount: amount, fee: fee, destination: .generate)
-
         } catch ValidationError.totalExceedsBalance, ValidationError.amountExceedsBalance {
             return .restriction(.notEnoughBalanceForSwapping(requiredAmount: amount.value), quote: correctState.quote)
-
         } catch ValidationError.feeExceedsBalance {
             return .restriction(.notEnoughAmountForFee(correctState), quote: correctState.quote)
-
         } catch let error as ValidationError {
-
-            let context = ValidationErrorContext(isFeeCurrency: fee.amount.type == amount.type, feeAmount: fee.amount.value)
+            let context = ValidationErrorContext(isFeeCurrency: fee.amount.type == amount.type, feeValue: fee.amount.value)
             return .restriction(.validationError(error: error, context: context), quote: correctState.quote)
         } catch {
             return .restriction(.requiredRefresh(occurredError: error), quote: correctState.quote)
@@ -494,7 +490,7 @@ private extension ExpressInteractor {
                 return .restriction(.noDestinationTokens, quote: .none)
             }
 
-            // If we have a amount to we will start the full update
+            // If we have an amount to we will start the full update
             if let amount = await interactor.expressManager.getAmount(), amount > 0 {
                 interactor.updateState(.loading(type: .full))
             }

--- a/Tangem/App/Services/ExpressInteractor/ExpressInteractor.swift
+++ b/Tangem/App/Services/ExpressInteractor/ExpressInteractor.swift
@@ -446,8 +446,9 @@ private extension ExpressInteractor {
             return .restriction(.notEnoughAmountForFee(correctState), quote: correctState.quote)
 
         } catch let error as ValidationError {
-            return .restriction(.validationError(error), quote: correctState.quote)
 
+            let context = ValidationErrorContext(isFeeCurrency: fee.amount.type == amount.type, feeAmount: fee.amount.value)
+            return .restriction(.validationError(error: error, context: context), quote: correctState.quote)
         } catch {
             return .restriction(.requiredRefresh(occurredError: error), quote: correctState.quote)
         }
@@ -820,7 +821,7 @@ extension ExpressInteractor {
         case notEnoughAmountForFee(_ returnState: State)
         case requiredRefresh(occurredError: Error)
         case noDestinationTokens
-        case validationError(ValidationError)
+        case validationError(error: ValidationError, context: ValidationErrorContext)
         case notEnoughReceivedAmount(minAmount: Decimal, tokenSymbol: String)
     }
 

--- a/Tangem/App/Services/NotificationManagers/BlockchainSDKNotifications/ValidationErrorContext.swift
+++ b/Tangem/App/Services/NotificationManagers/BlockchainSDKNotifications/ValidationErrorContext.swift
@@ -12,5 +12,5 @@ import Foundation
 struct ValidationErrorContext: Hashable {
     /// `true` when the transaction is denominated in the same currency as the fee currency for the blockchain, `false` otherwise.
     let isFeeCurrency: Bool
-    let feeAmount: Decimal
+    let feeValue: Decimal
 }

--- a/Tangem/App/Services/NotificationManagers/BlockchainSDKNotifications/ValidationErrorContext.swift
+++ b/Tangem/App/Services/NotificationManagers/BlockchainSDKNotifications/ValidationErrorContext.swift
@@ -1,0 +1,16 @@
+//
+//  ValidationErrorContext.swift
+//  Tangem
+//
+//  Created by Andrey Fedorov on 14.06.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+/// Carries additional information for a failed validation of the transaction.
+struct ValidationErrorContext: Hashable {
+    /// `true` when the transaction is denominated in the same currency as the fee currency for the blockchain, `false` otherwise.
+    let isFeeCurrency: Bool
+    let feeAmount: Decimal
+}

--- a/Tangem/App/Services/NotificationManagers/ExpressNotifications/ExpressNotificationEvent.swift
+++ b/Tangem/App/Services/NotificationManagers/ExpressNotifications/ExpressNotificationEvent.swift
@@ -24,7 +24,7 @@ enum ExpressNotificationEvent {
 
     // Generic notifications is received from BSDK
     case withdrawalNotificationEvent(WithdrawalNotificationEvent)
-    case validationErrorEvent(ValidationErrorEvent)
+    case validationErrorEvent(event: ValidationErrorEvent, context: ValidationErrorContext)
 
     // The notifications which is used only on the PendingExpressTxStatusBottomSheetView
     case verificationRequired
@@ -60,7 +60,7 @@ extension ExpressNotificationEvent: NotificationEvent {
             return .string(Localization.warningExpressNotificationInvalidReserveAmountTitle(amountFormatted))
         case .withdrawalNotificationEvent(let event):
             return event.title
-        case .validationErrorEvent(let event):
+        case .validationErrorEvent(let event, _):
             return event.title
         }
     }
@@ -90,11 +90,11 @@ extension ExpressNotificationEvent: NotificationEvent {
         case .feeWillBeSubtractFromSendingAmount(let cryptoAmountFormatted, let fiatAmountFormatted):
             return Localization.commonNetworkFeeWarningContent(cryptoAmountFormatted, fiatAmountFormatted)
         // Only for dustRestriction we have to use different desription
-        case .validationErrorEvent(.dustRestriction(let minimumAmountFormatted, let minimumChangeFormatted)):
+        case .validationErrorEvent(.dustRestriction(let minimumAmountFormatted, let minimumChangeFormatted), _):
             return Localization.warningExpressDustMessage(minimumAmountFormatted, minimumChangeFormatted)
         case .withdrawalNotificationEvent(let event):
             return event.description
-        case .validationErrorEvent(let event):
+        case .validationErrorEvent(let event, _):
             return event.description
         }
     }
@@ -117,7 +117,7 @@ extension ExpressNotificationEvent: NotificationEvent {
             return .action
         case .withdrawalNotificationEvent(let event):
             return event.colorScheme
-        case .validationErrorEvent(let event):
+        case .validationErrorEvent(let event, _):
             return event.colorScheme
         }
     }
@@ -143,7 +143,7 @@ extension ExpressNotificationEvent: NotificationEvent {
             return .init(iconType: .image(Assets.redCircleWarning.image))
         case .withdrawalNotificationEvent(let event):
             return event.icon
-        case .validationErrorEvent(let event):
+        case .validationErrorEvent(let event, _):
             return event.icon
         }
     }
@@ -167,7 +167,7 @@ extension ExpressNotificationEvent: NotificationEvent {
             return .critical
         case .withdrawalNotificationEvent(let event):
             return event.severity
-        case .validationErrorEvent(let event):
+        case .validationErrorEvent(let event, _):
             return event.severity
         }
     }
@@ -180,7 +180,7 @@ extension ExpressNotificationEvent: NotificationEvent {
             return .refresh
         case .verificationRequired, .cexOperationFailed:
             return .goToProvider
-        case .validationErrorEvent(let event):
+        case .validationErrorEvent(let event, _):
             return event.buttonActionType
         case .withdrawalNotificationEvent(let event):
             return event.buttonActionType

--- a/Tangem/App/Services/NotificationManagers/ExpressNotifications/ExpressNotificationEvent.swift
+++ b/Tangem/App/Services/NotificationManagers/ExpressNotifications/ExpressNotificationEvent.swift
@@ -89,7 +89,7 @@ extension ExpressNotificationEvent: NotificationEvent {
             return Localization.expressExchangeNotificationFailedText
         case .feeWillBeSubtractFromSendingAmount(let cryptoAmountFormatted, let fiatAmountFormatted):
             return Localization.commonNetworkFeeWarningContent(cryptoAmountFormatted, fiatAmountFormatted)
-        // Only for dustRestriction we have to use different desription
+        // Only for dustRestriction we have to use different description
         case .validationErrorEvent(.dustRestriction(let minimumAmountFormatted, let minimumChangeFormatted), _):
             return Localization.warningExpressDustMessage(minimumAmountFormatted, minimumChangeFormatted)
         case .withdrawalNotificationEvent(let event):

--- a/Tangem/App/Services/NotificationManagers/ExpressNotifications/ExpressNotificationManager.swift
+++ b/Tangem/App/Services/NotificationManagers/ExpressNotifications/ExpressNotificationManager.swift
@@ -123,11 +123,11 @@ class ExpressNotificationManager {
         case .invalidNumber:
             event = .refreshRequired(title: Localization.commonError, message: validationError.localizedDescription)
         case .insufficientBalance:
-            assertionFailure("It had to mapped to ExpressInteractor.RestrictionType.notEnoughBalanceForSwapping")
+            assertionFailure("It have to be mapped to ExpressInteractor.RestrictionType.notEnoughBalanceForSwapping")
             notificationInputsSubject.value = []
             return
         case .insufficientBalanceForFee:
-            assertionFailure("It had to mapped to ExpressInteractor.RestrictionType.notEnoughAmountForFee")
+            assertionFailure("It have to be mapped to ExpressInteractor.RestrictionType.notEnoughAmountForFee")
             guard let notEnoughFeeForTokenTxEvent = makeNotEnoughFeeForTokenTx(sender: sender) else {
                 notificationInputsSubject.value = []
                 return

--- a/Tangem/App/Services/NotificationManagers/ExpressNotifications/ExpressNotificationManager.swift
+++ b/Tangem/App/Services/NotificationManagers/ExpressNotifications/ExpressNotificationManager.swift
@@ -83,8 +83,8 @@ class ExpressNotificationManager {
         case .notEnoughBalanceForSwapping:
             notificationInputsSubject.value = []
             return
-        case .validationError(let validationError):
-            setupNotification(for: validationError)
+        case .validationError(let error, let context):
+            setupNotification(for: error, context: context)
             return
         case .notEnoughAmountForFee:
             guard let notEnoughFeeForTokenTxEvent = makeNotEnoughFeeForTokenTx(sender: interactor.getSender()) else {
@@ -111,7 +111,7 @@ class ExpressNotificationManager {
         notificationInputsSubject.value = [notification]
     }
 
-    private func setupNotification(for validationError: ValidationError) {
+    private func setupNotification(for validationError: ValidationError, context: ValidationErrorContext) {
         guard let interactor = expressInteractor else { return }
 
         let sender = interactor.getSender()
@@ -141,7 +141,7 @@ class ExpressNotificationManager {
              .insufficientAmountToReserveAtDestination,
              .cardanoCannotBeSentBecauseHasTokens,
              .cardanoInsufficientBalanceToSendToken:
-            event = .validationErrorEvent(validationErrorEvent)
+            event = .validationErrorEvent(event: validationErrorEvent, context: context)
         }
 
         let notification = NotificationsFactory().buildNotificationInput(for: event) { [weak self] id, actionType in

--- a/Tangem/Modules/ExpressView/ExpressViewModel.swift
+++ b/Tangem/Modules/ExpressView/ExpressViewModel.swift
@@ -688,7 +688,7 @@ private extension ExpressViewModel {
     func feeValue(from event: ExpressNotificationEvent) -> Decimal? {
         switch event {
         case .validationErrorEvent(_, let context) where context.isFeeCurrency:
-            return context.feeAmount
+            return context.feeValue
         case .permissionNeeded,
              .refreshRequired,
              .hasPendingTransaction,

--- a/Tangem/Modules/Send/SendNotifications/SendNotificationManager.swift
+++ b/Tangem/Modules/Send/SendNotifications/SendNotificationManager.swift
@@ -269,7 +269,7 @@ class CommonSendNotificationManager: SendNotificationManager {
         case .invalidNumber:
             return nil
         case .insufficientAmountToReserveAtDestination:
-            // Use async validation and show the notifcation before. Instead of alert
+            // Use async validation and show the notification before. Instead of alert
             return nil
         }
     }

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -641,6 +641,7 @@
 		B66AB8B52BBC682A00C8F3E7 /* UserTokensReorderingSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66AB8B42BBC682A00C8F3E7 /* UserTokensReorderingSource.swift */; };
 		B66AB8B72BBC7AF200C8F3E7 /* UserTokensReorderingLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66AB8B62BBC7AF200C8F3E7 /* UserTokensReorderingLogger.swift */; };
 		B66C259E2A801CAB002ADFBD /* FakeOrganizeTokensOptionsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66C259D2A801CAB002ADFBD /* FakeOrganizeTokensOptionsManager.swift */; };
+		B66E5BDE2C1BC47C00778B13 /* ValidationErrorContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66E5BDD2C1BC47C00778B13 /* ValidationErrorContext.swift */; };
 		B673FC3D2B1BF4220089944C /* BottomScrollableSheetConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B673FC3C2B1BF4220089944C /* BottomScrollableSheetConfiguration.swift */; };
 		B674D6D72A96A90000172491 /* StoredUserTokenList.swift in Sources */ = {isa = PBXBuildFile; fileRef = B674D6D62A96A90000172491 /* StoredUserTokenList.swift */; };
 		B674D6D92A96AC8800172491 /* Sequence+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B674D6D82A96AC8800172491 /* Sequence+.swift */; };
@@ -2351,6 +2352,7 @@
 		B66AB8B42BBC682A00C8F3E7 /* UserTokensReorderingSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTokensReorderingSource.swift; sourceTree = "<group>"; };
 		B66AB8B62BBC7AF200C8F3E7 /* UserTokensReorderingLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTokensReorderingLogger.swift; sourceTree = "<group>"; };
 		B66C259D2A801CAB002ADFBD /* FakeOrganizeTokensOptionsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeOrganizeTokensOptionsManager.swift; sourceTree = "<group>"; };
+		B66E5BDD2C1BC47C00778B13 /* ValidationErrorContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationErrorContext.swift; sourceTree = "<group>"; };
 		B673FC3C2B1BF4220089944C /* BottomScrollableSheetConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomScrollableSheetConfiguration.swift; sourceTree = "<group>"; };
 		B674D6D62A96A90000172491 /* StoredUserTokenList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredUserTokenList.swift; sourceTree = "<group>"; };
 		B674D6D82A96AC8800172491 /* Sequence+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sequence+.swift"; sourceTree = "<group>"; };
@@ -8450,6 +8452,7 @@
 			children = (
 				EFEE22BE2BFCF3450099917E /* BlockchainSDKNotificationMapper.swift */,
 				EFEE22BB2BFCE44B0099917E /* ValidationErrorEvent.swift */,
+				B66E5BDD2C1BC47C00778B13 /* ValidationErrorContext.swift */,
 				EFEE22B92BFCE3D10099917E /* WithdrawalNotificationEvent.swift */,
 			);
 			path = BlockchainSDKNotifications;
@@ -9430,6 +9433,7 @@
 				B61980102AB8BD5200153886 /* PreviewContentShapeModifier.swift in Sources */,
 				DAB19D4B2B2C72A100DD08C4 /* AddCustomTokenCoordinatorView.swift in Sources */,
 				DC0A5844282BFDFC0031BECC /* UserWalletRepository.swift in Sources */,
+				B66E5BDE2C1BC47C00778B13 /* ValidationErrorContext.swift in Sources */,
 				DC7127B32897ECEE00F60F71 /* GenericConfig.swift in Sources */,
 				B06917E0270444CE0000E6C1 /* OnboardingWalletInfoPager.swift in Sources */,
 				DAF1EB9B2A9F83EF00467490 /* KingfisherImageProcessors.swift in Sources */,


### PR DESCRIPTION
[IOS-7084](https://tangem.atlassian.net/browse/IOS-7084)

В сенде депозит расчитывается корректно, но можно аналогично его подрефачить, чтобы там текущее значение fee тоже сохранялось в контекст вместо вычитывания из `sendModel.feeValue?.amount.value`:
```
var newAmount = source - amount
if sendModel.isFeeIncluded, let feeValue = sendModel.feeValue?.amount.value {
    newAmount = newAmount - feeValue
}
```

Я попробовал это сделать - получается довольно много изменений в рамках одного пула и рефакторинг ради рефакторинга. Пока думаю не смысла особо нет

[IOS-7084]: https://tangem.atlassian.net/browse/IOS-7084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ