### PR TITLE
IOS-7556 Fix text filed amount animation on the `Send`

### DIFF
--- a/Tangem/Common/UI/SendDecimalNumberTextField/SendDecimalNumberTextField.swift
+++ b/Tangem/Common/UI/SendDecimalNumberTextField/SendDecimalNumberTextField.swift
@@ -20,8 +20,6 @@ struct SendDecimalNumberTextField: View {
 
     // Internal state
     @FocusState private var isInputActive: Bool
-    @State private var textFieldText: String = ""
-    @State private var measuredTextSize: CGSize = .zero
 
     // Setupable
     private var initialFocusBehavior: InitialFocusBehavior = .noFocus
@@ -39,7 +37,7 @@ struct SendDecimalNumberTextField: View {
             text += makePrefixSuffixText(prefix, hasSpaceBeforeText: false, hasSpaceAfterText: hasSpace)
         }
 
-        text += (textFieldText.nilIfEmpty ?? Constants.placeholder)
+        text += (viewModel.textFieldText.nilIfEmpty ?? Constants.placeholder)
 
         if case .suffix(.some(let suffix), let hasSpace) = prefixSuffixOptions {
             text += makePrefixSuffixText(suffix, hasSpaceBeforeText: hasSpace, hasSpaceAfterText: false)
@@ -91,7 +89,7 @@ struct SendDecimalNumberTextField: View {
             .infinityFrame() // Provides centered alignment within `GeometryReader`
             .overlay(textSizeMeasurer)
         }
-        .frame(height: measuredTextSize.height)
+        .frame(height: viewModel.measuredTextSize.height)
     }
 
     /// A dummy invisible view that is used to calculate the ideal (unlimited) width for a single-line input string.
@@ -111,12 +109,12 @@ struct SendDecimalNumberTextField: View {
             .fixedSize()
             .hidden(true) // Native `.hidden()` may affect layout
             .allowsHitTesting(false)
-            .readGeometry(\.size, bindTo: $measuredTextSize)
+            .readGeometry(\.size, bindTo: $viewModel.measuredTextSize)
     }
 
     @ViewBuilder
     private var textField: some View {
-        DecimalNumberTextField(viewModel: viewModel, textFieldText: $textFieldText)
+        DecimalNumberTextField(viewModel: viewModel)
             .appearance(appearance)
             .placeholder(Constants.placeholder)
             .focused($isInputActive)
@@ -192,7 +190,7 @@ struct SendDecimalNumberTextField: View {
 
     private func scaleAndWidth(using proxy: GeometryProxy) -> (scale: CGFloat, width: CGFloat) {
         let maxWidth = proxy.size.width
-        let measuredWidth = measuredTextSize.width
+        let measuredWidth = viewModel.measuredTextSize.width
 
         guard
             let minTextScale,

--- a/Tangem/Modules/Send/Amount/SendAmountView.swift
+++ b/Tangem/Modules/Send/Amount/SendAmountView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct SendAmountView: View {
     @ObservedObject var viewModel: SendAmountViewModel
+
     let transitionService: SendTransitionService
     let namespace: Namespace
 
@@ -66,17 +67,12 @@ struct SendAmountView: View {
                 .matchedGeometryEffect(id: namespace.names.tokenIcon, in: namespace.id)
 
             VStack(spacing: 6) {
-                ZStack {
-                    SendDecimalNumberTextField(viewModel: viewModel.decimalNumberTextFieldViewModel)
-                        .initialFocusBehavior(.noFocus)
-                        .alignment(.center)
-                        .prefixSuffixOptions(viewModel.currentFieldOptions)
-                        .minTextScale(SendView.Constants.amountMinTextScale)
-                }
-                // We have to keep frame until SendDecimalNumberTextField size fix
-                // Just on appear it has the zero height. Is cause break animation
-                .frame(height: 35)
-                .matchedGeometryEffect(id: namespace.names.amountCryptoText, in: namespace.id)
+                SendDecimalNumberTextField(viewModel: viewModel.decimalNumberTextFieldViewModel)
+                    .initialFocusBehavior(.noFocus)
+                    .alignment(.center)
+                    .prefixSuffixOptions(viewModel.currentFieldOptions)
+                    .minTextScale(SendView.Constants.amountMinTextScale)
+                    .matchedGeometryEffect(id: namespace.names.amountCryptoText, in: namespace.id)
 
                 // Keep empty text so that the view maintains its place in the layout
                 Text(viewModel.alternativeAmount ?? " ")

--- a/Tangem/Modules/Send/Amount/SendAmountViewModel.swift
+++ b/Tangem/Modules/Send/Amount/SendAmountViewModel.swift
@@ -19,6 +19,7 @@ class SendAmountViewModel: ObservableObject {
     let currencyPickerData: SendCurrencyPickerData
 
     @Published var id: UUID = .init()
+    @Published var text: String = ""
 
     @Published var auxiliaryViewsVisible: Bool = true
     @Published var isEditMode: Bool = false


### PR DESCRIPTION
Была проблема из за `onAppear` где текст должен быть проставлен, как в `@State` он слетает при закрытии View, почему я хз.
Сейчас все `@State` перенес в `@Published` и удалил костыль из `onAppear`

P.S. еще осталось с клавитурой решить, как так пока убрал автооткрытие, так как это ломало анимации

https://github.com/user-attachments/assets/3b4b0ca2-cc8c-4d06-b724-e51a1ae6d0bd