### PR TITLE
IOS-7230 Update model after backup

### DIFF
--- a/Tangem/App/Services/UserWalletModel/UserWalletModel.swift
+++ b/Tangem/App/Services/UserWalletModel/UserWalletModel.swift
@@ -36,5 +36,5 @@ protocol UserWalletModel: MainHeaderSupplementInfoProvider, TotalBalanceProvidin
 
 enum BackupUpdateType {
     case primaryCardBackuped(card: Card)
-    case completed
+    case backupCompleted
 }

--- a/Tangem/App/Services/UserWalletModel/UserWalletModel.swift
+++ b/Tangem/App/Services/UserWalletModel/UserWalletModel.swift
@@ -29,7 +29,12 @@ protocol UserWalletModel: MainHeaderSupplementInfoProvider, TotalBalanceProvidin
     var totalSignedHashes: Int { get }
     var name: String { get }
     func validate() -> Bool
-    func onBackupCreated(_ card: Card)
+    func onBackupUpdate(type: BackupUpdateType)
     func updateWalletName(_ name: String)
     func addAssociatedCard(_ cardId: String)
+}
+
+enum BackupUpdateType {
+    case primaryCardBackuped(card: Card)
+    case completed
 }

--- a/Tangem/App/Services/UserWalletRepository/LockedUserWalletModel.swift
+++ b/Tangem/App/Services/UserWalletRepository/LockedUserWalletModel.swift
@@ -102,7 +102,7 @@ class LockedUserWalletModel: UserWalletModel {
         return true
     }
 
-    func onBackupCreated(_ card: Card) {}
+    func onBackupUpdate(type: BackupUpdateType) {}
 
     func addAssociatedCard(_ cardId: String) {}
 }

--- a/Tangem/App/ViewModels/CommonUserWalletModel.swift
+++ b/Tangem/App/ViewModels/CommonUserWalletModel.swift
@@ -344,15 +344,21 @@ extension CommonUserWalletModel: UserWalletModel {
         userWalletRepository.save()
     }
 
-    func onBackupCreated(_ card: Card) {
-        for updatedWallet in card.wallets {
-            cardInfo.card.wallets[updatedWallet.publicKey]?.hasBackup = updatedWallet.hasBackup
-        }
+    func onBackupUpdate(type: BackupUpdateType) {
+        switch type {
+        case .primaryCardBackuped(let card):
+            for updatedWallet in card.wallets {
+                cardInfo.card.wallets[updatedWallet.publicKey]?.hasBackup = updatedWallet.hasBackup
+            }
 
-        cardInfo.card.settings = CardDTO.Settings(settings: card.settings)
-        cardInfo.card.isAccessCodeSet = card.isAccessCodeSet
-        cardInfo.card.backupStatus = card.backupStatus
-        onUpdate()
+            cardInfo.card.settings = CardDTO.Settings(settings: card.settings)
+            cardInfo.card.isAccessCodeSet = card.isAccessCodeSet
+            cardInfo.card.backupStatus = card.backupStatus
+            onUpdate()
+        case .completed:
+            // we have to read an actual status from backup validator
+            _updatePublisher.send()
+        }
     }
 
     func addAssociatedCard(_ cardId: String) {

--- a/Tangem/App/ViewModels/CommonUserWalletModel.swift
+++ b/Tangem/App/ViewModels/CommonUserWalletModel.swift
@@ -355,7 +355,7 @@ extension CommonUserWalletModel: UserWalletModel {
             cardInfo.card.isAccessCodeSet = card.isAccessCodeSet
             cardInfo.card.backupStatus = card.backupStatus
             onUpdate()
-        case .completed:
+        case .backupCompleted:
             // we have to read an actual status from backup validator
             _updatePublisher.send()
         }

--- a/Tangem/Modules/Onboarding/Wallet/WalletOnboardingViewModel.swift
+++ b/Tangem/Modules/Onboarding/Wallet/WalletOnboardingViewModel.swift
@@ -739,11 +739,12 @@ class WalletOnboardingViewModel: OnboardingViewModel<WalletOnboardingStep, Onboa
                             self.userWalletModel?.addAssociatedCard(updatedCard.cardId)
                             self.pendingBackupManager.onProceedBackup(updatedCard)
                             if updatedCard.cardId == self.backupService.primaryCard?.cardId {
-                                self.userWalletModel?.onBackupCreated(updatedCard)
+                                self.userWalletModel?.onBackupUpdate(type: .primaryCardBackuped(card: updatedCard))
                             }
 
                             if self.backupServiceState == .finished {
                                 self.pendingBackupManager.onBackupCompleted()
+                                self.userWalletModel?.onBackupUpdate(type: .completed)
                                 Analytics.log(
                                     event: .backupFinished,
                                     params: [.cardsCount: String((updatedCard.backupStatus?.backupCardsCount ?? 0) + 1)]

--- a/Tangem/Modules/Onboarding/Wallet/WalletOnboardingViewModel.swift
+++ b/Tangem/Modules/Onboarding/Wallet/WalletOnboardingViewModel.swift
@@ -744,7 +744,7 @@ class WalletOnboardingViewModel: OnboardingViewModel<WalletOnboardingStep, Onboa
 
                             if self.backupServiceState == .finished {
                                 self.pendingBackupManager.onBackupCompleted()
-                                self.userWalletModel?.onBackupUpdate(type: .completed)
+                                self.userWalletModel?.onBackupUpdate(type: .backupCompleted)
                                 Analytics.log(
                                     event: .backupFinished,
                                     params: [.cardsCount: String((updatedCard.backupStatus?.backupCardsCount ?? 0) + 1)]

--- a/Tangem/Preview Content/Fakes/FakeUserWalletModel.swift
+++ b/Tangem/Preview Content/Fakes/FakeUserWalletModel.swift
@@ -95,7 +95,7 @@ class FakeUserWalletModel: UserWalletModel, ObservableObject {
         return true
     }
 
-    func onBackupCreated(_ card: Card) {}
+    func onBackupUpdate(type: BackupUpdateType) {}
     func addAssociatedCard(_ cardId: String) {}
 }
 

--- a/Tangem/Preview Content/Mocks/UserWalletModelMock.swift
+++ b/Tangem/Preview Content/Mocks/UserWalletModelMock.swift
@@ -73,7 +73,7 @@ class UserWalletModelMock: UserWalletModel {
 
     func validate() -> Bool { true }
 
-    func onBackupCreated(_ card: Card) {}
+    func onBackupUpdate(type: BackupUpdateType) {}
 
     func addAssociatedCard(_ cardId: String) {}
 }


### PR DESCRIPTION
Проблема была в том, что ошибка активации не исчезала после завершения бэкапа, начатого при уже открытом кошельке. (С главной или настроек)

Из-за того, что при завершении бэкапа не выполнялся апдейт модели и сервис нотификаций не считывал актуальное состояние из валидатора бэкапа. 