### PR TITLE
IOS-7217 Use backup cards count to handle all the cases

### DIFF
--- a/Tangem/Common/TangemSdk/UserWalletIdPreflightReadFilter.swift
+++ b/Tangem/Common/TangemSdk/UserWalletIdPreflightReadFilter.swift
@@ -20,7 +20,8 @@ struct UserWalletIdPreflightReadFilter: PreflightReadFilter {
 
     func onFullCardRead(_ card: Card, environment: SessionEnvironment) throws {
         guard let firstPublicKey = card.wallets.first?.publicKey else {
-            throw TangemSdkError.walletNotFound
+            // We can safely reset this card because there are no wallets in it. Case with cardLinked status without any wallets
+            return
         }
 
         let userWalletId = UserWalletId(with: firstPublicKey)

--- a/Tangem/Modules/CardSettings/CardSettingsViewModel.swift
+++ b/Tangem/Modules/CardSettings/CardSettingsViewModel.swift
@@ -27,7 +27,7 @@ class CardSettingsViewModel: ObservableObject {
     }
 
     var resetToFactoryFooterMessage: String {
-        if input.linkedCardsCount > 0 {
+        if input.backupCardsCount > 0 {
             return Localization.resetCardWithBackupToFactoryMessage
         } else {
             return Localization.resetCardWithoutBackupToFactoryMessage
@@ -178,7 +178,7 @@ extension CardSettingsViewModel {
         } else {
             let input = ResetToFactoryViewModel.Input(
                 cardInteractor: input.factorySettingsResettingCardInteractor,
-                linkedCardsCount: input.linkedCardsCount,
+                backupCardsCount: input.backupCardsCount,
                 userWalletId: input.userWalletId
             )
             coordinator?.openResetCardToFactoryWarning(with: input)
@@ -198,7 +198,7 @@ extension CardSettingsViewModel {
         let securityOptionChangeInteractor: SecurityOptionChanging
         let factorySettingsResettingCardInteractor: FactorySettingsResettingCardInteractor
         let isResetToFactoryAvailable: Bool
-        let linkedCardsCount: Int
+        let backupCardsCount: Int
         let canTwin: Bool
         let twinInput: OnboardingInput?
         let cardIdFormatted: String

--- a/Tangem/Modules/ResetToFactory/ResetToFactoryView.swift
+++ b/Tangem/Modules/ResetToFactory/ResetToFactoryView.swift
@@ -128,7 +128,7 @@ struct ResetToFactoryView_Previews: PreviewProvider {
     static let viewModel = ResetToFactoryViewModel(
         input: .init(
             cardInteractor: FactorySettingsResettingMock(),
-            linkedCardsCount: 0,
+            backupCardsCount: 0,
             userWalletId: UserWalletId(value: Data())
         ),
         coordinator: CardSettingsCoordinator()

--- a/Tangem/Modules/ResetToFactory/ResetToFactoryViewModel.swift
+++ b/Tangem/Modules/ResetToFactory/ResetToFactoryViewModel.swift
@@ -18,24 +18,24 @@ class ResetToFactoryViewModel: ObservableObject {
     }
 
     var message: String {
-        if hasLinkedCards {
+        if hasBackupCards {
             return Localization.resetCardWithBackupToFactoryMessage
         } else {
             return Localization.resetCardWithoutBackupToFactoryMessage
         }
     }
 
-    private let hasLinkedCards: Bool
+    private let hasBackupCards: Bool
     private let resetHelper: ResetToFactoryService
     private let cardInteractor: FactorySettingsResetting
     private weak var coordinator: ResetToFactoryViewRoutable?
 
     init(input: ResetToFactoryViewModel.Input, coordinator: ResetToFactoryViewRoutable) {
         cardInteractor = input.cardInteractor
-        hasLinkedCards = input.linkedCardsCount > 0
+        hasBackupCards = input.backupCardsCount > 0
         resetHelper = ResetToFactoryService(
             userWalletId: input.userWalletId,
-            totalCardsCount: input.linkedCardsCount + 1
+            totalCardsCount: input.backupCardsCount + 1
         )
         self.coordinator = coordinator
 
@@ -63,7 +63,7 @@ private extension ResetToFactoryViewModel {
     func setupView() {
         warnings.append(Warning(isAccepted: false, type: .accessToCard))
 
-        if hasLinkedCards {
+        if hasBackupCards {
             warnings.append(Warning(isAccepted: false, type: .accessCodeRecovery))
         }
     }

--- a/Tangem/Modules/ResetToFactory/ResetToFactoryViewModelInput.swift
+++ b/Tangem/Modules/ResetToFactory/ResetToFactoryViewModelInput.swift
@@ -11,7 +11,7 @@ import Foundation
 extension ResetToFactoryViewModel {
     struct Input {
         let cardInteractor: FactorySettingsResetting
-        let linkedCardsCount: Int
+        let backupCardsCount: Int
         let userWalletId: UserWalletId
     }
 }

--- a/Tangem/Modules/ScanCardSettings/ScanCardSettingsViewModel.swift
+++ b/Tangem/Modules/ScanCardSettings/ScanCardSettingsViewModel.swift
@@ -98,7 +98,7 @@ extension ScanCardSettingsViewModel {
             securityOptionChangeInteractor: SecurityOptionChangingCardInteractor(with: cardInfo),
             factorySettingsResettingCardInteractor: FactorySettingsResettingCardInteractor(with: cardInfo),
             isResetToFactoryAvailable: !config.getFeatureAvailability(.resetToFactory).isHidden,
-            linkedCardsCount: cardInfo.card.backupStatus?.linkedCardsCount ?? 0,
+            backupCardsCount: cardInfo.card.backupStatus?.backupCardsCount ?? 0,
             canTwin: config.hasFeature(.twinning),
             twinInput: makeTwinInput(from: cardInfo, config: config, userWalletId: userWalletId),
             cardIdFormatted: cardInfo.cardIdFormatted,


### PR DESCRIPTION
Решили сбрасывать linked-карты как карты-одиночки, чтобы покрыть все потенциальные риски.

Дополнительно ослабил userwalletidfilter, чтобы пропускать пустые карты и давать возможность их сбросить