### PR TITLE
IOS-6696: Increase button unlock delay

### DIFF
--- a/Tangem/UIComponents/ButtonWithIcon/ButtonWithLeadingIcon.swift
+++ b/Tangem/UIComponents/ButtonWithIcon/ButtonWithLeadingIcon.swift
@@ -241,7 +241,7 @@ private struct ButtonWithLeadingIconContentView: View {
         action()
 
         // We need to add a delay to prevent the button from being clicked multiple times
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
             disabled = false
         }
     }


### PR DESCRIPTION
проблема возникает, когда открывается модальный экран, например своп. Если сразу после смахивания модального экрана сразу же начать тапать на кнопку, приложение подлагивает и из-за маленькой задержки дает сразу ткнуть второй раз на кнопку. Это решение в принципе само по себе не очень, т.к. на тоненького, но альтернативу я пока только такую нашел:
везде проверять что координатор или вью модель - `nil`, если нет - игнорировать создание экрана и навигацию, но это много где надо будет сделать и надо будет все время помнить об этом. Хочется все же одно универсальное решение проблемы.