### PR TITLE
IOS-7479: Migrate to inline navigation bar LegacyManageTokens

### DIFF
--- a/Tangem/Modules/LegacyTokenList/LegacyTokenListView.swift
+++ b/Tangem/Modules/LegacyTokenList/LegacyTokenListView.swift
@@ -20,7 +20,7 @@ struct LegacyTokenListView: View {
             overlay
         }
         .scrollDismissesKeyboardCompat(.immediately)
-        .navigationBarTitle(Text(Localization.addTokensTitle), displayMode: .automatic)
+        .navigationBarTitle(Text(Localization.addTokensTitle), displayMode: .inline)
         .navigationBarItems(trailing: addCustomView)
         .alert(item: $viewModel.alert, content: { $0.alert })
         .searchable(text: $viewModel.enteredSearchText.value, placement: .navigationBarDrawer(displayMode: .always))

--- a/Tangem/Modules/Welcome/SearchTokens/WelcomeSearchTokensView.swift
+++ b/Tangem/Modules/Welcome/SearchTokens/WelcomeSearchTokensView.swift
@@ -22,7 +22,7 @@ struct WelcomeSearchTokensView: View {
         ManageTokensListView(viewModel: viewModel.manageTokensListViewModel, isReadOnly: true)
             .scrollDismissesKeyboardCompat(.immediately)
             .navigationTitle(Text(Localization.commonSearchTokens))
-            .navigationBarTitleDisplayMode(.automatic)
+            .navigationBarTitleDisplayMode(.inline)
             .searchable(text: $viewModel.enteredSearchText.value, placement: .navigationBarDrawer(displayMode: .always))
             .keyboardType(.alphabet)
             .autocorrectionDisabled()


### PR DESCRIPTION
Автоматический навбар иногда неправильно определял полностью раскрытое состояние и свернутое, поэтому решили перейти на инлайн онли. Вдобавок в дизайне нет к этому требований, привел к единому виду как и в онбординге, и новом `ManageTokens`.