### PR TITLE
IOS-7217 Allow reset any card

### DIFF
--- a/Tangem/Modules/ScanCardSettings/ScanCardSettingsViewModel.swift
+++ b/Tangem/Modules/ScanCardSettings/ScanCardSettingsViewModel.swift
@@ -86,11 +86,8 @@ extension ScanCardSettingsViewModel {
     func processSuccessScan(for cardInfo: CardInfo) {
         let config = UserWalletConfigFactory(cardInfo).makeConfig()
 
-        guard let userWalletIdSeed = config.userWalletIdSeed else {
-            return
-        }
-
-        let userWalletId = UserWalletId(with: userWalletIdSeed)
+        // We just allow to reset cards wthout keys via any wallet
+        let userWalletId = config.userWalletIdSeed.map { UserWalletId(with: $0) } ?? UserWalletId(value: Data())
 
         let input = CardSettingsViewModel.Input(
             userWalletId: userWalletId,


### PR DESCRIPTION
UserWalletId фильтр пропускает, поправил и в настройках. Это безопасно, выглядит просто как сброс карты без последствий в виде удаления кошелька с главной