### PR TITLE
IOS-7507: [Markets] Unable to load state for details page

### DIFF
--- a/Tangem/App/Models/Markets/MarketsPricePerformanceData.swift
+++ b/Tangem/App/Models/Markets/MarketsPricePerformanceData.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct MarketsPricePerformanceData: Codable {
+struct MarketsPricePerformanceData: Codable, Equatable {
     let lowPrice: Decimal
     let highPrice: Decimal
 }

--- a/Tangem/App/Models/Markets/MarketsTokenDetailsLinks.swift
+++ b/Tangem/App/Models/Markets/MarketsTokenDetailsLinks.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct MarketsTokenDetailsLinks: Codable {
+struct MarketsTokenDetailsLinks: Codable, Equatable {
     let officialLinks: [LinkInfo]
     let social: [LinkInfo]
     let repository: [LinkInfo]
@@ -16,7 +16,7 @@ struct MarketsTokenDetailsLinks: Codable {
 }
 
 extension MarketsTokenDetailsLinks {
-    struct LinkInfo: Codable {
+    struct LinkInfo: Codable, Equatable {
         let id: String?
         let title: String
         let link: String

--- a/Tangem/App/Models/Markets/MarketsTokenDetailsMetrics.swift
+++ b/Tangem/App/Models/Markets/MarketsTokenDetailsMetrics.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct MarketsTokenDetailsMetrics: Codable {
+struct MarketsTokenDetailsMetrics: Codable, Equatable {
     let marketRating: Int?
     let circulatingSupply: Decimal?
     let marketCap: Decimal?

--- a/Tangem/App/Models/Markets/TokenMarketsDetailsModel.swift
+++ b/Tangem/App/Models/Markets/TokenMarketsDetailsModel.swift
@@ -24,7 +24,16 @@ struct TokenMarketsDetailsModel: Identifiable {
     let links: MarketsTokenDetailsLinks
 }
 
-struct TokenMarketsDetailsInsights {
+extension TokenMarketsDetailsModel: Equatable {
+    // This model won't be reloaded for now (no PTR or some kind of refresh mechanism),
+    // so it is safe to compare this fields.
+    static func == (lhs: TokenMarketsDetailsModel, rhs: TokenMarketsDetailsModel) -> Bool {
+        return lhs.id == rhs.id && lhs.insights == rhs.insights && lhs.metrics == rhs.metrics
+            && lhs.pricePerformance == rhs.pricePerformance && lhs.links == rhs.links
+    }
+}
+
+struct TokenMarketsDetailsInsights: Equatable {
     let holders: [MarketsPriceIntervalType: Decimal]
     let liquidity: [MarketsPriceIntervalType: Decimal]
     let buyPressure: [MarketsPriceIntervalType: Decimal]

--- a/Tangem/Common/Extensions/Error+.swift
+++ b/Tangem/Common/Extensions/Error+.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Moya
 import SwiftUI
+import TangemSdk
 
 extension Error {
     var detailedError: Error {
@@ -54,4 +55,22 @@ extension BindableErrorWrapper: LocalizedError {
     var recoverySuggestion: String? { (error as? LocalizedError)?.recoverySuggestion }
 
     var helpAnchor: String? { (error as? LocalizedError)?.helpAnchor }
+}
+
+extension Error {
+    var isCancellation: Bool {
+        switch self {
+        case let sdkError as TangemSdkError:
+            return sdkError.isUserCancelled
+        case let moyaError as MoyaError:
+            switch moyaError {
+            case .underlying(let error, _):
+                return error.asAFError?.isExplicitlyCancelledError ?? false
+            default:
+                return false
+            }
+        default:
+            return false
+        }
+    }
 }

--- a/Tangem/Common/Extensions/Error+.swift
+++ b/Tangem/Common/Extensions/Error+.swift
@@ -9,7 +9,6 @@
 import Foundation
 import Moya
 import SwiftUI
-import TangemSdk
 
 extension Error {
     var detailedError: Error {
@@ -60,8 +59,6 @@ extension BindableErrorWrapper: LocalizedError {
 extension Error {
     var isCancellation: Bool {
         switch self {
-        case let sdkError as TangemSdkError:
-            return sdkError.isUserCancelled
         case let moyaError as MoyaError:
             switch moyaError {
             case .underlying(let error, _):

--- a/Tangem/Common/Extensions/Error+.swift
+++ b/Tangem/Common/Extensions/Error+.swift
@@ -69,6 +69,8 @@ extension Error {
             default:
                 return false
             }
+        case is CancellationError:
+            return true
         default:
             return false
         }

--- a/Tangem/Common/Extensions/Error+.swift
+++ b/Tangem/Common/Extensions/Error+.swift
@@ -57,7 +57,7 @@ extension BindableErrorWrapper: LocalizedError {
 }
 
 extension Error {
-    var isCancellation: Bool {
+    var isCancellationError: Bool {
         switch self {
         case let moyaError as MoyaError:
             switch moyaError {
@@ -68,6 +68,8 @@ extension Error {
             }
         case is CancellationError:
             return true
+        case let urlError as URLError:
+            return urlError.code == URLError.Code.cancelled
         default:
             return false
         }

--- a/Tangem/Modules/App/AppCoordinatorView.swift
+++ b/Tangem/Modules/App/AppCoordinatorView.swift
@@ -13,6 +13,8 @@ struct AppCoordinatorView: CoordinatorView {
     @ObservedObject var coordinator: AppCoordinator
     @ObservedObject var sensitiveTextVisibilityViewModel = SensitiveTextVisibilityViewModel.shared
 
+    @Environment(\.mainWindowSize) var mainWindowSize: CGSize
+
     var body: some View {
         NavigationView {
             switch coordinator.viewState {
@@ -33,6 +35,7 @@ struct AppCoordinatorView: CoordinatorView {
         .accentColor(Colors.Text.primary1)
         .overlayContentContainer(item: $coordinator.marketsCoordinator) { coordinator in
             MarketsCoordinatorView(coordinator: coordinator)
+                .environment(\.mainWindowSize, mainWindowSize)
         }
         .bottomSheet(
             item: $sensitiveTextVisibilityViewModel.informationHiddenBalancesViewModel,

--- a/Tangem/Modules/Markets/TokenList/MarketsView.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsView.swift
@@ -122,20 +122,10 @@ struct MarketsView: View {
     }
 
     private var errorStateView: some View {
-        VStack(spacing: 12) {
-            Text(Localization.marketsLoadingErrorTitle)
-                .style(Fonts.Bold.caption1, color: Colors.Text.tertiary)
-
-            Button(action: {
-                viewModel.onTryLoadList()
-            }, label: {
-                HStack(spacing: .zero) {
-                    Text(Localization.tryToLoadDataAgainButtonTitle)
-                        .style(Fonts.Regular.footnote.bold(), color: Colors.Text.primary1)
-                }
-            })
-            .roundedBackground(with: Colors.Button.secondary, verticalPadding: 6, horizontalPadding: 12, radius: 10)
-        }
+        MarketsUnableToLoadDataView(
+            isButtonBusy: viewModel.tokenListLoadingState == .loading,
+            retryButtonAction: viewModel.onTryLoadList
+        )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.horizontal, 16)
     }

--- a/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/HistoryChart/MarketsHistoryChartView.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/HistoryChart/MarketsHistoryChartView.swift
@@ -22,7 +22,8 @@ struct MarketsHistoryChartView: View {
                 case .loaded(let chartData):
                     makeChartView(for: chartData)
                 case .failed:
-                    errorView
+                    // No need to add state for button, because view will switch to loading state and remove this view
+                    MarketsUnableToLoadDataView(isButtonBusy: false, retryButtonAction: viewModel.reload)
                 }
             }
             .transition(.opacity)
@@ -31,22 +32,6 @@ struct MarketsHistoryChartView: View {
         .animation(.linear(duration: 0.2), value: viewModel.viewState)
         .allowsHitTesting(viewModel.allowsHitTesting)
         .onAppear(perform: viewModel.onViewAppear)
-    }
-
-    @ViewBuilder
-    private var errorView: some View {
-        VStack(spacing: 12.0) {
-            Text(Localization.marketsLoadingErrorTitle)
-                .style(Fonts.Regular.caption1.weight(.medium).bold(), color: Colors.Text.tertiary)
-
-            Button(action: viewModel.reload) {
-                Text(Localization.tryToLoadDataAgainButtonTitle)
-                    .style(Fonts.Regular.caption1.weight(.medium).bold(), color: Colors.Text.primary1)
-            }
-            .padding(.vertical, 8.0)
-            .padding(.horizontal, 12.0)
-            .roundedBackground(with: Colors.Button.secondary, padding: .zero, radius: 8.0)
-        }
     }
 
     @ViewBuilder

--- a/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/HistoryChart/MarketsHistoryChartViewModel.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/HistoryChart/MarketsHistoryChartViewModel.swift
@@ -132,9 +132,10 @@ final class MarketsHistoryChartViewModel: ObservableObject {
         do {
             let chartViewData = try result.get()
             await updateViewState(.loaded(data: chartViewData), selectedPriceInterval: selectedPriceInterval)
-        } catch is CancellationError {
-            // No-op, cancelling a load request is perfectly normal
         } catch {
+            if error.isCancellation {
+                return
+            }
             // There is no point in updating `selectedPriceInterval` on failure, so nil is passed instead
             await updateViewState(.failed, selectedPriceInterval: nil)
         }

--- a/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/HistoryChart/MarketsHistoryChartViewModel.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/HistoryChart/MarketsHistoryChartViewModel.swift
@@ -133,7 +133,7 @@ final class MarketsHistoryChartViewModel: ObservableObject {
             let chartViewData = try result.get()
             await updateViewState(.loaded(data: chartViewData), selectedPriceInterval: selectedPriceInterval)
         } catch {
-            if error.isCancellation {
+            if error.isCancellationError {
                 return
             }
             // There is no point in updating `selectedPriceInterval` on failure, so nil is passed instead

--- a/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/Insights/MarketsTokenDetailsInsightsView.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/Insights/MarketsTokenDetailsInsightsView.swift
@@ -40,7 +40,7 @@ struct MarketsTokenDetailsInsightsView: View {
             }
 
             LazyVGrid(columns: gridItems, alignment: .center, spacing: 10, content: {
-                ForEach(viewModel.records.indexed(), id: \.1.id) { index, info in
+                ForEach(viewModel.records.indexed(), id: \.0) { index, info in
                     TokenMarketsDetailsStatisticsRecordView(
                         title: info.title,
                         message: info.recordData,
@@ -54,12 +54,13 @@ struct MarketsTokenDetailsInsightsView: View {
                             firstItemWidth = value
                         }
                     })
+                    .transition(.opacity)
                     .padding(.vertical, 10)
                 }
             })
             .readGeometry(\.size.width, bindTo: $gridWidth)
         }
-        .animation(nil)
+        .animation(.default, value: viewModel.selectedInterval)
         .defaultRoundedBackground(with: Colors.Background.action)
     }
 }

--- a/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsView.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 
 struct TokenMarketsDetailsView: View {
     @ObservedObject var viewModel: TokenMarketsDetailsViewModel
-    @Environment(\.mainWindowSize) private var mainWindowSize: CGSize
 
     @State private var descriptionBottomSheetHeight: CGFloat = 0
 
@@ -31,7 +30,7 @@ struct TokenMarketsDetailsView: View {
                             isButtonBusy: viewModel.isLoading,
                             retryButtonAction: viewModel.reloadAllData
                         )
-                        .frame(width: mainWindowSize.width)
+                        .infinityFrame(axis: .horizontal)
                         .hidden(!viewModel.allDataLoadFailed)
                     })
 
@@ -119,7 +118,6 @@ struct TokenMarketsDetailsView: View {
                 portfolioView
 
                 contentBlocks
-                    .padding(.bottom, 46.0)
             case .failedToLoadDetails:
                 MarketsUnableToLoadDataView(
                     isButtonBusy: viewModel.isLoading,
@@ -142,51 +140,46 @@ struct TokenMarketsDetailsView: View {
     @ViewBuilder
     private var contentBlocks: some View {
         VStack(spacing: 14) {
-            portfolioView
-
-            Group {
-                if let insightsViewModel = viewModel.insightsViewModel {
-                    MarketsTokenDetailsInsightsView(viewModel: insightsViewModel)
-                }
-
-                if let metricsViewModel = viewModel.metricsViewModel {
-                    MarketsTokenDetailsMetricsView(viewModel: metricsViewModel)
-                }
-
-                if let pricePerformanceViewModel = viewModel.pricePerformanceViewModel {
-                    MarketsTokenDetailsPricePerformanceView(viewModel: pricePerformanceViewModel)
-                }
-
-                TokenMarketsDetailsLinksView(sections: viewModel.linksSections)
+            if let insightsViewModel = viewModel.insightsViewModel {
+                MarketsTokenDetailsInsightsView(viewModel: insightsViewModel)
             }
+
+            if let metricsViewModel = viewModel.metricsViewModel {
+                MarketsTokenDetailsMetricsView(viewModel: metricsViewModel)
+            }
+
+            if let pricePerformanceViewModel = viewModel.pricePerformanceViewModel {
+                MarketsTokenDetailsPricePerformanceView(viewModel: pricePerformanceViewModel)
+            }
+
+            TokenMarketsDetailsLinksView(sections: viewModel.linksSections)
         }
+        .padding(.bottom, 46.0)
     }
 
     @ViewBuilder
     private func description(shortDescription: String?, fullDescription: String?) -> some View {
         if let shortDescription {
-            Group {
-                if fullDescription == nil {
-                    Text(shortDescription)
-                        .style(Fonts.Regular.footnote, color: Colors.Text.secondary)
-                        .multilineTextAlignment(.leading)
-                } else {
-                    Button(action: viewModel.openFullDescription) {
-                        Group {
-                            Text("\(shortDescription) ")
-                                + Text(Localization.commonReadMore)
-                                .foregroundColor(Colors.Text.accent)
-                        }
-                        .style(Fonts.Regular.footnote, color: Colors.Text.secondary)
-                        .multilineTextAlignment(.leading)
+            if fullDescription == nil {
+                Text(shortDescription)
+                    .style(Fonts.Regular.footnote, color: Colors.Text.secondary)
+                    .multilineTextAlignment(.leading)
+            } else {
+                Button(action: viewModel.openFullDescription) {
+                    Group {
+                        Text("\(shortDescription) ")
+                            + Text(Localization.commonReadMore)
+                            .foregroundColor(Colors.Text.accent)
                     }
+                    .style(Fonts.Regular.footnote, color: Colors.Text.secondary)
+                    .multilineTextAlignment(.leading)
                 }
             }
         }
     }
 }
 
-extension TokenMarketsDetailsView {
+private extension TokenMarketsDetailsView {
     enum Constants {
         static let chartHeight: CGFloat = 200.0
     }

--- a/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsViewModel.swift
@@ -226,7 +226,7 @@ private extension TokenMarketsDetailsViewModel {
                     if case .failedToLoadDetails = viewModel.state {
                         viewModel.state = .failedToLoadAllData
                     }
-                case (.loading, .loaded):
+                case (.loading, .loaded), (.failed, .loaded):
                     if case .failedToLoadAllData = viewModel.state {
                         viewModel.state = .failedToLoadDetails
                     }

--- a/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsViewModel.swift
@@ -33,7 +33,6 @@ class TokenMarketsDetailsViewModel: ObservableObject {
     @Published private var pickedTimeInterval: TimeInterval?
     @Published private var loadedHistoryInfo: [TimeInterval: Decimal] = [:]
     @Published private var loadedPriceChangeInfo: [String: Decimal] = [:]
-    @Published private var currentPriceSubject: CurrentValueSubject<Decimal, Never>
 
     let priceChangeIntervalOptions = MarketsPriceIntervalType.allCases
 
@@ -93,6 +92,7 @@ class TokenMarketsDetailsViewModel: ObservableObject {
         formatEpsilonAsLowestRepresentableValue: false,
         roundingType: .defaultFiat(roundingMode: .bankers)
     )
+    private let currentPriceSubject: CurrentValueSubject<Decimal, Never>
     private let quotesUpdateTimeInterval: TimeInterval = 60.0
 
     private let tokenInfo: MarketsTokenModel

--- a/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsViewModel.swift
@@ -177,11 +177,17 @@ class TokenMarketsDetailsViewModel: ObservableObject {
 
 private extension TokenMarketsDetailsViewModel {
     func handleLoadDetailedInfo(_ result: Result<TokenMarketsDetailsModel, Error>) async {
+        defer {
+            DispatchQueue.main.async {
+                self.isLoading = false
+            }
+        }
+
         do {
             let detailsModel = try result.get()
             await setupUI(using: detailsModel)
         } catch {
-            if error.isCancellation {
+            if error.isCancellationError {
                 return
             }
 
@@ -197,7 +203,6 @@ private extension TokenMarketsDetailsViewModel {
         state = .loaded(model: model)
 
         makeBlocksViewModels(using: model)
-        isLoading = false
     }
 
     @MainActor
@@ -207,8 +212,6 @@ private extension TokenMarketsDetailsViewModel {
         } else if state != .failedToLoadAllData {
             state = .failedToLoadDetails
         }
-
-        isLoading = false
     }
 }
 

--- a/Tangem/Modules/Markets/UIComponents/MarketsUnableToLoadDataView.swift
+++ b/Tangem/Modules/Markets/UIComponents/MarketsUnableToLoadDataView.swift
@@ -1,0 +1,48 @@
+//
+//  MarketsUnableToLoadDataView.swift
+//  Tangem
+//
+//  Created by Andrew Son on 01/08/24.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import SwiftUI
+
+struct MarketsUnableToLoadDataView: View {
+    let isButtonBusy: Bool
+    let retryButtonAction: () -> Void
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Text(Localization.marketsLoadingErrorTitle)
+                .style(Fonts.Bold.caption1.weight(.medium), color: Colors.Text.tertiary)
+
+            Button(action: retryButtonAction, label: {
+                HStack(spacing: .zero) {
+                    Text(Localization.tryToLoadDataAgainButtonTitle)
+                        .style(Fonts.Bold.caption1.weight(.medium), color: Colors.Text.primary1)
+                }
+                .hidden(isButtonBusy)
+                .overlay {
+                    if isButtonBusy {
+                        ProgressView()
+                            .progressViewStyle(CircularProgressViewStyle(tint: Colors.Icon.informative))
+                    }
+                }
+            })
+            .roundedBackground(with: Colors.Button.secondary, verticalPadding: 6, horizontalPadding: 12, radius: 10)
+            .disabled(isButtonBusy)
+        }
+    }
+}
+
+#Preview {
+    @State var isLoading = false
+
+    return MarketsUnableToLoadDataView(isButtonBusy: isLoading) {
+        isLoading = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            isLoading = false
+        }
+    }
+}

--- a/Tangem/UIComponents/DetentBottonSheet/SelfSizeableVariant/SelfSizingBottomSheetContainer.swift
+++ b/Tangem/UIComponents/DetentBottonSheet/SelfSizeableVariant/SelfSizingBottomSheetContainer.swift
@@ -37,7 +37,7 @@ struct SelfSizingDetentBottomSheetContainer<ContentView: View & SelfSizingBottom
             sheetContent
                 .frame(minWidth: mainWindowSize.width)
         }
-        .frame(alignment: .top) // TODO: Remove this frame when migrate increase min iOS to 16.
+        .frame(alignment: .top) // TODO: Remove this frame when migrate to minimum iOS 16.
         .ignoresSafeArea(edges: .bottom)
         .readGeometry(onChange: { geometry in
             containerHeight = geometry.size.height

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -530,6 +530,7 @@
 		B0AC1A312BA47D5D00FE6879 /* OnboardingSeedPassphraseInfoBottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0AC1A302BA47D5D00FE6879 /* OnboardingSeedPassphraseInfoBottomSheetView.swift */; };
 		B0ADFD3E298A70CD00EF2869 /* WalletConnectEthTransactionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0ADFD3D298A70CD00EF2869 /* WalletConnectEthTransactionBuilder.swift */; };
 		B0ADFD40298A70FF00EF2869 /* WalletConnectV2SignTransactionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0ADFD3F298A70FF00EF2869 /* WalletConnectV2SignTransactionHandler.swift */; };
+		B0AEC7D72C5B857100E60A93 /* MarketsUnableToLoadDataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0AEC7D62C5B857100E60A93 /* MarketsUnableToLoadDataView.swift */; };
 		B0AF2DEF2B1D8FF9001A8696 /* PendingExpressTransactionsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0AF2DEE2B1D8FF9001A8696 /* PendingExpressTransactionsManager.swift */; };
 		B0AF2DF12B1DAACD001A8696 /* PendingExpressTransactionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0AF2DF02B1DAACD001A8696 /* PendingExpressTransactionStatus.swift */; };
 		B0AF2DF42B1DF29F001A8696 /* PendingExpressTransactionsConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0AF2DF32B1DF29F001A8696 /* PendingExpressTransactionsConverter.swift */; };
@@ -2445,6 +2446,7 @@
 		B0AC1A302BA47D5D00FE6879 /* OnboardingSeedPassphraseInfoBottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSeedPassphraseInfoBottomSheetView.swift; sourceTree = "<group>"; };
 		B0ADFD3D298A70CD00EF2869 /* WalletConnectEthTransactionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletConnectEthTransactionBuilder.swift; sourceTree = "<group>"; };
 		B0ADFD3F298A70FF00EF2869 /* WalletConnectV2SignTransactionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletConnectV2SignTransactionHandler.swift; sourceTree = "<group>"; };
+		B0AEC7D62C5B857100E60A93 /* MarketsUnableToLoadDataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketsUnableToLoadDataView.swift; sourceTree = "<group>"; };
 		B0AF2DEE2B1D8FF9001A8696 /* PendingExpressTransactionsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingExpressTransactionsManager.swift; sourceTree = "<group>"; };
 		B0AF2DF02B1DAACD001A8696 /* PendingExpressTransactionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingExpressTransactionStatus.swift; sourceTree = "<group>"; };
 		B0AF2DF32B1DF29F001A8696 /* PendingExpressTransactionsConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingExpressTransactionsConverter.swift; sourceTree = "<group>"; };
@@ -3974,6 +3976,7 @@
 				2DB6487E2C35877000DA100D /* MarketsRaitingHeaderView.swift */,
 				2DB6487F2C35877000DA100D /* MarketsRaitingHeaderViewModel.swift */,
 				2DB648802C35877000DA100D /* MarketsSkeletonItemView.swift */,
+				B0AEC7D62C5B857100E60A93 /* MarketsUnableToLoadDataView.swift */,
 			);
 			path = UIComponents;
 			sourceTree = "<group>";
@@ -11198,6 +11201,7 @@
 				DAA5E30228D21369003C0E80 /* UserWalletStorageAgreementView.swift in Sources */,
 				EF7B9CF5286C7023004C33A9 /* CardSettingsCoordinator.swift in Sources */,
 				B0E20E122C2B01F600213580 /* PriceChangeUtility.swift in Sources */,
+				B0AEC7D72C5B857100E60A93 /* MarketsUnableToLoadDataView.swift in Sources */,
 				B0A4C4A02A270F5B0060E039 /* BalanceWithButtonsView.swift in Sources */,
 				DCBC94532993FEC80050BC35 /* Analytics+CardScanSource.swift in Sources */,
 				B6CF16822B22548A004925CC /* PropertyListObjectRepresentable.swift in Sources */,


### PR DESCRIPTION
* добавил стейты для деталки токена.
* компоненты с неудавшейся попыткой загрузить инфу вынес в отдельную вьюху, т.к. везде одинаковая логика
* есть проблема с синхронизацией стейта между вьюхой и графиком в случае, когда в начале вся инфа не загрузилась, а при повторном попытке деталка не грузится, а график загружается. В этом случае загрузчик на кнопке пропадает, до того как загрузится инфа по графику. Немного специфичный кейс, но чтобы его захендлить надо либо много костылей, либо переделывать компонент графика и объединять все управление стейтами во вью модели деталки токена. Пока что 3го варианта у меня не появилось.


В видео все долго грузится из-за проксимэна

https://github.com/user-attachments/assets/de24ca7c-085a-42f1-9f9d-e6759a0ae700

