### PR TITLE
IOS-6791: WC Unlock new connection after pairing

### DIFF
--- a/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
+++ b/Tangem/App/Services/WalletConnect/WalletConnectV2Service/WalletConnectV2Service.swift
@@ -176,6 +176,13 @@ final class WalletConnectV2Service {
             try await pairApi.pair(uri: url)
             try Task.checkCancellation()
             log("Established pair for \(url)")
+            DispatchQueue.main.async {
+                Toast(view: SuccessToast(text: Localization.walletConnectToastAwaitingSessionProposal))
+                    .present(
+                        layout: .top(padding: 20),
+                        type: .temporary()
+                    )
+            }
         } catch {
             displayErrorUI(WalletConnectV2Error.pairClientError(error.localizedDescription))
             AppLog.shared.error("[WC 2.0] Failed to connect to \(url) with error: \(error)")
@@ -183,6 +190,7 @@ final class WalletConnectV2Service {
             // Hack to delete the topic from the user default storage inside the WC 2.0 SDK
             await disconnect(topic: url.topic)
         }
+        canEstablishNewSessionSubject.send(true)
     }
 
     private func disconnect(topic: String) async {

--- a/Tangem/Resources/Localizations/de.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/de.lproj/Localizable.strings
@@ -656,6 +656,7 @@
 "wallet_connect_sessions_title" = "WalletConnect Sessions";
 "wallet_connect_subtitle" = "Connect to dApps";
 "wallet_connect_title" = "WalletConnect";
+"wallet_connect_toast_awaiting_session_proposal" = "Connecting may take a few seconds";
 "wallet_marketplace_block_title" = "%@ Market Price";
 "wallet_marketprice_block_update_time" = "last 24h";
 "wallet_network_group_title" = "%@ network";

--- a/Tangem/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/en.lproj/Localizable.strings
@@ -663,6 +663,7 @@
 "wallet_connect_sessions_title" = "WalletConnect Sessions";
 "wallet_connect_subtitle" = "Connect to dApps";
 "wallet_connect_title" = "WalletConnect";
+"wallet_connect_toast_awaiting_session_proposal" = "Connecting may take a few seconds";
 "wallet_marketplace_block_title" = "%@ Market Price";
 "wallet_marketprice_block_update_time" = "last 24h";
 "wallet_network_group_title" = "%@ network";

--- a/Tangem/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/fr.lproj/Localizable.strings
@@ -663,6 +663,7 @@
 "wallet_connect_sessions_title" = "WalletConnect Sessions";
 "wallet_connect_subtitle" = "Connect to dApps";
 "wallet_connect_title" = "WalletConnect";
+"wallet_connect_toast_awaiting_session_proposal" = "Connecting may take a few seconds";
 "wallet_marketplace_block_title" = "%@ Market Price";
 "wallet_marketprice_block_update_time" = "last 24h";
 "wallet_network_group_title" = "%@ network";

--- a/Tangem/Resources/Localizations/it.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/it.lproj/Localizable.strings
@@ -663,6 +663,7 @@
 "wallet_connect_sessions_title" = "WalletConnect Sessions";
 "wallet_connect_subtitle" = "Connect to dApps";
 "wallet_connect_title" = "WalletConnect";
+"wallet_connect_toast_awaiting_session_proposal" = "Connecting may take a few seconds";
 "wallet_marketplace_block_title" = "%@ Market Price";
 "wallet_marketprice_block_update_time" = "last 24h";
 "wallet_network_group_title" = "%@ network";

--- a/Tangem/Resources/Localizations/ru.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/ru.lproj/Localizable.strings
@@ -663,6 +663,7 @@
 "wallet_connect_sessions_title" = "Сессии WalletConnect";
 "wallet_connect_subtitle" = "Подключение к dApps";
 "wallet_connect_title" = "WalletConnect";
+"wallet_connect_toast_awaiting_session_proposal" = "Подключение может занять несколько секунд";
 "wallet_marketplace_block_title" = "Рыночная цена %@";
 "wallet_marketprice_block_update_time" = "за 24 часа";
 "wallet_network_group_title" = "Сеть %@";

--- a/Tangem/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -663,6 +663,7 @@
 "wallet_connect_sessions_title" = "WalletConnect 連接";
 "wallet_connect_subtitle" = "連結到Dapps";
 "wallet_connect_title" = "WalletConnect";
+"wallet_connect_toast_awaiting_session_proposal" = "Connecting may take a few seconds";
 "wallet_marketplace_block_title" = "%@市場價格";
 "wallet_marketprice_block_update_time" = "last 24h";
 "wallet_network_group_title" = "%@ network";


### PR DESCRIPTION
Проблема в том, что дАпп не присылает информацию о сессии, после успешного сканирования мы создаем успешно пару, а потом со стороны дАппа тишина. В итоге у нас кнопка не разблокируется, и ничего не происходит. Обсудили с Лешей быстрый фикс с нашей стороны. В дАпп я уже написал в дискорде, будем ждать что ответят. В трастволлете такое же поведение - отсканировал QR и тишина

А пока просто будем разблокировать сразу кнопку и показывать тост, что подключение займет какое-то время


https://github.com/tangem/tangem-app-ios/assets/24321494/bb1e2c13-4d48-4cd6-b04f-6265f87206dd

