### PR TITLE
IOS-7568: Load 40 items per page instead of 150

### DIFF
--- a/Tangem/Modules/Markets/Providers/MarketsListDataProvider.swift
+++ b/Tangem/Modules/Markets/Providers/MarketsListDataProvider.swift
@@ -53,7 +53,7 @@ final class MarketsListDataProvider {
     private var currentOffset: Int = 0
 
     // Limit of records per page
-    private let limitPerPage: Int = 150
+    private let limitPerPage: Int = 40
 
     // Total tokens value by pages
     private var totalTokensCount: Int?


### PR DESCRIPTION
АЛ попросил изменить на загрузку 40 элементов, а не 150. Окончательное решение ещё будем принимать по результатам тестирования