### PR TITLE
IOS-7535 Use fee decimals

### DIFF
--- a/Tangem/App/Services/ExpressFeeProvider/CommonExpressFeeProvider.swift
+++ b/Tangem/App/Services/ExpressFeeProvider/CommonExpressFeeProvider.swift
@@ -27,7 +27,7 @@ extension CommonExpressFeeProvider: ExpressFeeProvider {
     }
 
     func estimatedFee(amount: Decimal) async throws -> ExpressFee {
-        let amount = makeAmount(amount: amount)
+        let amount = makeAmount(amount: amount, isFeeTokenItem: false)
         let fees = try await wallet.estimatedFee(amount: amount).async()
         return try mapToExpressFee(fees: fees)
     }
@@ -43,11 +43,11 @@ extension CommonExpressFeeProvider: ExpressFeeProvider {
         )
 
         let amount = parameters.calculateFee(decimalValue: wallet.feeTokenItem.decimalValue)
-        return Fee(makeAmount(amount: amount))
+        return Fee(makeAmount(amount: amount, isFeeTokenItem: false))
     }
 
-    func getFee(amount: Decimal, destination: String, hexData: Data?) async throws -> ExpressFee {
-        let amount = makeAmount(amount: amount)
+    func getFee(amount: Decimal, destination: String, hexData: Data?, isFeeTokenItem: Bool) async throws -> ExpressFee {
+        let amount = makeAmount(amount: amount, isFeeTokenItem: isFeeTokenItem)
 
         // If EVM network we should pass data in the fee calculation
         if let ethereumNetworkProvider = wallet.ethereumNetworkProvider, let hexData {
@@ -71,10 +71,10 @@ extension CommonExpressFeeProvider: ExpressFeeProvider {
 // MARK: - Private
 
 private extension CommonExpressFeeProvider {
-    func makeAmount(amount: Decimal) -> Amount {
+    func makeAmount(amount: Decimal, isFeeTokenItem: Bool) -> Amount {
         Amount(
             with: wallet.blockchainNetwork.blockchain,
-            type: wallet.amountType,
+            type: isFeeTokenItem ? wallet.feeTokenItem.amountType : wallet.amountType,
             value: amount
         )
     }

--- a/TangemExpress/Interfaces/FeeProvider.swift
+++ b/TangemExpress/Interfaces/FeeProvider.swift
@@ -11,7 +11,7 @@ import Foundation
 public protocol FeeProvider {
     func estimatedFee(amount: Decimal) async throws -> ExpressFee
     func estimatedFee(estimatedGasLimit: Int) async throws -> Fee
-    func getFee(amount: Decimal, destination: String, hexData: Data?) async throws -> ExpressFee
+    func getFee(amount: Decimal, destination: String, hexData: Data?, isFeeTokenItem: Bool) async throws -> ExpressFee
 }
 
 public enum ExpressFee {

--- a/TangemExpress/Manager/ExpressProviderManager/Implementations/DEXExpressProviderManager.swift
+++ b/TangemExpress/Manager/ExpressProviderManager/Implementations/DEXExpressProviderManager.swift
@@ -172,11 +172,11 @@ private extension DEXExpressProviderManager {
         var fee = try await feeProvider.getFee(
             amount: txValue,
             destination: data.destinationAddress,
-            hexData: data.txData.map { Data(hexString: $0) }
+            hexData: data.txData.map { Data(hexString: $0) },
+            isFeeTokenItem: true // decimals for txValue (other native fee) must be equal to main coin decimals
         )
 
         try Task.checkCancellation()
-
         if let otherNativeFee = data.otherNativeFee.map(request.pair.source.feeCurrencyConvertFromWEI) {
             fee = include(otherNativeFee: otherNativeFee, in: fee)
             log("The fee was increased by otherNativeFee \(otherNativeFee)")
@@ -199,7 +199,12 @@ private extension DEXExpressProviderManager {
 
         let contractAddress = request.pair.source.expressCurrency.contractAddress
         let data = try allowanceProvider.makeApproveData(spender: spender, amount: amount)
-        let fee = try await feeProvider.getFee(amount: 0, destination: request.pair.source.expressCurrency.contractAddress, hexData: data)
+        let fee = try await feeProvider.getFee(
+            amount: 0,
+            destination: request.pair.source.expressCurrency.contractAddress,
+            hexData: data,
+            isFeeTokenItem: false
+        )
         try Task.checkCancellation()
 
         // For approve use the fastest fee


### PR DESCRIPTION
Проблема была в том, что для other native fee использовался decimals от токена, а не от основной валюты. Интерфейс не очень красивый получается, но иначе надо кидать прям amount и правок будет слишком много