### PR TITLE
IOS-7373 Do not show onboarding for empty steps

### DIFF
--- a/Tangem/Modules/Welcome/WelcomeCoordinator.swift
+++ b/Tangem/Modules/Welcome/WelcomeCoordinator.swift
@@ -84,6 +84,9 @@ class WelcomeCoordinator: CoordinatorObject {
         let permissionManager = factory.makePermissionManagerForWelcomeOnboarding(using: pushNotificationsInteractor)
         let builder = WelcomeOnboardingStepsBuilder(isPushNotificationsAvailable: availabilityProvider.isAvailable)
         let steps = builder.buildSteps()
+        guard !steps.isEmpty else {
+            return
+        }
 
         let dismissAction: Action<WelcomeOnboardingCoordinator.OutputOptions> = { [weak self] _ in
             self?.welcomeOnboardingCoordinator = nil


### PR DESCRIPTION
Где-то потерялся guard, показывался пустой онбординг и срабатывала пауза на сторис