### PR TITLE
IOS-6885: Fix existential deposit handling in Send

### DIFF
--- a/Tangem/Modules/Send/SendModel.swift
+++ b/Tangem/Modules/Send/SendModel.swift
@@ -35,6 +35,7 @@ class SendModel {
         _sendError.eraseToAnyPublisher()
     }
 
+    /// - Warning: Buggy in some cases and needs to be fixed (IOS-7211)
     var isFeeIncluded: Bool {
         _isFeeIncluded.value
     }
@@ -512,6 +513,7 @@ extension SendModel: SendFeeViewModelInput {
         sendType.canIncludeFeeIntoAmount && walletModel.amountType == walletModel.feeTokenItem.amountType
     }
 
+    /// - Warning: Buggy in some cases and needs to be fixed (IOS-7211)
     var isFeeIncludedPublisher: AnyPublisher<Bool, Never> {
         _isFeeIncluded.eraseToAnyPublisher()
     }

--- a/Tangem/Modules/Send/SendModel.swift
+++ b/Tangem/Modules/Send/SendModel.swift
@@ -340,12 +340,12 @@ class SendModel {
 
         do {
             try walletModel.transactionCreator.validate(amount: amount, fee: fee)
+        } catch ValidationError.totalExceedsBalance, ValidationError.minimumBalance {
+            return true
         } catch {
-            let validationError = error as? ValidationError
-            if case .totalExceedsBalance = validationError {
-                return true
-            }
+            // Fall through to the last return
         }
+
         return false
     }
 


### PR DESCRIPTION
[IOS-6885](https://tangem.atlassian.net/browse/IOS-6885)

Описанный с таске кейс некорректно обрабатывался в сенде,  экспрессе норм.
И как оказалось - код для него отличался от кода для max_amount, поэтому его пришлось фиксить отдельно

[IOS-6885]: https://tangem.atlassian.net/browse/IOS-6885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ