### PR TITLE
IOS-7526: Styling segmented picker text padding

### DIFF
--- a/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/Insights/MarketsTokenDetailsInsightsView.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/Insights/MarketsTokenDetailsInsightsView.swift
@@ -35,6 +35,7 @@ struct MarketsTokenDetailsInsightsView: View {
                     marketPriceIntervalType: $viewModel.selectedInterval,
                     options: viewModel.availableIntervals,
                     shouldStretchToFill: false,
+                    style: .init(textVerticalPadding: 2),
                     titleFactory: { $0.tokenDetailsNameLocalized }
                 )
             }

--- a/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/PricePerformance/MarketsTokenDetailsPricePerformanceView.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/PricePerformance/MarketsTokenDetailsPricePerformanceView.swift
@@ -24,6 +24,7 @@ struct MarketsTokenDetailsPricePerformanceView: View {
                     marketPriceIntervalType: $viewModel.selectedInterval,
                     options: viewModel.intervalOptions,
                     shouldStretchToFill: false,
+                    style: .init(textVerticalPadding: 2),
                     titleFactory: { $0.tokenDetailsNameLocalized }
                 )
             })

--- a/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/TokenMarketsDetailsView+Skeletons.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/TokenMarketsDetailsView+Skeletons.swift
@@ -34,8 +34,9 @@ extension TokenMarketsDetailsView {
 
                     MarketsPickerView(
                         marketPriceIntervalType: .constant(.day),
-                        options: [.day, .month, .year],
+                        options: [.day, .week, .month],
                         shouldStretchToFill: false,
+                        style: .init(textVerticalPadding: 2),
                         titleFactory: { $0.tokenDetailsNameLocalized }
                     )
                 }
@@ -96,8 +97,9 @@ extension TokenMarketsDetailsView {
 
                     MarketsPickerView(
                         marketPriceIntervalType: .constant(.day),
-                        options: [.day, .month, .year],
+                        options: [.day, .week, .month],
                         shouldStretchToFill: false,
+                        style: .init(textVerticalPadding: 2),
                         titleFactory: { $0.tokenDetailsNameLocalized }
                     )
                 }

--- a/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsView.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsView.swift
@@ -93,6 +93,7 @@ struct TokenMarketsDetailsView: View {
             marketPriceIntervalType: $viewModel.selectedPriceChangeIntervalType,
             options: viewModel.priceChangeIntervalOptions,
             shouldStretchToFill: true,
+            style: .init(textVerticalPadding: 4),
             titleFactory: { $0.tokenDetailsNameLocalized }
         )
     }

--- a/Tangem/Modules/Markets/UIComponents/MarketsPickerView.swift
+++ b/Tangem/Modules/Markets/UIComponents/MarketsPickerView.swift
@@ -13,6 +13,7 @@ struct MarketsPickerView: View {
 
     let options: [MarketsPriceIntervalType]
     let shouldStretchToFill: Bool
+    let style: SegmentedPicker<MarketsPriceIntervalType>.Style
     let titleFactory: (MarketsPriceIntervalType) -> String
 
     var body: some View {
@@ -20,6 +21,7 @@ struct MarketsPickerView: View {
             selectedOption: $marketPriceIntervalType,
             options: options,
             shouldStretchToFill: shouldStretchToFill,
+            style: style,
             titleFactory: titleFactory
         )
     }
@@ -37,6 +39,7 @@ struct MarketsPickerView: View {
                     marketPriceIntervalType: $firstInterval,
                     options: [.day, .week, .month],
                     shouldStretchToFill: false,
+                    style: .init(textVerticalPadding: 2),
                     titleFactory: { $0.marketsListId }
                 )
 
@@ -44,6 +47,7 @@ struct MarketsPickerView: View {
                     marketPriceIntervalType: $secondInterval,
                     options: MarketsPriceIntervalType.allCases,
                     shouldStretchToFill: false,
+                    style: .init(textVerticalPadding: 2),
                     titleFactory: { $0.rawValue }
                 )
 
@@ -51,6 +55,7 @@ struct MarketsPickerView: View {
                     marketPriceIntervalType: $secondInterval,
                     options: MarketsPriceIntervalType.allCases,
                     shouldStretchToFill: true,
+                    style: .init(textVerticalPadding: 2),
                     titleFactory: { $0.rawValue }
                 )
                 .padding(.horizontal, 16)

--- a/Tangem/Modules/Markets/UIComponents/MarketsRaitingHeaderView.swift
+++ b/Tangem/Modules/Markets/UIComponents/MarketsRaitingHeaderView.swift
@@ -48,6 +48,7 @@ struct MarketsRatingHeaderView: View {
                 marketPriceIntervalType: $viewModel.marketPriceIntervalType,
                 options: viewModel.marketPriceIntervalTypeOptions,
                 shouldStretchToFill: false,
+                style: .init(textVerticalPadding: 4),
                 titleFactory: { $0.tokenDetailsNameLocalized }
             )
         }

--- a/Tangem/UIComponents/BalanceWithButtonsView/BalanceWithButtonsView.swift
+++ b/Tangem/UIComponents/BalanceWithButtonsView/BalanceWithButtonsView.swift
@@ -44,7 +44,8 @@ struct BalanceWithButtonsView: View {
             SegmentedPicker(
                 selectedOption: $viewModel.selectedBalanceType,
                 options: balanceTypeValues,
-                shouldStretchToFill: false
+                shouldStretchToFill: false,
+                style: .init(textVerticalPadding: 2)
             ) { $0.title }
         } else {
             EmptyView()

--- a/Tangem/UIComponents/SegmentPickerView/SegmentedPicker.swift
+++ b/Tangem/UIComponents/SegmentPickerView/SegmentedPicker.swift
@@ -13,6 +13,7 @@ struct SegmentedPicker<Option: Hashable & Identifiable>: View {
 
     let options: [Option]
     let shouldStretchToFill: Bool
+    let style: Style
     let titleFactory: (Option) -> String
 
     var body: some View {
@@ -47,13 +48,20 @@ struct SegmentedPicker<Option: Hashable & Identifiable>: View {
         }
         .animation(.default, value: isSelected)
         .lineLimit(1)
-        .padding(.vertical, 2)
-        .padding(.horizontal, 12)
+        .padding(.vertical, style.textVerticalPadding)
+        .padding(.horizontal, style.textHorizontalPadding)
     }
 
     private var selectionView: some View {
         Colors.Background.primary
             .clipShape(RoundedRectangle(cornerRadius: Constants.selectionViewCornerRadius))
+    }
+}
+
+extension SegmentedPicker {
+    struct Style {
+        let textVerticalPadding: CGFloat
+        var textHorizontalPadding: CGFloat = 12.0
     }
 }
 

--- a/Tangem/UIComponents/SegmentPickerView/SegmentedPickerView.swift
+++ b/Tangem/UIComponents/SegmentPickerView/SegmentedPickerView.swift
@@ -139,7 +139,6 @@ private extension SegmentedPickerView {
         var body: some View {
             Button(action: action) {
                 content
-                    .padding(.vertical, 2.0)
                     .frame(maxWidth: shouldStretchToFill ? .infinity : targetWidth)
                     .background {
                         if isSelected {


### PR DESCRIPTION
Теперь отступы для текстов пикера можно задавать извне. Была зашита глубоко внутри пикера

<img width="300" src="https://github.com/user-attachments/assets/b6287ab9-dd7f-4180-8b48-20f89ddf37ba">
<img width="300" src="https://github.com/user-attachments/assets/b3328820-9727-4462-8a56-e465b4b7fb92">
