### PR TITLE
IOS-7518: Send summary view - broken text scale (to 5.13)

### DIFF
--- a/Tangem/Common/UI/SendCurrencyView/SendCurrencyView.swift
+++ b/Tangem/Common/UI/SendCurrencyView/SendCurrencyView.swift
@@ -24,7 +24,7 @@ struct SendCurrencyView: View {
             SendDecimalNumberTextField(viewModel: viewModel.decimalNumberTextFieldViewModel)
                 .toolbarType(maxAmountAction.map { .maxAmount(action: $0) })
                 .initialFocusBehavior(.immediateFocus)
-                .minTextScale(Constants.amountMinTextScale)
+                .minTextScale(SendView.Constants.amountMinTextScale)
                 .offset(x: isShaking ? 10 : 0)
                 .simultaneousGesture(TapGesture().onEnded {
                     viewModel.textFieldDidTapped()
@@ -53,14 +53,6 @@ extension SendCurrencyView: Setupable {
 
     func didTapChangeCurrency(_ block: @escaping () -> Void) -> Self {
         map { $0.didTapChangeCurrency = block }
-    }
-}
-
-// MARK: - Constants
-
-private extension SendCurrencyView {
-    enum Constants {
-        static let amountMinTextScale = 0.5
     }
 }
 

--- a/Tangem/Common/UI/SendDecimalNumberTextField/SendDecimalNumberTextField.swift
+++ b/Tangem/Common/UI/SendDecimalNumberTextField/SendDecimalNumberTextField.swift
@@ -198,7 +198,19 @@ struct SendDecimalNumberTextField: View {
             let minTextScale,
             measuredWidth > maxWidth
         else {
-            return (1.0, maxWidth)
+            // Apparently, SwiftUI structural identity changes when the scale of the view changes from 1.0 (no scaling)
+            // to any other value and vice versa, from any other value back to back to 1.0 (no scaling).
+            // This change of SwiftUI structural identity causes a reset of some of the view's internal state
+            // (including `@Focused` properties), which in turn causes the active first responder to resign, i.e. hide the keyboard.
+            //
+            // The workaround here prevents this by placing the view into a `scaled` state, even if text scaling
+            // is not actually needed at the moment. This scaled state should not affect view dimensions at all, because
+            // it mimics the absence of scaling (by increasing the scale by 1% and decreasing the width by the same value, 1%)
+            let onePercent = 0.01
+            let defaultScaleMultiplier = 1.0 + onePercent
+            let defaultWidthMultiplier = 1.0 - onePercent
+
+            return (1.0 * defaultScaleMultiplier, maxWidth * defaultWidthMultiplier)
         }
 
         // It turns out that in some cases, HStack inserts some space (1pt) between neighboring child views,

--- a/Tangem/Common/UI/SendDecimalNumberTextField/SendDecimalNumberTextField.swift
+++ b/Tangem/Common/UI/SendDecimalNumberTextField/SendDecimalNumberTextField.swift
@@ -207,8 +207,9 @@ struct SendDecimalNumberTextField: View {
             // is not actually needed at the moment. This scaled state should not affect view dimensions at all, because
             // it mimics the absence of scaling (by increasing the scale by 1% and decreasing the width by the same value, 1%)
             let onePercent = 0.01
-            let defaultScaleMultiplier = 1.0 + onePercent
-            let defaultWidthMultiplier = 1.0 - onePercent
+            let multiplierBase = 1.0
+            let defaultScaleMultiplier = multiplierBase + onePercent
+            let defaultWidthMultiplier = multiplierBase - onePercent
 
             return (1.0 * defaultScaleMultiplier, maxWidth * defaultWidthMultiplier)
         }

--- a/Tangem/Modules/Send/Base/SendView.swift
+++ b/Tangem/Modules/Send/Base/SendView.swift
@@ -211,7 +211,7 @@ extension SendView {
         static let amountMinTextScale = 0.5
         static let animationDuration: TimeInterval = 0.3
         static let defaultAnimation: Animation = .spring(duration: animationDuration)
-        static let backButtonAnimation: Animation = .easeOut(duration: 0.1)
+        fileprivate static let backButtonAnimation: Animation = .easeOut(duration: 0.1)
     }
 }
 

--- a/Tangem/Modules/Send/Base/SendView.swift
+++ b/Tangem/Modules/Send/Base/SendView.swift
@@ -116,6 +116,7 @@ struct SendView: View {
                 viewModel: sendSummaryViewModel,
                 namespace: .init(id: namespace, names: SendGeometryEffectNames())
             )
+            .amountMinTextScale(Constants.amountMinTextScale)
         case .finish(let sendFinishViewModel):
             SendFinishView(
                 viewModel: sendFinishViewModel,


### PR DESCRIPTION
[IOS-7518](https://tangem.atlassian.net/browse/IOS-7518)

- Потерялось вот тут, в ходе рефака сенда 2e0f0fde6a5998452483a78798089f65d0a0b37b
- Ветка сразу в 5.13, потому что в девелопе рефак уже завершен и весь UI поменялся, будет отдельный пулл
- Заодно пофиксил проблему, когда при переключении из non-scaled в scaled и обратно SwiftUI сбрасывал какой-то внутренний стейт вьюхи и из-за этого убиралась клава

[IOS-7518]: https://tangem.atlassian.net/browse/IOS-7518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ