### PR TITLE
IOS-6901: Markets Token Details metrics block

### DIFF
--- a/Tangem/App/Models/Markets/Mappers/TokenMarketsDetailsMapper.swift
+++ b/Tangem/App/Models/Markets/Mappers/TokenMarketsDetailsMapper.swift
@@ -30,7 +30,8 @@ struct TokenMarketsDetailsMapper {
             fullDescription: response.fullDescription,
             priceChangePercentage: response.priceChangePercentage,
             tokenItems: mapToTokenItems(response: response),
-            insights: .init(dto: response.insights?.first)
+            insights: .init(dto: response.insights?.first),
+            metrics: response.metrics
         )
     }
 

--- a/Tangem/App/Models/Markets/MarketsDTO+Coin.swift
+++ b/Tangem/App/Models/Markets/MarketsDTO+Coin.swift
@@ -30,8 +30,8 @@ extension MarketsDTO.Coins {
         let shortDescription: String?
         let fullDescription: String?
         let insights: [Insight]?
-        let metrics: Metrics
         let links: Links
+        let metrics: MarketsTokenDetailsMetrics?
         let pricePerformance: PricePerformance
     }
 
@@ -47,15 +47,6 @@ extension MarketsDTO.Coins {
         let liquidityChange: [String: Decimal]
         let buyPressureChange: [String: Decimal]
         let experiencedBuyerChange: [String: Decimal]
-    }
-
-    struct Metrics: Codable {
-        let marketRating: Decimal
-        let circulatingSupply: Decimal
-        let marketCap: Decimal
-        let volume24H: Decimal
-        let totalSupply: Decimal
-        let fullyDilutedValuation: Decimal?
     }
 
     struct Links: Codable {

--- a/Tangem/App/Models/Markets/MarketsTokenDetailsMetrics.swift
+++ b/Tangem/App/Models/Markets/MarketsTokenDetailsMetrics.swift
@@ -1,0 +1,18 @@
+//
+//  MarketsTokenDetailsMetrics.swift
+//  Tangem
+//
+//  Created by Andrew Son on 10/07/24.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+struct MarketsTokenDetailsMetrics: Codable {
+    let marketRating: Int?
+    let circulatingSupply: Decimal?
+    let marketCap: Decimal?
+    let volume24H: Decimal?
+    let totalSupply: Decimal?
+    let fullyDilutedValuation: Decimal?
+}

--- a/Tangem/App/Models/Markets/TokenMarketsDetailsModel.swift
+++ b/Tangem/App/Models/Markets/TokenMarketsDetailsModel.swift
@@ -19,6 +19,7 @@ struct TokenMarketsDetailsModel: Identifiable {
     let priceChangePercentage: [String: Decimal]
     let tokenItems: [TokenItem]
     let insights: TokenMarketsDetailsInsights?
+    let metrics: MarketsTokenDetailsMetrics?
 }
 
 struct TokenMarketsDetailsInsights {
@@ -27,13 +28,9 @@ struct TokenMarketsDetailsInsights {
     let buyPressure: [MarketsPriceIntervalType: Decimal]
     let experiencedBuyers: [MarketsPriceIntervalType: Decimal]
 
-    init(dto: MarketsDTO.Coins.Insight?) {
+    init?(dto: MarketsDTO.Coins.Insight?) {
         guard let dto else {
-            holders = [:]
-            liquidity = [:]
-            buyPressure = [:]
-            experiencedBuyers = [:]
-            return
+            return nil
         }
 
         func mapToInterval(_ dict: [String: Decimal]) -> [MarketsPriceIntervalType: Decimal] {

--- a/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/Insights/MarketsTokenDetailsInsightsView.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/Insights/MarketsTokenDetailsInsightsView.swift
@@ -1,0 +1,134 @@
+//
+//  MarketsTokenDetailsInsightsView.swift
+//  Tangem
+//
+//  Created by Andrew Son on 08/07/24.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import SwiftUI
+
+struct MarketsTokenDetailsInsightsView: View {
+    @ObservedObject var viewModel: MarketsTokenDetailsInsightsViewModel
+
+    @State private var gridWidth: CGFloat = .zero
+    @State private var firstItemWidth: CGFloat = .zero
+
+    private var itemWidth: CGFloat {
+        let halfSizeWidth = gridWidth / 2 - Constants.itemsSpacing
+        return halfSizeWidth > firstItemWidth ? halfSizeWidth : firstItemWidth
+    }
+
+    private var gridItems: [GridItem] {
+        [GridItem(.adaptive(minimum: itemWidth), spacing: Constants.itemsSpacing, alignment: .leading)]
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text(Localization.marketsTokenDetailsInsights)
+                    .style(Fonts.Bold.footnote, color: Colors.Text.tertiary)
+
+                Spacer()
+
+                MarketsPickerView(
+                    marketPriceIntervalType: $viewModel.selectedInterval,
+                    options: viewModel.availableIntervals,
+                    shouldStretchToFill: false,
+                    titleFactory: { $0.rawValue }
+                )
+            }
+
+            LazyVGrid(columns: gridItems, alignment: .center, spacing: 10, content: {
+                ForEach(viewModel.records.indexed(), id: \.1.id) { index, info in
+                    TokenMarketsDetailsStatisticsRecordView(
+                        title: info.title,
+                        message: info.recordData,
+                        infoButtonAction: {
+                            viewModel.showInfoBottomSheet(for: info.type)
+                        },
+                        containerWidth: gridWidth
+                    )
+                    .readGeometry(\.size.width, onChange: { value in
+                        if value > firstItemWidth {
+                            firstItemWidth = value
+                        }
+                    })
+                    .padding(.vertical, 10)
+                }
+            })
+            .readGeometry(\.size.width, bindTo: $gridWidth)
+        }
+        .animation(nil)
+        .defaultRoundedBackground(with: Colors.Background.action)
+    }
+}
+
+extension MarketsTokenDetailsInsightsView {
+    enum Constants {
+        static let itemsSpacing: CGFloat = 12
+    }
+}
+
+extension MarketsTokenDetailsInsightsView {
+    enum RecordType: String, Identifiable, MarketsTokenDetailsInfoDescriptionProvider {
+        case buyers
+        case buyPressure
+        case holdersChange
+        case liquidity
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .buyers: return Localization.marketsTokenDetailsExperiencedBuyers
+            case .buyPressure: return Localization.marketsTokenDetailsBuyPressure
+            case .holdersChange: return Localization.marketsTokenDetailsHolders
+            case .liquidity: return Localization.marketsTokenDetailsLiquidity
+            }
+        }
+
+        var infoDescription: String {
+            switch self {
+            case .buyers: return Localization.marketsTokenDetailsExperiencedBuyersDescription
+            case .buyPressure: return Localization.marketsTokenDetailsBuyPressureDescription
+            case .holdersChange: return Localization.marketsTokenDetailsHoldersDescription
+            case .liquidity: return Localization.marketsTokenDetailsLiquidityDescription
+            }
+        }
+    }
+
+    struct RecordInfo: Identifiable {
+        let type: RecordType
+        let recordData: String
+
+        var id: String {
+            "\(type.id) - \(recordData)"
+        }
+
+        var title: String {
+            type.title
+        }
+    }
+}
+
+#Preview {
+    let records: [MarketsTokenDetailsInsightsView.RecordInfo] = [
+        .init(type: .buyers, recordData: "+44"),
+        .init(type: .buyPressure, recordData: "-$400"),
+        .init(type: .holdersChange, recordData: "+100"),
+        .init(type: .liquidity, recordData: "+445,9K"),
+    ]
+
+    return MarketsTokenDetailsInsightsView(
+        viewModel: .init(
+            insights: .init(dto: .init(
+                holdersChange: [:],
+                liquidityChange: [:],
+                buyPressureChange: [:],
+                experiencedBuyerChange: [:]
+            ))!,
+            infoRouter: nil
+        )
+    )
+}

--- a/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/Metrics/MarketsTokenDetailsMetricsView.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/Metrics/MarketsTokenDetailsMetricsView.swift
@@ -1,15 +1,15 @@
 //
-//  MarketsTokenDetailsInsightsView.swift
+//  MarketsTokenDetailsMetricsView.swift
 //  Tangem
 //
-//  Created by Andrew Son on 08/07/24.
+//  Created by Andrew Son on 10/07/24.
 //  Copyright © 2024 Tangem AG. All rights reserved.
 //
 
 import SwiftUI
 
-struct MarketsTokenDetailsInsightsView: View {
-    @ObservedObject var viewModel: MarketsTokenDetailsInsightsViewModel
+struct MarketsTokenDetailsMetricsView: View {
+    let viewModel: MarketsTokenDetailsMetricsViewModel
 
     @State private var gridWidth: CGFloat = .zero
     @State private var firstItemWidth: CGFloat = .zero
@@ -20,23 +20,16 @@ struct MarketsTokenDetailsInsightsView: View {
     }
 
     private var gridItems: [GridItem] {
-        [GridItem(.adaptive(minimum: itemWidth), spacing: Constants.itemsSpacing, alignment: .leading)]
+        [GridItem(.adaptive(minimum: itemWidth), spacing: Constants.itemsSpacing, alignment: .topLeading)]
     }
 
     var body: some View {
         VStack(spacing: 0) {
             HStack {
-                Text(Localization.marketsTokenDetailsInsights)
+                Text(Localization.marketsTokenDetailsMetrics)
                     .style(Fonts.Bold.footnote, color: Colors.Text.tertiary)
 
                 Spacer()
-
-                MarketsPickerView(
-                    marketPriceIntervalType: $viewModel.selectedInterval,
-                    options: viewModel.availableIntervals,
-                    shouldStretchToFill: false,
-                    titleFactory: { $0.rawValue }
-                )
             }
 
             LazyVGrid(columns: gridItems, alignment: .center, spacing: 10, content: {
@@ -47,7 +40,8 @@ struct MarketsTokenDetailsInsightsView: View {
                         infoButtonAction: {
                             viewModel.showInfoBottomSheet(for: info.type)
                         },
-                        containerWidth: gridWidth
+                        containerWidth: gridWidth,
+                        estimateTitleAndMessageSizes: false
                     )
                     .readGeometry(\.size.width, onChange: { value in
                         if value > firstItemWidth {
@@ -64,36 +58,42 @@ struct MarketsTokenDetailsInsightsView: View {
     }
 }
 
-extension MarketsTokenDetailsInsightsView {
+extension MarketsTokenDetailsMetricsView {
     enum Constants {
         static let itemsSpacing: CGFloat = 12
     }
 }
 
-extension MarketsTokenDetailsInsightsView {
+extension MarketsTokenDetailsMetricsView {
     enum RecordType: String, Identifiable, MarketsTokenDetailsInfoDescriptionProvider {
-        case buyers
-        case buyPressure
-        case holdersChange
-        case liquidity
+        case marketCapitalization
+        case marketRating
+        case tradingVolume
+        case fullyDilutedValuation
+        case circulatingSupply
+        case totalSupply
 
         var id: String { rawValue }
 
         var title: String {
             switch self {
-            case .buyers: return Localization.marketsTokenDetailsExperiencedBuyers
-            case .buyPressure: return Localization.marketsTokenDetailsBuyPressure
-            case .holdersChange: return Localization.marketsTokenDetailsHolders
-            case .liquidity: return Localization.marketsTokenDetailsLiquidity
+            case .marketCapitalization: return Localization.marketsTokenDetailsMarketCapitalization
+            case .marketRating: return Localization.marketsTokenDetailsMarketRating
+            case .tradingVolume: return Localization.marketsTokenDetailsTradingVolume
+            case .fullyDilutedValuation: return Localization.marketsTokenDetailsFullyDilutedValuation
+            case .circulatingSupply: return Localization.marketsTokenDetailsCirculatingSupply
+            case .totalSupply: return Localization.marketsTokenDetailsTotalSupply
             }
         }
 
         var infoDescription: String {
             switch self {
-            case .buyers: return Localization.marketsTokenDetailsExperiencedBuyersDescription
-            case .buyPressure: return Localization.marketsTokenDetailsBuyPressureDescription
-            case .holdersChange: return Localization.marketsTokenDetailsHoldersDescription
-            case .liquidity: return Localization.marketsTokenDetailsLiquidityDescription
+            case .marketCapitalization: return Localization.marketsTokenDetailsMarketCapitalizationDescription
+            case .marketRating: return Localization.marketsTokenDetailsMarketRatingDescription
+            case .tradingVolume: return Localization.marketsTokenDetailsTradingVolume24hDescription
+            case .fullyDilutedValuation: return Localization.marketsTokenDetailsFullyDilutedValuationDescription
+            case .circulatingSupply: return Localization.marketsTokenDetailsCirculatingSupplyDescription
+            case .totalSupply: return Localization.marketsTokenDetailsTotalSupplyDescription
             }
         }
     }
@@ -113,21 +113,16 @@ extension MarketsTokenDetailsInsightsView {
 }
 
 #Preview {
-    let records: [MarketsTokenDetailsInsightsView.RecordInfo] = [
-        .init(type: .buyers, recordData: "+44"),
-        .init(type: .buyPressure, recordData: "-$400"),
-        .init(type: .holdersChange, recordData: "+100"),
-        .init(type: .liquidity, recordData: "+445,9K"),
-    ]
-
-    return MarketsTokenDetailsInsightsView(
+    MarketsTokenDetailsMetricsView(
         viewModel: .init(
-            insights: .init(dto: .init(
-                holdersChange: [:],
-                liquidityChange: [:],
-                buyPressureChange: [:],
-                experiencedBuyerChange: [:]
-            )),
+            metrics: .init(
+                marketRating: 3,
+                circulatingSupply: 112259808785.143,
+                marketCap: 112234033891,
+                volume24H: 42854017104,
+                totalSupply: 112286364258.112,
+                fullyDilutedValuation: 112234033891
+            ),
             infoRouter: nil
         )
     )

--- a/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/Metrics/MarketsTokenDetailsMetricsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/Metrics/MarketsTokenDetailsMetricsViewModel.swift
@@ -1,0 +1,48 @@
+//
+//  MarketsTokenDetailsMetricsViewModel.swift
+//  Tangem
+//
+//  Created by Andrew Son on 10/07/24.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+struct MarketsTokenDetailsMetricsViewModel {
+    let records: [MarketsTokenDetailsMetricsView.RecordInfo]
+
+    private weak var infoRouter: MarketsTokenDetailsBottomSheetRouter?
+
+    init(metrics: MarketsTokenDetailsMetrics, infoRouter: MarketsTokenDetailsBottomSheetRouter?) {
+        self.infoRouter = infoRouter
+
+        let formatter = BalanceFormatter()
+        let options = BalanceFormattingOptions(minFractionDigits: 0, maxFractionDigits: 0, formatEpsilonAsLowestRepresentableValue: false, roundingType: .default(roundingMode: .plain, scale: 0))
+        let emptyValue = AppConstants.dashSign
+
+        func formatFiatValue(_ value: Decimal?) -> String {
+            guard let value, value > 0 else {
+                return emptyValue
+            }
+
+            return formatter.formatFiatBalance(value, formattingOptions: options)
+        }
+
+        var rating = emptyValue
+        if let marketRating = metrics.marketRating, marketRating > 0 {
+            rating = formatter.formatCryptoBalance(Decimal(marketRating), currencyCode: "", formattingOptions: options)
+        }
+        records = [
+            .init(type: .marketCapitalization, recordData: formatFiatValue(metrics.marketCap)),
+            .init(type: .marketRating, recordData: rating),
+            .init(type: .tradingVolume, recordData: formatFiatValue(metrics.volume24H)),
+            .init(type: .fullyDilutedValuation, recordData: formatFiatValue(metrics.fullyDilutedValuation)),
+            .init(type: .circulatingSupply, recordData: formatFiatValue(metrics.circulatingSupply)),
+            .init(type: .totalSupply, recordData: formatFiatValue(metrics.totalSupply)),
+        ]
+    }
+
+    func showInfoBottomSheet(for type: MarketsTokenDetailsInfoDescriptionProvider) {
+        infoRouter?.openInfoBottomSheet(title: type.title, message: type.infoDescription)
+    }
+}

--- a/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/TokenMarketsDetailsStatisticsRecordView.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/TokenMarketsDetailsStatisticsRecordView.swift
@@ -13,6 +13,7 @@ struct TokenMarketsDetailsStatisticsRecordView: View {
     let message: String
     let infoButtonAction: () -> Void
     let containerWidth: CGFloat
+    var estimateTitleAndMessageSizes: Bool = true
 
     @State private var titleTargetWidth: CGFloat = .zero
     @State private var messageTargetWidth: CGFloat = .zero
@@ -35,11 +36,14 @@ struct TokenMarketsDetailsStatisticsRecordView: View {
                 .fixedSize()
                 .readGeometry(\.size.width, bindTo: $titleTargetWidth)
         }
-        .overlay {
-            messageView
-                .opacity(0.0)
-                .fixedSize()
-                .readGeometry(\.size.width, bindTo: $messageTargetWidth)
+        .if(estimateTitleAndMessageSizes) {
+            $0
+                .overlay {
+                    messageView
+                        .opacity(0.0)
+                        .fixedSize()
+                        .readGeometry(\.size.width, bindTo: $messageTargetWidth)
+                }
         }
     }
 
@@ -60,7 +64,7 @@ struct TokenMarketsDetailsStatisticsRecordView: View {
     private var messageView: some View {
         Text(message)
             .lineLimit(1)
-            .fixedSize()
+            .minimumScaleFactor(0.6)
             .style(Fonts.Regular.callout, color: Colors.Text.primary1)
     }
 }

--- a/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsView.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsView.swift
@@ -113,9 +113,13 @@ struct TokenMarketsDetailsView: View {
                 Group {
                     if let insightsViewModel = viewModel.insightsViewModel {
                         MarketsTokenDetailsInsightsView(viewModel: insightsViewModel)
-                            .animation(nil, value: viewModel.isLoading)
+                    }
+
+                    if let metricsViewModel = viewModel.metricsViewModel {
+                        MarketsTokenDetailsMetricsView(viewModel: metricsViewModel)
                     }
                 }
+                .animation(nil, value: viewModel.isLoading)
                 .padding(.horizontal, 16)
             }
         }

--- a/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsViewModel.swift
@@ -20,6 +20,7 @@ class TokenMarketsDetailsViewModel: ObservableObject {
     // MARK: Blocks
 
     @Published var insightsViewModel: MarketsTokenDetailsInsightsViewModel?
+    @Published var metricsViewModel: MarketsTokenDetailsMetricsViewModel?
 
     let priceChangeIntervalOptions = MarketsPriceIntervalType.allCases
 
@@ -131,6 +132,10 @@ class TokenMarketsDetailsViewModel: ObservableObject {
     private func makeBlocksViewModels(using model: TokenMarketsDetailsModel) {
         if let insights = model.insights {
             insightsViewModel = .init(insights: insights, infoRouter: self)
+        }
+
+        if let metrics = model.metrics {
+            metricsViewModel = .init(metrics: metrics, infoRouter: self)
         }
     }
 

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -610,6 +610,9 @@
 		B0E20E0A2C2AEA5B00213580 /* SheetHandleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E20E092C2AEA5B00213580 /* SheetHandleView.swift */; };
 		B0E20E122C2B01F600213580 /* PriceChangeUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E20E112C2B01F600213580 /* PriceChangeUtility.swift */; };
 		B0E3381C2A7A809600D36727 /* LockedUserTokensManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E3381B2A7A809600D36727 /* LockedUserTokensManager.swift */; };
+		B0E479BA2C3E7CEC0043B239 /* MarketsTokenDetailsMetricsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E479B92C3E7CEC0043B239 /* MarketsTokenDetailsMetricsView.swift */; };
+		B0E479BF2C3EB2890043B239 /* MarketsTokenDetailsMetricsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E479BE2C3EB2890043B239 /* MarketsTokenDetailsMetricsViewModel.swift */; };
+		B0E479C22C3EB39D0043B239 /* MarketsTokenDetailsMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E479C12C3EB39D0043B239 /* MarketsTokenDetailsMetrics.swift */; };
 		B0E7489C2A3C130B0015E3FC /* ReceiveBottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E7489B2A3C130B0015E3FC /* ReceiveBottomSheetView.swift */; };
 		B0E9775C2B97511F0006896B /* OnboardingSeedPhraseGenerateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E9775B2B97511F0006896B /* OnboardingSeedPhraseGenerateViewModel.swift */; };
 		B0E9E2FD2679DA5B00269C7A /* Separator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E9E2FC2679DA5B00269C7A /* Separator.swift */; };
@@ -2393,6 +2396,9 @@
 		B0E20E092C2AEA5B00213580 /* SheetHandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetHandleView.swift; sourceTree = "<group>"; };
 		B0E20E112C2B01F600213580 /* PriceChangeUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceChangeUtility.swift; sourceTree = "<group>"; };
 		B0E3381B2A7A809600D36727 /* LockedUserTokensManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockedUserTokensManager.swift; sourceTree = "<group>"; };
+		B0E479B92C3E7CEC0043B239 /* MarketsTokenDetailsMetricsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketsTokenDetailsMetricsView.swift; sourceTree = "<group>"; };
+		B0E479BE2C3EB2890043B239 /* MarketsTokenDetailsMetricsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketsTokenDetailsMetricsViewModel.swift; sourceTree = "<group>"; };
+		B0E479C12C3EB39D0043B239 /* MarketsTokenDetailsMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketsTokenDetailsMetrics.swift; sourceTree = "<group>"; };
 		B0E7489B2A3C130B0015E3FC /* ReceiveBottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveBottomSheetView.swift; sourceTree = "<group>"; };
 		B0E9775B2B97511F0006896B /* OnboardingSeedPhraseGenerateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSeedPhraseGenerateViewModel.swift; sourceTree = "<group>"; };
 		B0E9E2FC2679DA5B00269C7A /* Separator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Separator.swift; sourceTree = "<group>"; };
@@ -3532,6 +3538,7 @@
 				B0CF5A562C2D420300B197D4 /* MarketsDTO+Coin.swift */,
 				B0A37B6F2C2D9A9F005397FA /* TokenMarketsDetailsModel.swift */,
 				2D1BB3672C07421C008392F7 /* MarketsTokenModel.swift */,
+				B0E479C12C3EB39D0043B239 /* MarketsTokenDetailsMetrics.swift */,
 			);
 			path = Markets;
 			sourceTree = "<group>";
@@ -5439,7 +5446,8 @@
 		B0AF9BFA2C32D01200EC5830 /* Subviews */ = {
 			isa = PBXGroup;
 			children = (
-				B0ED3F062C3D76AC00311DE2 /* MarketsTokenDetailsInsight */,
+				B0E479B82C3E7B380043B239 /* Metrics */,
+				B0ED3F062C3D76AC00311DE2 /* Insights */,
 				B0AF9BF92C32D01200EC5830 /* TokenMarketsDetailsView+Skeletons.swift */,
 				B0FF51C72C3C0FA800746705 /* TokenMarketsDetailsStatisticsRecordView.swift */,
 			);
@@ -5805,6 +5813,15 @@
 			path = PriceChange;
 			sourceTree = "<group>";
 		};
+		B0E479B82C3E7B380043B239 /* Metrics */ = {
+			isa = PBXGroup;
+			children = (
+				B0E479B92C3E7CEC0043B239 /* MarketsTokenDetailsMetricsView.swift */,
+				B0E479BE2C3EB2890043B239 /* MarketsTokenDetailsMetricsViewModel.swift */,
+			);
+			path = Metrics;
+			sourceTree = "<group>";
+		};
 		B0E7489A2A3C12920015E3FC /* ReceiveBottomSheetView */ = {
 			isa = PBXGroup;
 			children = (
@@ -5855,13 +5872,13 @@
 			path = DecimalRoundingUtility;
 			sourceTree = "<group>";
 		};
-		B0ED3F062C3D76AC00311DE2 /* MarketsTokenDetailsInsight */ = {
+		B0ED3F062C3D76AC00311DE2 /* Insights */ = {
 			isa = PBXGroup;
 			children = (
 				B040FA332C3BCA00002C127B /* MarketsTokenDetailsInsightsView.swift */,
 				B0ED3F072C3D76C100311DE2 /* MarketsTokenDetailsInsightsViewModel.swift */,
 			);
-			path = MarketsTokenDetailsInsight;
+			path = Insights;
 			sourceTree = "<group>";
 		};
 		B0F16D6F26EF253000687C47 /* Simple */ = {
@@ -9916,6 +9933,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DC70C0312B96129E002205BA /* KeysDerivingProvider.swift in Sources */,
+				B0E479C22C3EB39D0043B239 /* MarketsTokenDetailsMetrics.swift in Sources */,
 				B6FE5B282B93C0FF00B7A76B /* UserCodeRecoveringMock.swift in Sources */,
 				DA070DE52ADD4F6600F7C0E4 /* SprinklrConfig.swift in Sources */,
 				DA43719D2A7D1937006215CA /* ManageTokensCoinItemViewModel.swift in Sources */,
@@ -10944,6 +10962,7 @@
 				EFAD40B62A9CB22500364D65 /* SensitiveTextVisibilityViewModel.swift in Sources */,
 				DAF97FC92BAAF2CC006D9A44 /* Locale+.swift in Sources */,
 				6596AD4B28738F0100508D0A /* WarningBankCardViewModel.swift in Sources */,
+				B0E479BF2C3EB2890043B239 /* MarketsTokenDetailsMetricsViewModel.swift in Sources */,
 				DC0A57D72822A3C80031BECC /* InjectionKey.swift in Sources */,
 				EFF034AC28B4B6ED00F70FF7 /* Publisher+TangemAPIError.swift in Sources */,
 				EF9F6F4428D499F600D6B190 /* LoadingValue.swift in Sources */,
@@ -11228,6 +11247,7 @@
 				B69E7FC82B220C3400B78D9A /* Dictionary+.swift in Sources */,
 				DC51187C2860B728004FB954 /* AppCoordinatorView.swift in Sources */,
 				B0F62C5025DE4EC9005C8BA0 /* MailView.swift in Sources */,
+				B0E479BA2C3E7CEC0043B239 /* MarketsTokenDetailsMetricsView.swift in Sources */,
 				B60B9FDB2A95D96B00A7E905 /* OrganizeTokensListSectionViewModel.swift in Sources */,
 				DAC37FBA2A2DFB730068F3ED /* PromotionView.swift in Sources */,
 				DA559C392B0261F400F59584 /* SendViewModel.swift in Sources */,


### PR DESCRIPTION
* Добавлен блок метрик
* В результате обсуждений выяснилось, что часть метрик может отсутствовать, поэтому сделал все опциональным, ибо мало ли))
* В чатике утвердили требования для блока `Insights`, подумал и добавил сюда, чтобы не катить 100500 МРов, небольшая правка по форматированию
* Принципиально блок метрик не сильно отличается от `Insights`, отличаются вью модельки и енум преимущественно, решил пока не объединять в единую вьюху, чтобы не было огромное количество настроек

https://github.com/tangem/tangem-app-ios/assets/24321494/8eea7025-5085-4d8a-b6ba-d1aba7c613e3

