### PR TITLE
IOS-7550: [Markets] Filter items below 100k market cap in search

### DIFF
--- a/Tangem/App/Models/Markets/MarketsDTO.swift
+++ b/Tangem/App/Models/Markets/MarketsDTO.swift
@@ -22,7 +22,6 @@ extension MarketsDTO.General {
         let limit: Int
         let interval: MarketsPriceIntervalType
         let order: MarketsListOrderType
-        let generalCoins: Bool
         let search: String?
 
         init(
@@ -31,7 +30,6 @@ extension MarketsDTO.General {
             limit: Int = 20,
             interval: MarketsPriceIntervalType,
             order: MarketsListOrderType,
-            generalCoins: Bool = false,
             search: String?
         ) {
             self.currency = currency
@@ -39,7 +37,6 @@ extension MarketsDTO.General {
             self.limit = limit
             self.interval = interval
             self.order = order
-            self.generalCoins = generalCoins
             self.search = search
         }
 
@@ -53,10 +50,6 @@ extension MarketsDTO.General {
                 "interval": interval.marketsListId,
                 "order": order.rawValue,
             ]
-
-            if generalCoins {
-                params["general_coins"] = generalCoins
-            }
 
             if let search, !search.isEmpty {
                 params["search"] = search

--- a/Tangem/Modules/Markets/TokenList/MarketsView.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsView.swift
@@ -51,7 +51,7 @@ struct MarketsView: View {
 
     @ViewBuilder
     private var list: some View {
-        ScrollView {
+        ScrollView(showsIndicators: false) {
             ScrollViewReader { proxy in
                 Color.clear.frame(height: 0)
                     .id(scrollTopAnchorID)
@@ -61,13 +61,13 @@ struct MarketsView: View {
                         MarketsItemView(viewModel: $0)
                     }
 
-                    if viewModel.isShowUnderCapButton {
-                        showTokensUnderCapView
-                    }
-
                     // Need for display list skeleton view
                     if case .loading = viewModel.tokenListLoadingState {
                         loadingSkeletons
+                    }
+
+                    if viewModel.shouldDisplayShowTokensUnderCapView {
+                        showTokensUnderCapView
                     }
                 }
                 .onReceive(viewModel.resetScrollPositionPublisher) { _ in

--- a/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
@@ -17,7 +17,6 @@ final class MarketsViewModel: ObservableObject {
     @Published var alert: AlertBinder?
     @Published var tokenViewModels: [MarketsItemViewModel] = []
     @Published var marketsRatingHeaderViewModel: MarketsRatingHeaderViewModel
-    @Published var isShowUnderCapButton: Bool = false
     @Published var tokenListLoadingState: MarketsView.ListLoadingState = .idle
 
     // MARK: - Properties
@@ -30,19 +29,30 @@ final class MarketsViewModel: ObservableObject {
         !currentSearchValue.isEmpty
     }
 
+    var shouldDisplayShowTokensUnderCapView: Bool {
+        let hasFilteredItems = tokenViewModels.count != dataProvider.items.count
+        let dataLoaded = !dataProvider.isLoading
+
+        return filterItemsBelowMarketCapThreshold && hasFilteredItems && dataLoaded
+    }
+
     private weak var coordinator: MarketsRoutable?
 
     private let filterProvider = MarketsListDataFilterProvider()
     private let dataProvider = MarketsListDataProvider()
     private let chartsHistoryProvider = MarketsListChartsHistoryProvider()
     private let quotesUpdater = MarketsQuotesUpdater()
+    private let imageCache = KingfisherManager.shared.cache
 
     private lazy var listDataController: MarketsListDataController = .init(dataProvider: dataProvider, viewVisibilityPublisher: $isViewVisible, cellsStateUpdater: self)
 
     private var bag = Set<AnyCancellable>()
     private var currentSearchValue: String = ""
+    private var showItemsBelowCapThreshold: Bool = false
 
-    private let imageCache = KingfisherManager.shared.cache
+    private var filterItemsBelowMarketCapThreshold: Bool {
+        isSearching && !showItemsBelowCapThreshold
+    }
 
     // MARK: - Init
 
@@ -82,6 +92,7 @@ final class MarketsViewModel: ObservableObject {
         fetch(with: "", by: filterProvider.currentFilterValue)
         currentSearchValue = ""
         isViewVisible = false
+        showItemsBelowCapThreshold = false
         chartsHistoryProvider.reset()
         onDisappearPrepareImageCache()
     }
@@ -91,9 +102,14 @@ final class MarketsViewModel: ObservableObject {
     }
 
     func onShowUnderCapAction() {
-        isShowUnderCapButton = false
-        dataProvider.isGeneralCoins = true
-        dataProvider.fetchMore()
+        showItemsBelowCapThreshold = true
+
+        if tokenViewModels.count == dataProvider.items.count, dataProvider.canFetchMore {
+            dataProvider.fetchMore()
+            return
+        }
+
+        tokenViewModels = mapToItemViewModel(dataProvider.items)
     }
 
     func onTryLoadList() {
@@ -178,14 +194,9 @@ private extension MarketsViewModel {
             .sink(receiveValue: { viewModel, items in
                 viewModel.chartsHistoryProvider.fetch(for: items.map { $0.id }, with: viewModel.filterProvider.currentFilterValue.interval)
 
+                // TODO: IOS-7583
                 // Refactor this. Each time data provider receive next page - whole item models list recreated.
-                let tokenViewModels = items.enumerated().compactMap { index, item in
-                    let tokenViewModel = viewModel.mapToTokenViewModel(tokenItemModel: item, with: index)
-                    return tokenViewModel
-                }
-                viewModel.tokenViewModels = tokenViewModels
-
-                viewModel.showUnderCapButtonIfNeeded()
+                viewModel.tokenViewModels = viewModel.mapToItemViewModel(items)
             })
             .store(in: &bag)
 
@@ -242,7 +253,26 @@ private extension MarketsViewModel {
 
     // MARK: - Private Implementation
 
-    private func mapToTokenViewModel(tokenItemModel: MarketsTokenModel, with index: Int) -> MarketsItemViewModel {
+    private func mapToItemViewModel(_ list: [MarketsTokenModel]) -> [MarketsItemViewModel] {
+        let listToProcess = filterItemsBelowMarketCapIfNeeded(list)
+        return listToProcess.enumerated().map { mapToTokenViewModel(index: $0, tokenItemModel: $1) }
+    }
+
+    private func filterItemsBelowMarketCapIfNeeded(_ list: [MarketsTokenModel]) -> [MarketsTokenModel] {
+        guard filterItemsBelowMarketCapThreshold else {
+            return list
+        }
+
+        return list.filter {
+            guard let marketCap = $0.marketCap else {
+                return false
+            }
+
+            return marketCap >= Constants.marketCapThreshold
+        }
+    }
+
+    private func mapToTokenViewModel(index: Int, tokenItemModel: MarketsTokenModel) -> MarketsItemViewModel {
         let inputData = MarketsItemViewModel.InputData(
             index: index,
             id: tokenItemModel.id,
@@ -274,18 +304,8 @@ private extension MarketsViewModel {
         imageCache.memoryStorage.config.countLimit = .max
     }
 
-    private func showUnderCapButtonIfNeeded() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-            guard let self else { return }
-
-            isShowUnderCapButton = isSearching &&
-                !dataProvider.isGeneralCoins &&
-                !dataProvider.items.isEmpty
-        }
-    }
-
     private func resetUI() {
-        isShowUnderCapButton = false
+        showItemsBelowCapThreshold = false
     }
 }
 
@@ -322,5 +342,11 @@ extension MarketsViewModel: MarketsListStateUpdater {
         }
 
         quotesUpdater.scheduleQuotesUpdate(for: idsToUpdate)
+    }
+}
+
+private extension MarketsViewModel {
+    enum Constants {
+        static let marketCapThreshold: Decimal = 100_000.0
     }
 }


### PR DESCRIPTION
* Не работала кнопка показа элементов ниже 100к маркет капа, потому что значения не фильтровались
* Из запроса удалили `general_coins`, поэтому почистил
* не было логики отмены предыдущего запроса, могло происходить если медленно отрабатывает бэк на первом введенном поиске, а на последующий запрос быстро отвечает, мешанина получалась.

https://github.com/user-attachments/assets/902f99a9-c494-41b6-b97f-450fe86d6379

