### PR TITLE
IOS-7393: Scheduling quotes updates for hot area

### DIFF
--- a/Tangem/App/Utilities/AsyncTaskScheduler.swift
+++ b/Tangem/App/Utilities/AsyncTaskScheduler.swift
@@ -11,6 +11,10 @@ import Foundation
 class AsyncTaskScheduler {
     private var task: Task<Void, Error>?
 
+    var isScheduled: Bool {
+        !(task?.isCancelled ?? true)
+    }
+
     func scheduleJob(interval: TimeInterval, repeats: Bool, action: @escaping () async throws -> Void) {
         task?.cancel()
         task = Task {

--- a/Tangem/Modules/Markets/TokenList/MarketsListDataController.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsListDataController.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import Combine
+import CombineExt
 
 class MarketsListDataController {
     var visibleRangeAreaPublisher: some Publisher<VisibleArea, Never> {
@@ -17,32 +18,37 @@ class MarketsListDataController {
     // MARK: - Private Properties
 
     private let dataProvider: MarketsListDataProvider
+    private weak var cellsStateUpdater: MarketsListStateUpdater?
 
     private let lastAppearedIndexSubject: CurrentValueSubject<Int, Never> = .init(0)
     private let lastDisappearedIndexSubject: CurrentValueSubject<Int, Never> = .init(0)
     private let visibleRangeAreaSubject: CurrentValueSubject<VisibleArea, Never> = .init(VisibleArea(range: 0 ... 1, direction: .down))
+    private let hotAreaSubject: CurrentValueSubject<VisibleArea, Never> = .init(VisibleArea(range: 0 ... 1, direction: .down))
 
     private var bag = Set<AnyCancellable>()
-    private var isViewVisible: Bool
+    private var isViewVisible: Bool = false
 
     // MARK: - Init
 
-    init(dataProvider: MarketsListDataProvider, isViewVisible: Bool) {
+    init(dataProvider: MarketsListDataProvider, viewVisibilityPublisher: any Publisher<Bool, Never>, cellsStateUpdater: MarketsListStateUpdater?) {
         self.dataProvider = dataProvider
-        self.isViewVisible = isViewVisible
+        self.cellsStateUpdater = cellsStateUpdater
 
+        bind(viewVisibilityPublisher: viewVisibilityPublisher)
         bind()
-    }
-
-    func update(viewDidAppear: Bool) {
-        isViewVisible = viewDidAppear
     }
 
     // MARK: - Private Implementation
 
+    private func bind(viewVisibilityPublisher: any Publisher<Bool, Never>) {
+        viewVisibilityPublisher
+            .assign(to: \.isViewVisible, on: self, ownership: .weak)
+            .store(in: &bag)
+    }
+
     private func bind() {
         lastAppearedIndexSubject.dropFirst().removeDuplicates()
-            .combineLatest(lastDisappearedIndexSubject.dropFirst().removeDuplicates())
+            .combineLatest(lastDisappearedIndexSubject.removeDuplicates())
             .receive(on: DispatchQueue.main)
             .withWeakCaptureOf(self)
             .sink(receiveValue: { elements in
@@ -75,6 +81,62 @@ class MarketsListDataController {
                 case .up:
                     break
                 }
+            }
+            .store(in: &bag)
+
+        visibleRangeAreaSubject.dropFirst().removeDuplicates()
+            .debounce(for: 0.5, scheduler: DispatchQueue.main)
+            .map { newVisibleArea in
+                let numberOfItemsInBufferZone = Constants.itemsInBufferZone
+                return .init(
+                    range: max(0, newVisibleArea.range.lowerBound - numberOfItemsInBufferZone) ... newVisibleArea.range.upperBound + numberOfItemsInBufferZone,
+                    direction: newVisibleArea.direction
+                )
+            }
+            .assign(to: \.value, on: hotAreaSubject, ownership: .weak)
+            .store(in: &bag)
+
+        hotAreaSubject.dropFirst()
+            .withPrevious()
+            .withWeakCaptureOf(self)
+            .sink { elements in
+                let (dataController, (oldHotArea, newHotArea)) = elements
+                let oldHotAreaRange = oldHotArea?.range
+                let newHotAreaRange = newHotArea.range
+
+                guard let oldHotAreaRange else {
+                    dataController.cellsStateUpdater?.setupUpdates(for: newHotAreaRange)
+                    return
+                }
+
+                var rangeToInvalidate: ClosedRange<Int>?
+                var rangeToSetupUpdates: ClosedRange<Int>
+
+                switch newHotArea.direction {
+                case .down:
+                    guard oldHotAreaRange.lowerBound < newHotAreaRange.lowerBound else {
+                        rangeToInvalidate = nil
+                        rangeToSetupUpdates = newHotAreaRange.lowerBound ... newHotAreaRange.upperBound
+                        break
+                    }
+
+                    rangeToSetupUpdates = min(oldHotAreaRange.upperBound, newHotAreaRange.upperBound) ... max(oldHotAreaRange.upperBound, newHotAreaRange.upperBound)
+                    rangeToInvalidate = oldHotAreaRange.lowerBound ... newHotAreaRange.lowerBound
+                case .up:
+                    guard newHotAreaRange.upperBound < oldHotAreaRange.upperBound else {
+                        rangeToInvalidate = nil
+                        rangeToSetupUpdates = newHotAreaRange.lowerBound ... newHotAreaRange.upperBound
+                        break
+                    }
+
+                    rangeToSetupUpdates = min(newHotAreaRange.lowerBound, oldHotAreaRange.lowerBound) ... max(newHotAreaRange.lowerBound, oldHotAreaRange.lowerBound)
+                    rangeToInvalidate = newHotAreaRange.upperBound ... oldHotAreaRange.upperBound
+                }
+
+                if let rangeToInvalidate {
+                    dataController.cellsStateUpdater?.invalidateCells(in: rangeToInvalidate)
+                }
+                dataController.cellsStateUpdater?.setupUpdates(for: rangeToSetupUpdates)
             }
             .store(in: &bag)
     }

--- a/Tangem/Modules/Markets/TokenList/MarketsListStateUpdater.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsListStateUpdater.swift
@@ -1,0 +1,14 @@
+//
+//  MarketsListStateUpdater.swift
+//  Tangem
+//
+//  Created by Andrew Son on 30/07/24.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+protocol MarketsListStateUpdater: AnyObject {
+    func invalidateCells(in range: ClosedRange<Int>)
+    func setupUpdates(for range: ClosedRange<Int>)
+}

--- a/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
@@ -23,11 +23,7 @@ final class MarketsViewModel: ObservableObject {
 
     // MARK: - Properties
 
-    private var isViewVisible: Bool = false {
-        didSet {
-            listDataController.update(viewDidAppear: isViewVisible)
-        }
-    }
+    @Published var isViewVisible: Bool = false
 
     var isSearching: Bool {
         !currentSearchValue.isEmpty
@@ -38,8 +34,9 @@ final class MarketsViewModel: ObservableObject {
     private let filterProvider = MarketsListDataFilterProvider()
     private let dataProvider = MarketsListDataProvider()
     private let chartsHistoryProvider = MarketsListChartsHistoryProvider()
+    private let quotesUpdater = MarketsQuotesUpdater()
 
-    private lazy var listDataController: MarketsListDataController = .init(dataProvider: dataProvider, isViewVisible: isViewVisible)
+    private lazy var listDataController: MarketsListDataController = .init(dataProvider: dataProvider, viewVisibilityPublisher: $isViewVisible, cellsStateUpdater: self)
 
     private var bag = Set<AnyCancellable>()
     private var currentSearchValue: String = ""
@@ -60,6 +57,7 @@ final class MarketsViewModel: ObservableObject {
         searchTextBind(searchTextPublisher: searchTextPublisher)
         searchFilterBind(filterPublisher: filterProvider.filterPublisher)
 
+        bind()
         dataProviderBind()
 
         // Need for preload markets list, when bottom sheet it has not been opened yet
@@ -138,6 +136,19 @@ private extension MarketsViewModel {
             .withWeakCaptureOf(self)
             .sink { viewModel, value in
                 viewModel.fetch(with: viewModel.dataProvider.lastSearchTextValue ?? "", by: viewModel.filterProvider.currentFilterValue)
+            }
+            .store(in: &bag)
+    }
+
+    func bind() {
+        $isViewVisible
+            .withWeakCaptureOf(self)
+            .sink { viewModel, isVisible in
+                if isVisible {
+                    viewModel.quotesUpdater.resumeUpdates()
+                } else {
+                    viewModel.quotesUpdater.pauseUpdates()
+                }
             }
             .store(in: &bag)
     }
@@ -253,5 +264,35 @@ private extension MarketsViewModel {
 extension MarketsViewModel: MarketsOrderHeaderViewModelOrderDelegate {
     func orderActionButtonDidTap() {
         coordinator?.openFilterOrderBottonSheet(with: filterProvider)
+    }
+}
+
+extension MarketsViewModel: MarketsListStateUpdater {
+    func invalidateCells(in range: ClosedRange<Int>) {
+        var invalidatedIds = Set<String>()
+        for index in range {
+            guard index < tokenViewModels.count else {
+                break
+            }
+
+            let tokenViewModel = tokenViewModels[index]
+            invalidatedIds.insert(tokenViewModel.tokenId)
+        }
+
+        quotesUpdater.stopUpdatingQuotes(for: invalidatedIds)
+    }
+
+    func setupUpdates(for range: ClosedRange<Int>) {
+        var idsToUpdate = Set<String>()
+        for index in range {
+            guard index < tokenViewModels.count else {
+                break
+            }
+
+            let tokenViewModel = tokenViewModels[index]
+            idsToUpdate.insert(tokenViewModel.tokenId)
+        }
+
+        quotesUpdater.scheduleQuotesUpdate(for: idsToUpdate)
     }
 }

--- a/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsViewModel.swift
@@ -95,7 +95,6 @@ class TokenMarketsDetailsViewModel: ObservableObject {
     private let dataProvider: MarketsTokenDetailsDataProvider
     private let walletDataProvider = MarketsWalletDataProvider()
 
-    private var quotesUpdateScheduler: AsyncTaskScheduler?
     private var loadedInfo: TokenMarketsDetailsModel?
     private var bag = Set<AnyCancellable>()
 
@@ -122,8 +121,6 @@ class TokenMarketsDetailsViewModel: ObservableObject {
 
     deinit {
         print("TokenMarketsDetailsViewModel deinit")
-        quotesUpdateScheduler?.cancel()
-        quotesUpdateScheduler = nil
     }
 
     // MARK: - Actions
@@ -179,7 +176,6 @@ private extension TokenMarketsDetailsViewModel {
             do {
                 let currencyId = viewModel.tokenInfo.id
                 viewModel.log("Attempt to load token markets data for token with id: \(currencyId)")
-                await viewModel.updateQuotes()
                 let result = try await viewModel.dataProvider.loadTokenMarketsDetails(for: currencyId)
 
                 await runOnMain {
@@ -187,23 +183,11 @@ private extension TokenMarketsDetailsViewModel {
                     viewModel.isLoading = false
                 }
 
-                viewModel.scheduleQuotesUpdate()
             } catch {
                 await runOnMain { viewModel.alert = error.alertBinder }
                 viewModel.log("Failed to load detailed info. Reason: \(error)")
             }
         }
-    }
-
-    func scheduleQuotesUpdate() {
-        log("Scheduling quote update for \(tokenInfo.id)")
-        quotesUpdateScheduler = .init()
-        quotesUpdateScheduler?.scheduleJob(interval: quotesUpdateTimeInterval, repeats: true, action: weakify(self, forFunction: TokenMarketsDetailsViewModel.updateQuotes))
-    }
-
-    func updateQuotes() async {
-        log("Updating quotes for \(tokenInfo.id)")
-        await quotesRepository.loadQuotes(currencyIds: [tokenInfo.id])
     }
 
     func updatePrice(_ newPrice: Decimal) {

--- a/Tangem/Modules/Markets/Utilities/MarketsQuotesUpdater.swift
+++ b/Tangem/Modules/Markets/Utilities/MarketsQuotesUpdater.swift
@@ -1,0 +1,60 @@
+//
+//  MarketsQuotesUpdater.swift
+//  Tangem
+//
+//  Created by Andrew Son on 30/07/24.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import TangemFoundation
+
+class MarketsQuotesUpdater {
+    @Injected(\.quotesRepository) private var quotesRepository: TokenQuotesRepository
+
+    private let lock = Lock(isRecursive: false)
+    private let quotesUpdateTimeInterval: TimeInterval = 60.0
+
+    private var updateList = Set<String>()
+    private var task: AsyncTaskScheduler = .init()
+
+    func scheduleQuotesUpdate(for tokenIDs: Set<String>) {
+        lock {
+            updateList.formUnion(tokenIDs)
+        }
+    }
+
+    func stopUpdatingQuotes(for tokenIDs: Set<String>) {
+        lock {
+            tokenIDs.forEach {
+                updateList.remove($0)
+            }
+        }
+    }
+
+    func pauseUpdates() {
+        task.cancel()
+    }
+
+    func resumeUpdates() {
+        setupUpdateTask()
+    }
+
+    private func setupUpdateTask() {
+        if task.isScheduled {
+            return
+        }
+
+        task.scheduleJob(interval: quotesUpdateTimeInterval, repeats: true, action: { [weak self] in
+            await self?.updateQuotes()
+        })
+    }
+
+    private func updateQuotes() async {
+        if updateList.isEmpty {
+            return
+        }
+        let quotesToUpdate = Array(updateList)
+        await quotesRepository.loadQuotes(currencyIds: quotesToUpdate)
+    }
+}

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -518,6 +518,8 @@
 		B0A4C4A22A271CD20060E039 /* BalanceWithButtonsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A4C4A12A271CD20060E039 /* BalanceWithButtonsViewModel.swift */; };
 		B0A596542991FC1200C7C512 /* UtorgService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A596532991FC1200C7C512 /* UtorgService.swift */; };
 		B0A596562992A5B700C7C512 /* FixedSizeButtonWithIconInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A596552992A5B700C7C512 /* FixedSizeButtonWithIconInfo.swift */; };
+		B0A7DB4E2C58E2AC00986D95 /* MarketsQuotesUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A7DB4D2C58E2AC00986D95 /* MarketsQuotesUpdater.swift */; };
+		B0A7DB502C58E56F00986D95 /* MarketsListStateUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A7DB4F2C58E56F00986D95 /* MarketsListStateUpdater.swift */; };
 		B0A884A12A6A5D6300210321 /* WalletConnectWalletModelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A884A02A6A5D6300210321 /* WalletConnectWalletModelProvider.swift */; };
 		B0A943602565010900A7958E /* TwinsWalletCreationUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A9435F2565010900A7958E /* TwinsWalletCreationUtil.swift */; };
 		B0A948FF2ACD999C00C80B0A /* WeakifyFuncion.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A948FE2ACD999C00C80B0A /* WeakifyFuncion.swift */; };
@@ -2418,6 +2420,8 @@
 		B0A4C4A12A271CD20060E039 /* BalanceWithButtonsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceWithButtonsViewModel.swift; sourceTree = "<group>"; };
 		B0A596532991FC1200C7C512 /* UtorgService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtorgService.swift; sourceTree = "<group>"; };
 		B0A596552992A5B700C7C512 /* FixedSizeButtonWithIconInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedSizeButtonWithIconInfo.swift; sourceTree = "<group>"; };
+		B0A7DB4D2C58E2AC00986D95 /* MarketsQuotesUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketsQuotesUpdater.swift; sourceTree = "<group>"; };
+		B0A7DB4F2C58E56F00986D95 /* MarketsListStateUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketsListStateUpdater.swift; sourceTree = "<group>"; };
 		B0A884A02A6A5D6300210321 /* WalletConnectWalletModelProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletConnectWalletModelProvider.swift; sourceTree = "<group>"; };
 		B0A9435F2565010900A7958E /* TwinsWalletCreationUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwinsWalletCreationUtil.swift; sourceTree = "<group>"; };
 		B0A948FE2ACD999C00C80B0A /* WeakifyFuncion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakifyFuncion.swift; sourceTree = "<group>"; };
@@ -3974,6 +3978,7 @@
 				2DD5C3982C4EA6570000658D /* MarketsListPrefetchDataSource.swift */,
 				2DC5675D2B0DFFAF00B0244F /* MarketsView.swift */,
 				2DC5675E2B0DFFAF00B0244F /* MarketsViewModel.swift */,
+				B0A7DB4F2C58E56F00986D95 /* MarketsListStateUpdater.swift */,
 			);
 			path = TokenList;
 			sourceTree = "<group>";
@@ -5694,6 +5699,14 @@
 			path = BalanceWithButtonsView;
 			sourceTree = "<group>";
 		};
+		B0A7DB4C2C58E29A00986D95 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				B0A7DB4D2C58E2AC00986D95 /* MarketsQuotesUpdater.swift */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
 		B0A8849F2A6A5D1700210321 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
@@ -7142,6 +7155,7 @@
 				2D1BB3752C07501C008392F7 /* Providers */,
 				2DC567592B0DFFAF00B0244F /* TokenList */,
 				B0A1BC0F2C296B3800DECCFD /* TokenMarketsDetails */,
+				B0A7DB4C2C58E29A00986D95 /* Utilities */,
 				2D5DCC2B2C3309F1000EE379 /* TokensNetworkSelector */,
 				2DB648812C35877000DA100D /* UIComponents */,
 			);
@@ -11260,6 +11274,7 @@
 				5D39516125597DB1002CC452 /* BalanceViewModel.swift in Sources */,
 				5D4B8BC327EDD601002CE87C /* CardInfo.swift in Sources */,
 				B63127D42A2F52E2007C124C /* OrganizeTokensListSection.swift in Sources */,
+				B0A7DB502C58E56F00986D95 /* MarketsListStateUpdater.swift in Sources */,
 				DC261CB7292CF6B700875E64 /* UncompletedBackupRoutable.swift in Sources */,
 				DA559C3A2B0261F400F59584 /* SendView.swift in Sources */,
 				DAB19D4E2B2C72C400DD08C4 /* AddCustomTokenNotificationEvent.swift in Sources */,
@@ -11802,6 +11817,7 @@
 				B6D274E82C38318900FEFCDC /* OnboardingLayoutConstants.swift in Sources */,
 				B0E20E0A2C2AEA5B00213580 /* SheetHandleView.swift in Sources */,
 				B67688EF2B078EDB006C94F7 /* MainBottomSheetOverlayViewModel.swift in Sources */,
+				B0A7DB4E2C58E2AC00986D95 /* MarketsQuotesUpdater.swift in Sources */,
 				EF9E2A442B55329800418559 /* ExpressCurrencyView.swift in Sources */,
 				EF9448E22ADFD4F800F4AFAC /* InformationHiddenBalancesRoutable.swift in Sources */,
 				B04EADEC2A80D659009B5768 /* SingleTokenBaseViewModel.swift in Sources */,


### PR DESCRIPTION
* добавил расчет "горячей зоны", которая распространяется в обе стороны на 20 ячеек.
* удалил перезапрашивание баланса с деталки токена, т.к. для открытой монеты в любом случае будет запрашиваться квоты из списка маркетсов
* добавил отключение запроса, когда шторка скрывается