### PR TITLE
[Markets] IOS-7496 reload markets list by interval

### DIFF
--- a/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
@@ -137,7 +137,17 @@ private extension MarketsViewModel {
             .removeDuplicates()
             .withWeakCaptureOf(self)
             .sink { viewModel, value in
-                viewModel.fetch(with: viewModel.dataProvider.lastSearchTextValue ?? "", by: viewModel.filterProvider.currentFilterValue)
+                // If use filter for losers or gainers, the order of the list may change. 
+                // Otherwise, we just get new charts for a given interval.
+                // The charts will also be updated when the list is updated
+                if value.order == .losers || value.order == .gainers {
+                    viewModel.fetch(with: viewModel.dataProvider.lastSearchTextValue ?? "", by: viewModel.filterProvider.currentFilterValue)
+                } else {
+                    viewModel.chartsHistoryProvider.fetch(
+                        for: viewModel.dataProvider.items.map { $0.id },
+                        with: viewModel.filterProvider.currentFilterValue.interval
+                    )
+                }
             }
             .store(in: &bag)
     }

--- a/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
@@ -137,7 +137,13 @@ private extension MarketsViewModel {
             .removeDuplicates()
             .withWeakCaptureOf(self)
             .sink { viewModel, value in
-                // If use filter for losers or gainers, the order of the list may change. 
+                // If we change the sorting, we always rebuild the list.
+                guard value.order == viewModel.dataProvider.lastFilterValue?.order else {
+                    viewModel.fetch(with: viewModel.dataProvider.lastSearchTextValue ?? "", by: viewModel.filterProvider.currentFilterValue)
+                    return
+                }
+
+                // If the sorting value has not changed, and order filter for losers or gainers, the order of the list may also change.
                 // Otherwise, we just get new charts for a given interval.
                 // The charts will also be updated when the list is updated
                 if value.order == .losers || value.order == .gainers {


### PR DESCRIPTION
Выставил обновление сортировки + интервалы в нужное поведение:

1. Если сортировка не top лузеры и гейнеры, переключение интервалов обновляет только графки
2. Если меняем сортировку переспрашиваем список


https://github.com/user-attachments/assets/dd826c82-6310-455f-97f7-13ccef86fed5
