### PR TITLE
IOS-7514 Do not select recommended if error

### DIFF
--- a/TangemExpress/Manager/ExpressManager/CommonExpressManager.swift
+++ b/TangemExpress/Manager/ExpressManager/CommonExpressManager.swift
@@ -220,7 +220,7 @@ private extension CommonExpressManager {
     func bestProvider() async -> ExpressAvailableProvider? {
         // If we have more then one provider then selected the best
         if availableProviders.count > 1 {
-            if let recommendedProvider = recommendedProvder() {
+            if let recommendedProvider = await recommendedProvder() {
                 return recommendedProvider
             }
             // Try to find the best with expectAmount
@@ -255,8 +255,18 @@ private extension CommonExpressManager {
         return nil
     }
 
-    func recommendedProvder() -> ExpressAvailableProvider? {
-        availableProviders.first(where: { $0.provider.recommended == true })
+    func recommendedProvder() async -> ExpressAvailableProvider? {
+        for provider in availableProviders {
+            if await provider.getState().isError {
+                continue
+            }
+
+            if provider.provider.recommended == true {
+                return provider
+            }
+        }
+
+        return nil
     }
 
     func updateStatesInProviders(request: ExpressManagerSwappingPairRequest, approvePolicy: ExpressApprovePolicy) async {


### PR DESCRIPTION
Была проблема в том, что рекоммендед провайдер падал с ошибкой, но другой не выбирался, из-за рекоммендед. Тут выстрелил недостаток апи, потому что ожидалось, что в массиве available providers уже учтены ошибки.