### PR TITLE
IOS-7435 Handle refunded tokens for swap

### DIFF
--- a/Tangem/App/Factories/ExpressModulesFactory/CommonExpressModulesFactory.swift
+++ b/Tangem/App/Factories/ExpressModulesFactory/CommonExpressModulesFactory.swift
@@ -112,6 +112,23 @@ extension CommonExpressModulesFactory: ExpressModulesFactory {
             coordinator: coordinator
         )
     }
+
+    func makePendingExpressTransactionsManager() -> any PendingExpressTransactionsManager {
+        let tokenFinder = CommonTokenFinder(supportedBlockchains: userWalletModel.config.supportedBlockchains)
+
+        let expressRefundedTokenHandler = CommonExpressRefundedTokenHandler(
+            userTokensManager: userWalletModel.userTokensManager,
+            tokenFinder: tokenFinder
+        )
+
+        let pendingExpressTransactionsManager = CommonPendingExpressTransactionsManager(
+            userWalletId: userWalletModel.userWalletId.stringValue,
+            walletModel: initialWalletModel,
+            expressRefundedTokenHandler: expressRefundedTokenHandler
+        )
+
+        return pendingExpressTransactionsManager
+    }
 }
 
 // MARK: Dependencies
@@ -141,7 +158,6 @@ private extension CommonExpressModulesFactory {
     var signer: TransactionSigner { userWalletModel.signer }
     var logger: Logger { AppLog.shared }
     var analyticsLogger: ExpressAnalyticsLogger { CommonExpressAnalyticsLogger() }
-    var userTokensManager: UserTokensManager { userWalletModel.userTokensManager }
 
     var expressTokensListAdapter: ExpressTokensListAdapter {
         CommonExpressTokensListAdapter(userWalletModel: userWalletModel)

--- a/Tangem/App/Factories/ExpressModulesFactory/ExpressModulesFactory.swift
+++ b/Tangem/App/Factories/ExpressModulesFactory/ExpressModulesFactory.swift
@@ -29,4 +29,6 @@ protocol ExpressModulesFactory {
         data: SentExpressTransactionData,
         coordinator: ExpressSuccessSentRoutable
     ) -> ExpressSuccessSentViewModel
+
+    func makePendingExpressTransactionsManager() -> PendingExpressTransactionsManager
 }

--- a/Tangem/App/Services/Analytics/Analytics+Event.swift
+++ b/Tangem/App/Services/Analytics/Analytics+Event.swift
@@ -219,6 +219,7 @@ extension Analytics {
         case tokenSwapStatus = "[Token] Swap Status"
         case tokenSwapStatusScreenOpened = "[Token] Swap Status Opened"
         case tokenButtonGoToProvider = "[Token] Button - Go To Provider"
+        case tokenButtonGoToToken = "[Token] Button - Go to Token"
 
         // MARK: - App settings
 

--- a/Tangem/App/Services/Express/AnalyticsTracker/CommonPendingExpressTransactionAnalyticsTracker.swift
+++ b/Tangem/App/Services/Express/AnalyticsTracker/CommonPendingExpressTransactionAnalyticsTracker.swift
@@ -15,7 +15,12 @@ class CommonPendingExpressTransactionAnalyticsTracker: PendingExpressTransaction
     private let mapper = PendingExpressTransactionAnalyticsStatusMapper()
     private var trackedStatuses: ThreadSafeContainer<[PendingTransactionId: Set<Analytics.ParameterValue>]> = .init([:])
 
-    func trackStatusForTransaction(with transactionId: PendingTransactionId, tokenSymbol: String, status: PendingExpressTransactionStatus) {
+    func trackStatusForTransaction(
+        with transactionId: PendingTransactionId,
+        tokenSymbol: String,
+        status: PendingExpressTransactionStatus,
+        provider: ExpressPendingTransactionRecord.Provider
+    ) {
         let statusToTrack = mapper.mapToAnalyticsStatus(pendingTxStatus: status)
         var trackedStatusesSet = trackedStatuses[transactionId] ?? []
         if trackedStatusesSet.contains(statusToTrack) {
@@ -25,6 +30,7 @@ class CommonPendingExpressTransactionAnalyticsTracker: PendingExpressTransaction
         Analytics.log(event: .tokenSwapStatus, params: [
             .token: tokenSymbol,
             .status: statusToTrack.rawValue,
+            .provider: provider.name,
         ])
         trackedStatusesSet.insert(statusToTrack)
         trackedStatuses.mutate { $0[transactionId] = trackedStatusesSet }

--- a/Tangem/App/Services/Express/AnalyticsTracker/PendingExpressTransactionAnalyticsTracker.swift
+++ b/Tangem/App/Services/Express/AnalyticsTracker/PendingExpressTransactionAnalyticsTracker.swift
@@ -12,7 +12,8 @@ protocol PendingExpressTransactionAnalyticsTracker {
     func trackStatusForTransaction(
         with transactionId: String,
         tokenSymbol: String,
-        status: PendingExpressTransactionStatus
+        status: PendingExpressTransactionStatus,
+        provider: ExpressPendingTransactionRecord.Provider
     )
 }
 

--- a/Tangem/App/Services/Express/ExpressPendingTransactionRepository/ExpressPendingTransactionRecord.swift
+++ b/Tangem/App/Services/Express/ExpressPendingTransactionRepository/ExpressPendingTransactionRecord.swift
@@ -27,6 +27,8 @@ struct ExpressPendingTransactionRecord: Codable, Equatable {
     var isHidden: Bool
     var transactionStatus: PendingExpressTransactionStatus
 
+    var refundedTokenItem: TokenItem?
+
     var fee: Decimal {
         convertToDecimal(feeString)
     }

--- a/Tangem/App/Services/Express/ExpressRefundedTokenHandler/CommonExpressRefundedTokenHandler.swift
+++ b/Tangem/App/Services/Express/ExpressRefundedTokenHandler/CommonExpressRefundedTokenHandler.swift
@@ -1,0 +1,26 @@
+//
+//  CommonExpressRefundedTokenHandler.swift
+//  Tangem
+//
+//  Created by Alexander Osokin on 24.07.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import TangemExpress
+
+class CommonExpressRefundedTokenHandler: ExpressRefundedTokenHandler {
+    private let userTokensManager: UserTokensManager
+    private let tokenFinder: TokenFinder
+
+    init(userTokensManager: any UserTokensManager, tokenFinder: any TokenFinder) {
+        self.userTokensManager = userTokensManager
+        self.tokenFinder = tokenFinder
+    }
+
+    func handle(expressCurrency: ExpressCurrency) async throws -> TokenItem {
+        let tokenItem = try await tokenFinder.findToken(contractAddress: expressCurrency.contractAddress, networkId: expressCurrency.network)
+        try userTokensManager.update(itemsToRemove: [], itemsToAdd: [tokenItem])
+        return tokenItem
+    }
+}

--- a/Tangem/App/Services/Express/ExpressRefundedTokenHandler/ExpressRefundedTokenHandler.swift
+++ b/Tangem/App/Services/Express/ExpressRefundedTokenHandler/ExpressRefundedTokenHandler.swift
@@ -1,0 +1,14 @@
+//
+//  ExpressRefundedTokenHandler.swift
+//  Tangem
+//
+//  Created by Alexander Osokin on 24.07.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import TangemExpress
+
+protocol ExpressRefundedTokenHandler {
+    func handle(expressCurrency: ExpressCurrency) async throws -> TokenItem
+}

--- a/Tangem/App/Services/Express/PendingExpressTransactionsManager.swift
+++ b/Tangem/App/Services/Express/PendingExpressTransactionsManager.swift
@@ -24,6 +24,7 @@ class CommonPendingExpressTransactionsManager {
     private let userWalletId: String
     private let walletModel: WalletModel
     private let expressAPIProvider: ExpressAPIProvider
+    private let expressRefundedTokenHandler: ExpressRefundedTokenHandler
 
     private let transactionsToUpdateStatusSubject = CurrentValueSubject<[ExpressPendingTransactionRecord], Never>([])
     private let transactionsInProgressSubject = CurrentValueSubject<[PendingExpressTransaction], Never>([])
@@ -34,9 +35,14 @@ class CommonPendingExpressTransactionsManager {
     private var transactionsScheduledForUpdate: [PendingExpressTransaction] = []
     private var tokenItem: TokenItem { walletModel.tokenItem }
 
-    init(userWalletId: String, walletModel: WalletModel) {
+    init(
+        userWalletId: String,
+        walletModel: WalletModel,
+        expressRefundedTokenHandler: ExpressRefundedTokenHandler
+    ) {
         self.userWalletId = userWalletId
         self.walletModel = walletModel
+        self.expressRefundedTokenHandler = expressRefundedTokenHandler
         expressAPIProvider = ExpressAPIProviderFactory().makeExpressAPIProvider(userId: userWalletId, logger: AppLog.shared)
 
         bind()
@@ -200,18 +206,38 @@ class CommonPendingExpressTransactionsManager {
         do {
             log("Requesting exchange status for transaction with id: \(transactionRecord.expressTransactionId)")
             let expressTransaction = try await expressAPIProvider.exchangeStatus(transactionId: transactionRecord.expressTransactionId)
-            let pendingTransaction = pendingTransactionFactory.buildPendingExpressTransaction(currentExpressStatus: expressTransaction.externalStatus, for: transactionRecord)
+            let refundedTokenItem = await handleRefundedTokenIfNeeded(for: expressTransaction, providerType: transactionRecord.provider.type)
+
+            let pendingTransaction = pendingTransactionFactory.buildPendingExpressTransaction(
+                currentExpressStatus: expressTransaction.externalStatus,
+                refundedTokenItem: refundedTokenItem,
+                for: transactionRecord
+            )
             log("Transaction external status: \(expressTransaction.externalStatus.rawValue)")
+            log("Refunded token: \(String(describing: refundedTokenItem))")
             pendingExpressTransactionAnalyticsTracker.trackStatusForTransaction(
                 with: pendingTransaction.transactionRecord.expressTransactionId,
                 tokenSymbol: tokenItem.currencySymbol,
-                status: pendingTransaction.transactionRecord.transactionStatus
+                status: pendingTransaction.transactionRecord.transactionStatus,
+                provider: pendingTransaction.transactionRecord.provider
             )
             return pendingTransaction
         } catch {
             log("Failed to load status info for transaction with id: \(transactionRecord.expressTransactionId). Error: \(error)")
             return nil
         }
+    }
+
+    private func handleRefundedTokenIfNeeded(
+        for transaction: ExpressTransaction,
+        providerType: ExpressPendingTransactionRecord.ProviderType
+    ) async -> TokenItem? {
+        guard providerType == .dexBridge,
+              let refundedCurrency = transaction.refundedCurrency else {
+            return nil
+        }
+
+        return try? await expressRefundedTokenHandler.handle(expressCurrency: refundedCurrency)
     }
 
     private func log<T>(_ message: @autoclosure () -> T) {

--- a/Tangem/App/Services/NotificationManagers/ExpressNotifications/ExpressNotificationEvent.swift
+++ b/Tangem/App/Services/NotificationManagers/ExpressNotifications/ExpressNotificationEvent.swift
@@ -29,6 +29,8 @@ enum ExpressNotificationEvent: Hashable {
     // The notifications which is used only on the PendingExpressTxStatusBottomSheetView
     case verificationRequired
     case cexOperationFailed
+
+    case refunded(tokenItem: TokenItem)
 }
 
 extension ExpressNotificationEvent: NotificationEvent {
@@ -62,6 +64,8 @@ extension ExpressNotificationEvent: NotificationEvent {
             return event.title
         case .validationErrorEvent(let event, _):
             return event.title
+        case .refunded(tokenItem: let tokenItem):
+            return .string(Localization.expressExchangeNotificationRefundTitle(tokenItem.currencySymbol, tokenItem.networkName))
         }
     }
 
@@ -96,6 +100,10 @@ extension ExpressNotificationEvent: NotificationEvent {
             return event.description
         case .validationErrorEvent(let event, _):
             return event.description
+        case .refunded(tokenItem: let tokenItem):
+            let url = TangemBlogUrlBuilder().url(post: .refundedDex)
+            let readMore = "[\(Localization.commonReadMore)](\(url.absoluteString))"
+            return Localization.expressExchangeNotificationRefundText(tokenItem.currencySymbol, readMore)
         }
     }
 
@@ -113,7 +121,8 @@ extension ExpressNotificationEvent: NotificationEvent {
              .refreshRequired,
              .verificationRequired,
              .cexOperationFailed,
-             .notEnoughReceivedAmountForReserve:
+             .notEnoughReceivedAmountForReserve,
+             .refunded:
             return .action
         case .withdrawalNotificationEvent(let event):
             return event.colorScheme
@@ -145,6 +154,9 @@ extension ExpressNotificationEvent: NotificationEvent {
             return event.icon
         case .validationErrorEvent(let event, _):
             return event.icon
+        case .refunded(let tokenItem):
+            let iconInfo = TokenIconInfoBuilder().build(from: tokenItem, isCustom: false)
+            return .init(iconType: .icon(iconInfo), size: CGSize(bothDimensions: 36))
         }
     }
 
@@ -154,7 +166,8 @@ extension ExpressNotificationEvent: NotificationEvent {
              .hasPendingTransaction,
              .hasPendingApproveTransaction,
              .verificationRequired,
-             .feeWillBeSubtractFromSendingAmount:
+             .feeWillBeSubtractFromSendingAmount,
+             .refunded:
             return .info
         case .notEnoughFeeForTokenTx,
              .tooSmallAmountToSwap,
@@ -184,6 +197,8 @@ extension ExpressNotificationEvent: NotificationEvent {
             return event.buttonActionType
         case .withdrawalNotificationEvent(let event):
             return event.buttonActionType
+        case .refunded:
+            return .openCurrency
         default:
             return nil
         }
@@ -200,7 +215,7 @@ extension ExpressNotificationEvent: NotificationEvent {
 
     var removingOnFullLoadingState: Bool {
         switch self {
-        case .noDestinationTokens, .refreshRequired, .verificationRequired, .cexOperationFailed:
+        case .noDestinationTokens, .refreshRequired, .verificationRequired, .cexOperationFailed, .refunded:
             return false
         case .permissionNeeded,
              .hasPendingTransaction,

--- a/Tangem/App/Services/NotificationManagers/NotificationButtonActionType.swift
+++ b/Tangem/App/Services/NotificationManagers/NotificationButtonActionType.swift
@@ -32,6 +32,7 @@ enum NotificationButtonActionType: Identifiable, Hashable {
     /// No action
     case empty
     case support
+    case openCurrency
 
     var id: Int { hashValue }
 
@@ -73,6 +74,8 @@ enum NotificationButtonActionType: Identifiable, Hashable {
             return ""
         case .support:
             return Localization.detailsRowTitleContactToSupport
+        case .openCurrency:
+            return Localization.commonGoToToken
         }
     }
 
@@ -97,7 +100,8 @@ enum NotificationButtonActionType: Identifiable, Hashable {
              .openFeedbackMail,
              .openAppStoreReview,
              .empty,
-             .support:
+             .support,
+             .openCurrency:
             return nil
         }
     }
@@ -122,7 +126,8 @@ enum NotificationButtonActionType: Identifiable, Hashable {
              .leaveAmount,
              .support,
              .stake,
-             .openFeedbackMail:
+             .openFeedbackMail,
+             .openCurrency:
             return .secondary
         }
     }

--- a/Tangem/App/Services/TokenFinder/CommonTokenFinder.swift
+++ b/Tangem/App/Services/TokenFinder/CommonTokenFinder.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Combine
 import BlockchainSdk
+import TangemExpress
 
 class CommonTokenFinder: TokenFinder {
     @Injected(\.tangemApiService) var tangemApiService: TangemApiService
@@ -22,6 +23,10 @@ class CommonTokenFinder: TokenFinder {
     func findToken(contractAddress: String, networkId: String) async throws -> TokenItem {
         guard let blockchain = supportedBlockchains.first(where: { $0.networkId == networkId }) else {
             throw Error.unknownNetworkId
+        }
+
+        if contractAddress == ExpressConstants.coinContractAddress {
+            return .blockchain(.init(blockchain, derivationPath: nil))
         }
 
         let requestModel = CoinsList.Request(

--- a/Tangem/App/Services/TokenFinder/CommonTokenFinder.swift
+++ b/Tangem/App/Services/TokenFinder/CommonTokenFinder.swift
@@ -1,0 +1,49 @@
+//
+//  CommonTokenFinder.swift
+//  Tangem
+//
+//  Created by Alexander Osokin on 24.07.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import Combine
+import BlockchainSdk
+
+class CommonTokenFinder: TokenFinder {
+    @Injected(\.tangemApiService) var tangemApiService: TangemApiService
+
+    private let supportedBlockchains: Set<Blockchain>
+
+    init(supportedBlockchains: Set<Blockchain>) {
+        self.supportedBlockchains = supportedBlockchains
+    }
+
+    func findToken(contractAddress: String, networkId: String) async throws -> TokenItem {
+        guard let blockchain = supportedBlockchains.first(where: { $0.networkId == networkId }) else {
+            throw Error.unknownNetworkId
+        }
+
+        let requestModel = CoinsList.Request(
+            supportedBlockchains: Set([blockchain]),
+            contractAddress: contractAddress
+        )
+
+        let response = try await tangemApiService
+            .loadCoins(requestModel: requestModel)
+            .async()
+
+        guard let tokenItem = response.first?.items.first(where: { $0.blockchain.networkId == blockchain.networkId })?.tokenItem else {
+            throw Error.notFound
+        }
+
+        return tokenItem
+    }
+}
+
+extension CommonTokenFinder {
+    enum Error: Swift.Error {
+        case unknownNetworkId
+        case notFound
+    }
+}

--- a/Tangem/App/Services/TokenFinder/TokenFinder.swift
+++ b/Tangem/App/Services/TokenFinder/TokenFinder.swift
@@ -1,0 +1,14 @@
+//
+//  TokenFinder.swift
+//  Tangem
+//
+//  Created by Alexander Osokin on 24.07.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import BlockchainSdk
+
+protocol TokenFinder {
+    func findToken(contractAddress: String, networkId: String) async throws -> TokenItem
+}

--- a/Tangem/App/Utilities/Express/PendingExpressTransactionFactory.swift
+++ b/Tangem/App/Utilities/Express/PendingExpressTransactionFactory.swift
@@ -17,7 +17,11 @@ struct PendingExpressTransactionFactory {
     private let awaitingHashStatusesList: [PendingExpressTransactionStatus] = [.awaitingHash]
     private let unknownHashStatusesList: [PendingExpressTransactionStatus] = [.unknown]
 
-    func buildPendingExpressTransaction(currentExpressStatus: ExpressTransactionStatus, for transactionRecord: ExpressPendingTransactionRecord) -> PendingExpressTransaction {
+    func buildPendingExpressTransaction(
+        currentExpressStatus: ExpressTransactionStatus,
+        refundedTokenItem: TokenItem?,
+        for transactionRecord: ExpressPendingTransactionRecord
+    ) -> PendingExpressTransaction {
         let currentStatus: PendingExpressTransactionStatus
         var statusesList: [PendingExpressTransactionStatus] = defaultStatusesList
         var transactionRecord = transactionRecord
@@ -54,6 +58,8 @@ struct PendingExpressTransactionFactory {
         }
 
         transactionRecord.transactionStatus = currentStatus
+        transactionRecord.refundedTokenItem = refundedTokenItem
+
         return .init(
             transactionRecord: transactionRecord,
             statuses: statusesList

--- a/Tangem/App/Utilities/Express/PendingExpressTransactionsConverter.swift
+++ b/Tangem/App/Utilities/Express/PendingExpressTransactionsConverter.swift
@@ -65,10 +65,11 @@ struct PendingExpressTransactionsConverter {
         let isFinished = currentStatus.isTerminated
         if isFinished {
             // Always display cross for failed state
+            // TODO: Refactor for clarity
             switch status {
             case .failed:
                 return .init(title: status.passedStatusTitle, state: .cross(passed: true))
-            case .canceled, .unknown:
+            case .canceled, .unknown, .refunded:
                 return .init(title: status.passedStatusTitle, state: .cross(passed: false))
             case .awaitingHash:
                 return .init(title: status.passedStatusTitle, state: .exclamationMark)
@@ -86,11 +87,11 @@ struct PendingExpressTransactionsConverter {
         switch status {
         case .failed, .unknown:
             state = .cross(passed: false)
+        case .verificationRequired, .awaitingHash:
+            state = .exclamationMark
         case .refunded:
             // Refunded state is the final state and it can't be pending (with loader)
             state = isFinished ? .checkmark : .empty
-        case .verificationRequired, .awaitingHash:
-            state = .exclamationMark
         case .awaitingDeposit, .confirming, .exchanging, .sendingToUser, .done, .canceled:
             break
         }

--- a/Tangem/App/Utilities/TangemBlogUrlBuilder.swift
+++ b/Tangem/App/Utilities/TangemBlogUrlBuilder.swift
@@ -27,6 +27,7 @@ extension TangemBlogUrlBuilder {
     enum Post {
         case fee
         case scanCard
+        case refundedDex
     }
 }
 
@@ -37,6 +38,8 @@ private extension TangemBlogUrlBuilder.Post {
             "what-is-a-transaction-fee-and-why-do-we-need-it"
         case .scanCard:
             "scan-tangem-card"
+        case .refundedDex:
+            "an-overview-of-cross-chain-bridges"
         }
     }
 }

--- a/Tangem/Modules/ExpressView/ExpressViewModel.swift
+++ b/Tangem/Modules/ExpressView/ExpressViewModel.swift
@@ -689,7 +689,8 @@ extension ExpressViewModel: NotificationTapDelegate {
              .openFeedbackMail,
              .openAppStoreReview,
              .swap,
-             .support:
+             .support,
+             .openCurrency:
             return
         }
     }
@@ -727,7 +728,8 @@ private extension ExpressViewModel {
              .withdrawalNotificationEvent,
              .validationErrorEvent,
              .verificationRequired,
-             .cexOperationFailed:
+             .cexOperationFailed,
+             .refunded:
             return nil
         }
     }

--- a/Tangem/Modules/Send/SendModel.swift
+++ b/Tangem/Modules/Send/SendModel.swift
@@ -357,7 +357,8 @@ extension SendModel: NotificationTapDelegate {
              .openFeedbackMail,
              .openAppStoreReview,
              .empty,
-             .support:
+             .support,
+             .openCurrency:
             assertionFailure("Notification tap not handled")
         }
     }

--- a/Tangem/Modules/TokenDetails/ExpressBottomSheet/PendingExpressTxStatusBottomSheetView.swift
+++ b/Tangem/Modules/TokenDetails/ExpressBottomSheet/PendingExpressTxStatusBottomSheetView.swift
@@ -38,8 +38,8 @@ struct PendingExpressTxStatusBottomSheetView: View {
 
                 statusesView
 
-                if let input = viewModel.notificationViewInput {
-                    NotificationView(input: input)
+                ForEach(viewModel.notificationViewInputs) {
+                    NotificationView(input: $0)
                         .transition(.bottomNotificationTransition)
                 }
             }
@@ -50,7 +50,7 @@ struct PendingExpressTxStatusBottomSheetView: View {
         // This animations are set explicitly to synchronise them with the delayed appearance of the notification
         .animation(animation, value: viewModel.statusesList)
         .animation(animation, value: viewModel.currentStatusIndex)
-        .animation(animation, value: viewModel.notificationViewInput)
+        .animation(animation, value: viewModel.notificationViewInputs)
         .animation(animation, value: viewModel.showGoToProviderHeaderButton)
     }
 
@@ -209,13 +209,14 @@ struct ExpressPendingTxStatusBottomSheetView_Preview: PreviewProvider {
             isHidden: false,
             transactionStatus: .awaitingDeposit
         )
-        let pendingTransaction = factory.buildPendingExpressTransaction(currentExpressStatus: .sending, for: record)
+        let pendingTransaction = factory.buildPendingExpressTransaction(currentExpressStatus: .sending, refundedTokenItem: nil, for: record)
         return .init(
             pendingTransaction: pendingTransaction,
             currentTokenItem: tokenItem,
             pendingTransactionsManager: CommonPendingExpressTransactionsManager(
                 userWalletId: userWalletId,
-                walletModel: .mockETH
+                walletModel: .mockETH,
+                expressRefundedTokenHandler: ExpressRefundedTokenHandlerMock()
             ),
             router: TokenDetailsCoordinator()
         )

--- a/Tangem/Modules/TokenDetails/ExpressBottomSheet/PendingExpressTxStatusRoutable.swift
+++ b/Tangem/Modules/TokenDetails/ExpressBottomSheet/PendingExpressTxStatusRoutable.swift
@@ -9,5 +9,6 @@
 import Foundation
 
 protocol PendingExpressTxStatusRoutable: AnyObject {
-    func openPendingExpressTxStatus(at url: URL)
+    func openURL(_ url: URL)
+    func openCurrency(tokenItem: TokenItem)
 }

--- a/Tangem/Modules/TokenDetails/TokenDetailsCoordinator.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsCoordinator.swift
@@ -38,6 +38,7 @@ class TokenDetailsCoordinator: CoordinatorObject {
     @Published var pendingExpressTxStatusBottomSheetViewModel: PendingExpressTxStatusBottomSheetViewModel? = nil
 
     private var safariHandle: SafariHandle?
+    private var options: Options?
 
     required init(
         dismissAction: @escaping Action<Void>,
@@ -48,6 +49,8 @@ class TokenDetailsCoordinator: CoordinatorObject {
     }
 
     func start(with options: Options) {
+        self.options = options
+
         let exchangeUtility = ExchangeCryptoUtility(
             blockchain: options.walletModel.blockchainNetwork.blockchain,
             address: options.walletModel.wallet.address,
@@ -65,10 +68,14 @@ class TokenDetailsCoordinator: CoordinatorObject {
             coordinator: self
         )
 
-        let pendingExpressTransactionsManager = CommonPendingExpressTransactionsManager(
-            userWalletId: options.userWalletModel.userWalletId.stringValue,
-            walletModel: options.walletModel
+        let expressFactory = CommonExpressModulesFactory(
+            inputModel: .init(
+                userWalletModel: options.userWalletModel,
+                initialWalletModel: options.walletModel
+            )
         )
+
+        let pendingExpressTransactionsManager = expressFactory.makePendingExpressTransactionsManager()
 
         let bannerNotificationManager = options.userWalletModel.config.hasFeature(.multiCurrency)
             ? BannerNotificationManager(placement: .tokenDetails(options.walletModel.tokenItem))
@@ -124,8 +131,27 @@ extension TokenDetailsCoordinator: TokenDetailsRoutable {
 // MARK: - PendingExpressTxStatusRoutable
 
 extension TokenDetailsCoordinator: PendingExpressTxStatusRoutable {
-    func openPendingExpressTxStatus(at url: URL) {
+    func openURL(_ url: URL) {
         safariManager.openURL(url)
+    }
+
+    func openCurrency(tokenItem: TokenItem) {
+        pendingExpressTxStatusBottomSheetViewModel = nil
+
+        guard let userWalletModel = options?.userWalletModel else {
+            return
+        }
+
+        // We don't have info about derivation here, so we have to find first non-custom walletModel.
+        guard let walletModel = userWalletModel.walletModelsManager.walletModels.first(where: {
+            $0.tokenItem.blockchain == tokenItem.blockchain
+                && $0.tokenItem.token == tokenItem.token
+                && !$0.isCustom
+        }) else {
+            return
+        }
+
+        openTokenDetails(for: walletModel)
     }
 }
 
@@ -143,27 +169,9 @@ extension TokenDetailsCoordinator: SingleTokenBaseRoutable {
         }
     }
 
+    // TODO: remove userWalletModel from params
     func openFeeCurrency(for model: WalletModel, userWalletModel: UserWalletModel) {
-        // TODO: Remove this stuff after Send screen refactoring
-        guard model.tokenItem != tokenDetailsViewModel?.walletModel.tokenItem else {
-            return
-        }
-
-        #warning("TODO: Add analytics")
-        let dismissAction: Action<Void> = { [weak self] _ in
-            self?.tokenDetailsCoordinator = nil
-        }
-
-        let coordinator = TokenDetailsCoordinator(dismissAction: dismissAction)
-        coordinator.start(
-            with: .init(
-                userWalletModel: userWalletModel,
-                walletModel: model,
-                userTokensManager: userWalletModel.userTokensManager
-            )
-        )
-
-        tokenDetailsCoordinator = coordinator
+        openTokenDetails(for: model)
     }
 
     func openSellCrypto(at url: URL, action: @escaping (String) -> Void) {
@@ -313,5 +321,32 @@ extension TokenDetailsCoordinator: SingleTokenBaseRoutable {
 
     func openInSafari(url: URL) {
         safariManager.openURL(url)
+    }
+}
+
+// MARK: - Private
+
+private extension TokenDetailsCoordinator {
+    func openTokenDetails(for walletModel: WalletModel) {
+        guard let options = options,
+              walletModel.tokenItem != options.walletModel.tokenItem else {
+            return
+        }
+
+        #warning("TODO: Add analytics")
+        let dismissAction: Action<Void> = { [weak self] _ in
+            self?.tokenDetailsCoordinator = nil
+        }
+
+        let coordinator = TokenDetailsCoordinator(dismissAction: dismissAction)
+        coordinator.start(
+            with: .init(
+                userWalletModel: options.userWalletModel,
+                walletModel: walletModel,
+                userTokensManager: options.userWalletModel.userTokensManager
+            )
+        )
+
+        tokenDetailsCoordinator = coordinator
     }
 }

--- a/Tangem/Modules/TokenDetails/TokenDetailsView.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsView.swift
@@ -143,7 +143,8 @@ private extension TokenDetailsView {
     )
     let pendingTxsManager = CommonPendingExpressTransactionsManager(
         userWalletId: userWalletModel.userWalletId.stringValue,
-        walletModel: walletModel
+        walletModel: walletModel,
+        expressRefundedTokenHandler: ExpressRefundedTokenHandlerMock()
     )
     let coordinator = TokenDetailsCoordinator()
 

--- a/Tangem/Modules/TokenDetails/TokenDetailsViewModel.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsViewModel.swift
@@ -106,7 +106,8 @@ final class TokenDetailsViewModel: SingleTokenBaseViewModel, ObservableObject {
              .stake,
              .openFeedbackMail,
              .openAppStoreReview,
-             .support:
+             .support,
+             .openCurrency:
             super.didTapNotification(with: id, action: action)
         }
     }

--- a/Tangem/Preview Content/Mocks/Express/ExpressModulesFactoryMock.swift
+++ b/Tangem/Preview Content/Mocks/Express/ExpressModulesFactoryMock.swift
@@ -100,6 +100,14 @@ class ExpressModulesFactoryMock: ExpressModulesFactory {
             coordinator: coordinator
         )
     }
+
+    func makePendingExpressTransactionsManager() -> any PendingExpressTransactionsManager {
+        CommonPendingExpressTransactionsManager(
+            userWalletId: userWalletModel.userWalletId.stringValue,
+            walletModel: initialWalletModel,
+            expressRefundedTokenHandler: ExpressRefundedTokenHandlerMock()
+        )
+    }
 }
 
 // MARK: Dependencies

--- a/Tangem/Preview Content/Mocks/ExpressRefundedTokenHandlerMock.swift
+++ b/Tangem/Preview Content/Mocks/ExpressRefundedTokenHandlerMock.swift
@@ -1,0 +1,16 @@
+//
+//  ExpressRefundedTokenHandlerMock.swift
+//  Tangem
+//
+//  Created by Alexander Osokin on 24.07.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import TangemExpress
+
+struct ExpressRefundedTokenHandlerMock: ExpressRefundedTokenHandler {
+    func handle(expressCurrency: ExpressCurrency) async throws -> TokenItem {
+        return .blockchain(.init(.polygon(testnet: false), derivationPath: nil))
+    }
+}

--- a/Tangem/Resources/Localizations/de.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/de.lproj/Localizable.strings
@@ -105,6 +105,7 @@
 "common_fee_selector_title" = "Geschwindigkeit und Gebühr";
 "common_generate_addresses" = "Adressen abrufen";
 "common_go_to_provider" = "Zum Anbieter gehen";
+"common_go_to_token" = "Go to token";
 "common_import" = "Importieren";
 "common_later" = "Später";
 "common_learn_and_earn" = "Lernen und verdienen";
@@ -228,6 +229,8 @@
 "express_exchange_by" = "Getauscht von %@";
 "express_exchange_notification_failed_text" = "Besuche die Website des Anbieters, um dein Geld zurückzuerhalten";
 "express_exchange_notification_failed_title" = "Fehler beim Vorgang durch Anbieter";
+"express_exchange_notification_refund_text" = "The transaction amount was refunded in %1$s to your wallet due to OKX or bridge rules. %2$s";
+"express_exchange_notification_refund_title" = "The amount was refunded in %1$s (%2$s network)";
 "express_exchange_notification_verification_text" = "Besuche die Website des Anbieters zur Überprüfung";
 "express_exchange_notification_verification_title" = "KYC-Überprüfung durch den Anbieter erforderlich";
 "express_exchange_status_canceled" = "Abgebrochen";

--- a/Tangem/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/en.lproj/Localizable.strings
@@ -105,6 +105,7 @@
 "common_fee_selector_title" = "Speed and fee";
 "common_generate_addresses" = "Get addresses";
 "common_go_to_provider" = "Go to provider";
+"common_go_to_token" = "Go to token";
 "common_import" = "Import";
 "common_later" = "Later";
 "common_learn_and_earn" = "Learn & Earn";
@@ -228,6 +229,8 @@
 "express_exchange_by" = "Exchange by %@";
 "express_exchange_notification_failed_text" = "Visit provider’s website to refund your money";
 "express_exchange_notification_failed_title" = "Operation failed by provider";
+"express_exchange_notification_refund_text" = "The transaction amount was refunded in %1$s to your wallet due to OKX or bridge rules. %2$s";
+"express_exchange_notification_refund_title" = "The amount was refunded in %1$s (%2$s network)";
 "express_exchange_notification_verification_text" = "Visit provider’s website for verification";
 "express_exchange_notification_verification_title" = "KYC verification required by provider";
 "express_exchange_status_canceled" = "Canceled";

--- a/Tangem/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/fr.lproj/Localizable.strings
@@ -105,6 +105,7 @@
 "common_fee_selector_title" = "Vitesse et frais";
 "common_generate_addresses" = "Obtenir des adresses";
 "common_go_to_provider" = "Aller au fournisseur";
+"common_go_to_token" = "Go to token";
 "common_import" = "Importez";
 "common_later" = "Plus tard";
 "common_learn_and_earn" = "Apprendre et Gagner";
@@ -228,6 +229,8 @@
 "express_exchange_by" = "Échange par %@";
 "express_exchange_notification_failed_text" = "Visitez le site Web du fournisseur pour obtenir un remboursement";
 "express_exchange_notification_failed_title" = "Opération échouée par le fournisseur";
+"express_exchange_notification_refund_text" = "The transaction amount was refunded in %1$s to your wallet due to OKX or bridge rules. %2$s";
+"express_exchange_notification_refund_title" = "The amount was refunded in %1$s (%2$s network)";
 "express_exchange_notification_verification_text" = "Visitez le site Web du fournisseur pour la vérification";
 "express_exchange_notification_verification_title" = "Vérification KYC requise par le fournisseur";
 "express_exchange_status_canceled" = "Annulé";

--- a/Tangem/Resources/Localizations/it.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/it.lproj/Localizable.strings
@@ -105,6 +105,7 @@
 "common_fee_selector_title" = "Speed and fee";
 "common_generate_addresses" = "Get addresses";
 "common_go_to_provider" = "Go to provider";
+"common_go_to_token" = "Go to token";
 "common_import" = "Import";
 "common_later" = "Later";
 "common_learn_and_earn" = "Learn & Earn";
@@ -228,6 +229,8 @@
 "express_exchange_by" = "Exchange by %@";
 "express_exchange_notification_failed_text" = "Visit provider’s website to refund your money";
 "express_exchange_notification_failed_title" = "Operation failed by provider";
+"express_exchange_notification_refund_text" = "The transaction amount was refunded in %1$s to your wallet due to OKX or bridge rules. %2$s";
+"express_exchange_notification_refund_title" = "The amount was refunded in %1$s (%2$s network)";
 "express_exchange_notification_verification_text" = "Visit provider’s website for verification";
 "express_exchange_notification_verification_title" = "KYC verification required by provider";
 "express_exchange_status_canceled" = "Canceled";

--- a/Tangem/Resources/Localizations/ja.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/ja.lproj/Localizable.strings
@@ -105,6 +105,7 @@
 "common_fee_selector_title" = "速度と料金";
 "common_generate_addresses" = "アドレスを取得する";
 "common_go_to_provider" = "プロバイダーへ移動";
+"common_go_to_token" = "Go to token";
 "common_import" = "インポート";
 "common_later" = "後で";
 "common_learn_and_earn" = "学ぶ＆稼ぐ";
@@ -228,6 +229,8 @@
 "express_exchange_by" = "%@による交換";
 "express_exchange_notification_failed_text" = "返金を受けるには、プロバイダーのウェブサイトにアクセスしてください。";
 "express_exchange_notification_failed_title" = "プロバイダーによる操作が失敗しました。";
+"express_exchange_notification_refund_text" = "The transaction amount was refunded in %1$s to your wallet due to OKX or bridge rules. %2$s";
+"express_exchange_notification_refund_title" = "The amount was refunded in %1$s (%2$s network)";
 "express_exchange_notification_verification_text" = "確認するには、プロバイダーのウェブサイトにアクセスしてください。";
 "express_exchange_notification_verification_title" = "プロバイダーによる本人確認手続きが必要です。";
 "express_exchange_status_canceled" = "キャンセルされました";

--- a/Tangem/Resources/Localizations/ru.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/ru.lproj/Localizable.strings
@@ -105,6 +105,7 @@
 "common_fee_selector_title" = "Скорость и комиссия";
 "common_generate_addresses" = "Получить адреса";
 "common_go_to_provider" = "К провайдеру";
+"common_go_to_token" = "Перейти в токен";
 "common_import" = "Импортировать";
 "common_later" = "Позже";
 "common_learn_and_earn" = "Learn & Earn";
@@ -228,6 +229,8 @@
 "express_exchange_by" = "Обмен через %@";
 "express_exchange_notification_failed_text" = "Чтобы вернуть ваши деньги, посетите сайт провайдера";
 "express_exchange_notification_failed_title" = "Операция не выполнена провайдером";
+"express_exchange_notification_refund_text" = "Отправленные средства были возвращены в %1$s на ваш кошелек в соответствии с правилами OKX или моста обмена. %2$s";
+"express_exchange_notification_refund_title" = "Сумма была возвращена в %1$s (%2$s сети)";
 "express_exchange_notification_verification_text" = "Посетите сайт провайдера для проверки";
 "express_exchange_notification_verification_title" = "Провайдер запрашивает прохождение верификации";
 "express_exchange_status_canceled" = "Отменен";

--- a/Tangem/Resources/Localizations/uk-UA.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/uk-UA.lproj/Localizable.strings
@@ -105,6 +105,7 @@
 "common_fee_selector_title" = "Швидкість та комісія";
 "common_generate_addresses" = "Отримати адреси";
 "common_go_to_provider" = "Перейти до провайдера";
+"common_go_to_token" = "Go to token";
 "common_import" = "Імпортувати";
 "common_later" = "Пізніше";
 "common_learn_and_earn" = "Навчайся та заробляй";
@@ -228,6 +229,8 @@
 "express_exchange_by" = "Обмін через %@";
 "express_exchange_notification_failed_text" = "Щоб повернути ваші кошти, відвідайте сайт провайдера";
 "express_exchange_notification_failed_title" = "Операція не виконана провайдером";
+"express_exchange_notification_refund_text" = "The transaction amount was refunded in %1$s to your wallet due to OKX or bridge rules. %2$s";
+"express_exchange_notification_refund_title" = "The amount was refunded in %1$s (%2$s network)";
 "express_exchange_notification_verification_text" = "Відвідайте сайт провайдера для перевірки";
 "express_exchange_notification_verification_title" = "Провайдер вимагає проходження KYC верифікації";
 "express_exchange_status_canceled" = "Скасовано";

--- a/Tangem/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Tangem/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -105,6 +105,7 @@
 "common_fee_selector_title" = "Speed and fee";
 "common_generate_addresses" = "Get addresses";
 "common_go_to_provider" = "Go to provider";
+"common_go_to_token" = "Go to token";
 "common_import" = "導入";
 "common_later" = "Later";
 "common_learn_and_earn" = "Learn & Earn";
@@ -228,6 +229,8 @@
 "express_exchange_by" = "Exchange by %@";
 "express_exchange_notification_failed_text" = "Visit provider’s website to refund your money";
 "express_exchange_notification_failed_title" = "Operation failed by provider";
+"express_exchange_notification_refund_text" = "The transaction amount was refunded in %1$s to your wallet due to OKX or bridge rules. %2$s";
+"express_exchange_notification_refund_title" = "The amount was refunded in %1$s (%2$s network)";
 "express_exchange_notification_verification_text" = "Visit provider’s website for verification";
 "express_exchange_notification_verification_title" = "KYC verification required by provider";
 "express_exchange_status_canceled" = "Canceled";

--- a/Tangem/UIComponents/NotificationView/NotificationView.swift
+++ b/Tangem/UIComponents/NotificationView/NotificationView.swift
@@ -105,8 +105,10 @@ struct NotificationView: View {
                 case .string(let string):
                     Text(string)
                         .style(Fonts.Bold.footnote, color: settings.event.colorScheme.titleColor)
+                        .fixedSize(horizontal: false, vertical: true)
                 case .attributed(let attributedString):
                     Text(attributedString)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
                 if let description = settings.event.description {

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -1221,6 +1221,11 @@
 		DC939F992C3C0323002D0326 /* CommonXPUBGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC939F952C3C0323002D0326 /* CommonXPUBGenerator.swift */; };
 		DC939F9A2C3C0323002D0326 /* XPUBGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC939F962C3C0323002D0326 /* XPUBGenerator.swift */; };
 		DC939F9B2C3C0323002D0326 /* XPUBGeneratorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC939F972C3C0323002D0326 /* XPUBGeneratorFactory.swift */; };
+		DC96325F2C5140CE009B250A /* ExpressRefundedTokenHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC96325E2C5140CE009B250A /* ExpressRefundedTokenHandler.swift */; };
+		DC9632612C5140DB009B250A /* CommonExpressRefundedTokenHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9632602C5140DB009B250A /* CommonExpressRefundedTokenHandler.swift */; };
+		DC9632632C5141B8009B250A /* TokenFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9632622C5141B8009B250A /* TokenFinder.swift */; };
+		DC9632662C51434C009B250A /* CommonTokenFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9632652C51434C009B250A /* CommonTokenFinder.swift */; };
+		DC9632682C515566009B250A /* ExpressRefundedTokenHandlerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9632672C515566009B250A /* ExpressRefundedTokenHandlerMock.swift */; };
 		DC9A4A2D2AB4ADD30031C7C2 /* UserCodeRecovering.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9A4A2C2AB4ADD30031C7C2 /* UserCodeRecovering.swift */; };
 		DC9A4A302AB4AE320031C7C2 /* UserCodeRecoveringCardInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9A4A2F2AB4AE320031C7C2 /* UserCodeRecoveringCardInteractor.swift */; };
 		DCA21D942BA1C77A000A3C1A /* ValidationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCA21D932BA1C77A000A3C1A /* ValidationMode.swift */; };
@@ -3131,6 +3136,11 @@
 		DC939F952C3C0323002D0326 /* CommonXPUBGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommonXPUBGenerator.swift; sourceTree = "<group>"; };
 		DC939F962C3C0323002D0326 /* XPUBGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XPUBGenerator.swift; sourceTree = "<group>"; };
 		DC939F972C3C0323002D0326 /* XPUBGeneratorFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XPUBGeneratorFactory.swift; sourceTree = "<group>"; };
+		DC96325E2C5140CE009B250A /* ExpressRefundedTokenHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressRefundedTokenHandler.swift; sourceTree = "<group>"; };
+		DC9632602C5140DB009B250A /* CommonExpressRefundedTokenHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonExpressRefundedTokenHandler.swift; sourceTree = "<group>"; };
+		DC9632622C5141B8009B250A /* TokenFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenFinder.swift; sourceTree = "<group>"; };
+		DC9632652C51434C009B250A /* CommonTokenFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonTokenFinder.swift; sourceTree = "<group>"; };
+		DC9632672C515566009B250A /* ExpressRefundedTokenHandlerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressRefundedTokenHandlerMock.swift; sourceTree = "<group>"; };
 		DC9A4A2C2AB4ADD30031C7C2 /* UserCodeRecovering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCodeRecovering.swift; sourceTree = "<group>"; };
 		DC9A4A2F2AB4AE320031C7C2 /* UserCodeRecoveringCardInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCodeRecoveringCardInteractor.swift; sourceTree = "<group>"; };
 		DCA21D932BA1C77A000A3C1A /* ValidationMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationMode.swift; sourceTree = "<group>"; };
@@ -5691,6 +5701,7 @@
 		B0AF2DED2B1D8FD2001A8696 /* Express */ = {
 			isa = PBXGroup;
 			children = (
+				DC96325D2C5140B4009B250A /* ExpressRefundedTokenHandler */,
 				EF5820462B33348B00940387 /* ExpressExchangeDataDecoder */,
 				EF6A8B012B278A5700CA3535 /* ExpressRepository */,
 				EF6A8AFC2B2786D400CA3535 /* ExpressFeeProvider */,
@@ -7214,6 +7225,7 @@
 		DC0A57DA2822A4DC0031BECC /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				DC9632642C514335009B250A /* TokenFinder */,
 				DC592B912C41A7EA005AB9A7 /* Staking */,
 				B62C65C62C38D04F00189AD4 /* PushNotifications */,
 				B098F3972C0474AD00F79989 /* ManageTokens */,
@@ -7779,6 +7791,24 @@
 			name = XPUB;
 			path = Tangem/Common/BlockchainSDK/XPUB;
 			sourceTree = SOURCE_ROOT;
+		};
+		DC96325D2C5140B4009B250A /* ExpressRefundedTokenHandler */ = {
+			isa = PBXGroup;
+			children = (
+				DC96325E2C5140CE009B250A /* ExpressRefundedTokenHandler.swift */,
+				DC9632602C5140DB009B250A /* CommonExpressRefundedTokenHandler.swift */,
+			);
+			path = ExpressRefundedTokenHandler;
+			sourceTree = "<group>";
+		};
+		DC9632642C514335009B250A /* TokenFinder */ = {
+			isa = PBXGroup;
+			children = (
+				DC9632622C5141B8009B250A /* TokenFinder.swift */,
+				DC9632652C51434C009B250A /* CommonTokenFinder.swift */,
+			);
+			path = TokenFinder;
+			sourceTree = "<group>";
 		};
 		DC9A4A2E2AB4AE1C0031C7C2 /* UserCodeRecovering */ = {
 			isa = PBXGroup;
@@ -8646,6 +8676,7 @@
 				EF9E2A522B56A5DF00418559 /* WalletModel+Mock.swift */,
 				EF9E2A542B56A6E800418559 /* UserWalletModelMock.swift */,
 				DA9493E62B9978A900F2BE0F /* EmailDataProviderMock.swift */,
+				DC9632672C515566009B250A /* ExpressRefundedTokenHandlerMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -10573,6 +10604,7 @@
 				B0B3FF6E2C0757E700B61EF7 /* ManageTokensView.swift in Sources */,
 				EF0DC11C2A0CE29E007E3DA7 /* ExpressApproveViewModel.swift in Sources */,
 				B62EE31C2B28977B006BA412 /* RateAppResponse.swift in Sources */,
+				DC9632612C5140DB009B250A /* CommonExpressRefundedTokenHandler.swift in Sources */,
 				EFC84B092C37FAB500546882 /* SendAmountStepBuilder.swift in Sources */,
 				DC70C01F2B95F196002205BA /* KeysDerivingMock.swift in Sources */,
 				EFAD02472A824E6700E9B959 /* TransactionViewModel.swift in Sources */,
@@ -10762,6 +10794,7 @@
 				B65CB3FE2A98A93F00C31199 /* UserTokensReorderingAction.swift in Sources */,
 				B67DC1EA2B7C4C48008ACB0E /* BlockchainAccountCreatorStub.swift in Sources */,
 				DC13D04029DF2D470003895C /* BackupServiceFactory.swift in Sources */,
+				DC96325F2C5140CE009B250A /* ExpressRefundedTokenHandler.swift in Sources */,
 				B675C3762BACB8AA007BE1DC /* PolkadotAccountHealthChecker.swift in Sources */,
 				DCBAF69F2A4AF4660029480A /* TwinWalletManagerFactory.swift in Sources */,
 				EFE7D5842AA224C50047D93A /* FetchMore.swift in Sources */,
@@ -10873,6 +10906,7 @@
 				DA559C322B0261F400F59584 /* SendModel.swift in Sources */,
 				EFFC861328BCF6C500F863CE /* StorageEntry.swift in Sources */,
 				EFC84AC22C35CB2900546882 /* SendFinishViewModel.swift in Sources */,
+				DC9632682C515566009B250A /* ExpressRefundedTokenHandlerMock.swift in Sources */,
 				B0B09BCF295B54FB001D6BA4 /* WalletConnectSessionsStorage.swift in Sources */,
 				B0E9E2FF2679DA8000269C7A /* AmountView.swift in Sources */,
 				EFB932192C3EC18300C999E9 /* StakingValidatorsViewModel.swift in Sources */,
@@ -11684,6 +11718,7 @@
 				B004A3E82B17672000C66CA9 /* PendingExpressTransactionView.swift in Sources */,
 				B62C65D42C38D06B00189AD4 /* CommonPushNotificationsInteractor.swift in Sources */,
 				B0C4F77526F08CDE0086D815 /* OnboardingProgressStateIndicatable.swift in Sources */,
+				DC9632632C5141B8009B250A /* TokenFinder.swift in Sources */,
 				B63442612AFE90A700C87481 /* CardsInfoPagerSwipeDiscoveryAnimationTrigger.swift in Sources */,
 				B6157AAD2C322733000640B4 /* OnboardingFeatureDescriptionView.swift in Sources */,
 				B6D274E82C38318900FEFCDC /* OnboardingLayoutConstants.swift in Sources */,
@@ -11848,6 +11883,7 @@
 				EF9E2A472B5532A600418559 /* ExpressCurrencyViewModel.swift in Sources */,
 				DA559C4A2B02622600F59584 /* SendRoutableMock.swift in Sources */,
 				DC66BC0A285B755800CDF765 /* PushTxRoutable.swift in Sources */,
+				DC9632662C51434C009B250A /* CommonTokenFinder.swift in Sources */,
 				B050F5082B6283CF00B2E53C /* VisaTransactionHistoryMapper.swift in Sources */,
 				DC7D3A0729E06365007BCD23 /* GenericBackupServiceFactory.swift in Sources */,
 				B03662652B6385C70064E073 /* VisaTransactionDetailsViewModelMock.swift in Sources */,

--- a/TangemExpress/Models/ExpressTransaction.swift
+++ b/TangemExpress/Models/ExpressTransaction.swift
@@ -11,4 +11,5 @@ import Foundation
 public struct ExpressTransaction {
     public let providerId: ExpressProvider.Id
     public let externalStatus: ExpressTransactionStatus
+    public let refundedCurrency: ExpressCurrency?
 }

--- a/TangemExpress/Services/ExpressAPIMapper/ExpressAPIMapper.swift
+++ b/TangemExpress/Services/ExpressAPIMapper/ExpressAPIMapper.swift
@@ -116,8 +116,18 @@ struct ExpressAPIMapper {
     func mapToExpressTransaction(response: ExpressDTO.ExchangeStatus.Response) -> ExpressTransaction {
         ExpressTransaction(
             providerId: .init(response.providerId),
-            externalStatus: response.status
+            externalStatus: response.status,
+            refundedCurrency: mapToRefundedExpressCurrency(response: response)
         )
+    }
+
+    private func mapToRefundedExpressCurrency(response: ExpressDTO.ExchangeStatus.Response) -> ExpressCurrency? {
+        guard let refundTokenAddress = response.refundTokenAddress,
+              let refundNetwork = response.refundNetwork else {
+            return nil
+        }
+
+        return ExpressCurrency(contractAddress: refundTokenAddress, network: refundNetwork)
     }
 }
 

--- a/TangemExpress/Services/ExpressAPIService/Types/ExpressDTO.swift
+++ b/TangemExpress/Services/ExpressAPIService/Types/ExpressDTO.swift
@@ -138,6 +138,8 @@ enum ExpressDTO {
         struct Response: Decodable {
             let providerId: Provider.Id
             let status: ExpressTransactionStatus
+            let refundNetwork: String?
+            let refundTokenAddress: String?
         }
     }
 


### PR DESCRIPTION
Хэндлинг рефандед токенов для провайдеров с типом dexBridge.

Требования тут https://tangem.atlassian.net/browse/IOS-7435

Если кратко, то теперь, если экспресс присылает рефандед статус с токеном внутри и это dexBridge, мы добавляем этот токен пользовалю в список (если не добавлен), вешаем уведомление с переходом в этот токен и делаем terminate олько после перехода в этот токен