### PR TITLE
IOS-7572:Add action buttons state update subscription

### DIFF
--- a/Tangem/Modules/SingleTokenBase/SingleTokenBaseViewModel.swift
+++ b/Tangem/Modules/SingleTokenBase/SingleTokenBaseViewModel.swift
@@ -292,6 +292,14 @@ extension SingleTokenBaseViewModel {
             .debounce(for: 0.1, scheduler: DispatchQueue.main)
             .assign(to: \.tokenNotificationInputs, on: self, ownership: .weak)
             .store(in: &bag)
+
+        walletModel.actionsUpdatePublisher
+            .receive(on: DispatchQueue.main)
+            .withWeakCaptureOf(self)
+            .sink { viewModel, _ in
+                viewModel.updateActionButtons()
+            }
+            .store(in: &bag)
     }
 
     private func updatePendingTransactionView() {


### PR DESCRIPTION
не было подписки на обновление стейта кнопок, после того как пришел результат запроса на доступность свопа, в итоге если пользователь открыл деталку токена - кнопка была неактивной, а при нажатии на неё проходила проверка и уже оказывалось что свопать можно.

на сколько помню - было обсуждение, что странно что кнопки будут скакать, когда у пользователя открыта деталка, но чет найти тред не могу. В общем-то решалось переоткрытием этого экрана, но мог быть случай, когда неверный стейт.