### PR TITLE
IOS-7465 Localisation: the bold is not applied  on the confirm send  screen in the hint at the bottom of the screen.

### DIFF
--- a/Tangem/Resources/Localizations/de.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/de.lproj/Localizable.strings
@@ -608,7 +608,7 @@
 "send_summary_tap_hint" = "Berühre an beliebiger Stelle für Änderungen";
 "send_summary_title" = "Versende %@";
 "send_summary_transaction_description" = "Du sendest **%1$@** inklusive der Netzwerkgebühr %2$@";
-"send_summary_transaction_description_no_fiat_fee" = "Du sendest ** %1$@ ** und %2$@";
+"send_summary_transaction_description_no_fiat_fee" = "Du sendest **%1$@** und %2$@";
 "send_title_currency_format" = "Senden %@";
 "send_total_label" = "Gesamt";
 "send_total_subtitle_asset_format" = "%1$@ und %2$@ werden gesendet";

--- a/Tangem/Resources/Localizations/de.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/de.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "send_fee_picker_priority" = "Priorität";
 "send_fee_unreachable_error_text" = "Überprüfe deine Netzwerkverbindung";
 "send_fee_unreachable_error_title" = "Informationen zur Netzwerkgebühr nicht erreichbar";
-"send_from_wallet" = "Von ** %@ **";
+"send_from_wallet" = "Von **%@**";
 "send_gas_limit" = "Grenzwert Gasgebühr";
 "send_gas_limit_footer" = "Dies ist die maximale Gasgebühr, die für den Abschluss einer Transaktion oder eines Vertrags ausgegeben wird. Ein Gaslimit verhindert unerwartete oder unbegrenzte Gebühren bei der Ausführung einer Transaktion.";
 "send_gas_price" = "Gaspreis";

--- a/Tangem/Resources/Localizations/ja.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/ja.lproj/Localizable.strings
@@ -607,7 +607,7 @@
 "send_sending" = "送金中...";
 "send_summary_tap_hint" = "変更するには任意の箇所をタップしてください";
 "send_summary_title" = "%@を送金する";
-"send_summary_transaction_description" = "** %1$@ ** を送金する (ネットワーク手数料%2$@を含む)";
+"send_summary_transaction_description" = "**%1$@** を送金する (ネットワーク手数料%2$@を含む)";
 "send_summary_transaction_description_no_fiat_fee" = "**%1$@** と %2$@ を送金しています。";
 "send_title_currency_format" = "%@を送信しています";
 "send_total_label" = "合計";

--- a/Tangem/Resources/Localizations/ja.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/ja.lproj/Localizable.strings
@@ -563,7 +563,7 @@
 "send_fee_picker_priority" = "優先";
 "send_fee_unreachable_error_text" = "ネットワーク接続を確認してください";
 "send_fee_unreachable_error_title" = "ネットワーク手数料についての情報にアクセスできません";
-"send_from_wallet" = "** %@ ** より";
+"send_from_wallet" = "**%@** より";
 "send_gas_limit" = "ガス上限";
 "send_gas_limit_footer" = "これは、取引または契約を完了するために使用されるガスの最大額です。ガス上限を設定することで、取引実行時に予期せぬ請求や無制限の請求を防ぐことができます。";
 "send_gas_price" = "ガス代";

--- a/Tangem/Resources/Localizations/uk-UA.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/uk-UA.lproj/Localizable.strings
@@ -607,8 +607,8 @@
 "send_sending" = "Надсилання...";
 "send_summary_tap_hint" = "Торкніться будь-якого поля, щоб змінити його";
 "send_summary_title" = "Надіслати %@";
-"send_summary_transaction_description" = "Ви надсилаєте ** %1$@ **, включно з комісію мережі %2$@";
-"send_summary_transaction_description_no_fiat_fee" = "Ви надсилаєте ** %1$@ ** і %2$@";
+"send_summary_transaction_description" = "Ви надсилаєте **%1$@**, включно з комісію мережі %2$@";
+"send_summary_transaction_description_no_fiat_fee" = "Ви надсилаєте **%1$@** і %2$@";
 "send_title_currency_format" = "Надсилання %@";
 "send_total_label" = "Всього";
 "send_total_subtitle_asset_format" = "%1$@ та %2$@ буде надіслано";


### PR DESCRIPTION
[IOS-7465](https://tangem.atlassian.net/browse/IOS-7465)

![image](https://github.com/user-attachments/assets/5bfa47e5-f781-4b58-a93d-a33d37a440ac)

![image](https://github.com/user-attachments/assets/ea33fcb2-b652-4e9a-8bd3-4a3dffb006e3)


[IOS-7465]: https://tangem.atlassian.net/browse/IOS-7465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ