### PR TITLE
[Markets] IOS-7540 make fix skeleton token details

### DIFF
--- a/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/TokenMarketsDetailsView+Skeletons.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/TokenMarketsDetailsView+Skeletons.swift
@@ -25,21 +25,9 @@ extension TokenMarketsDetailsView {
         }
 
         private var insights: some View {
-            VStack(spacing: 0) {
-                HStack {
-                    Text(Localization.marketsTokenDetailsInsights)
-                        .style(Fonts.Bold.footnote, color: Colors.Text.tertiary)
-
-                    Spacer()
-
-                    MarketsPickerView(
-                        marketPriceIntervalType: .constant(.day),
-                        options: [.day, .week, .month],
-                        shouldStretchToFill: false,
-                        style: .init(textVerticalPadding: 2),
-                        titleFactory: { $0.tokenDetailsNameLocalized }
-                    )
-                }
+            VStack(spacing: .zero) {
+                skeletonView(width: .infinity, height: 18)
+                    .padding(.bottom, Constants.bottomPaddingTitleConstant)
 
                 ForEach(0 ... 1) { _ in
                     fillableBlocks
@@ -51,13 +39,7 @@ extension TokenMarketsDetailsView {
         private var securityScore: some View {
             HStack(spacing: 0) {
                 VStack(alignment: .leading, spacing: 2) {
-                    HStack(alignment: .center, spacing: 4) {
-                        Text(Localization.marketsTokenDetailsSecurityScore)
-                            .style(Fonts.Bold.footnote, color: Colors.Text.tertiary)
-
-                        Assets.infoCircle16.image
-                            .foregroundStyle(Colors.Icon.informative)
-                    }
+                    skeletonView(width: 106, height: 16)
 
                     skeletonView(width: 106, height: 16)
                 }
@@ -70,15 +52,9 @@ extension TokenMarketsDetailsView {
         }
 
         private var metrics: some View {
-            VStack(spacing: 0) {
-                HStack {
-                    Text(Localization.marketsTokenDetailsMetrics)
-                        .style(Fonts.Bold.footnote, color: Colors.Text.tertiary)
-
-                    Spacer(minLength: 10)
-
-                    skeletonView(width: 70, height: 18)
-                }
+            VStack(spacing: .zero) {
+                skeletonView(width: .infinity, height: 18)
+                    .padding(.bottom, Constants.bottomPaddingTitleConstant)
 
                 ForEach(0 ... 2) { _ in
                     fillableBlocks
@@ -89,20 +65,8 @@ extension TokenMarketsDetailsView {
 
         private var pricePerformance: some View {
             VStack(spacing: 12) {
-                HStack {
-                    Text(Localization.marketsTokenDetailsPricePerformance)
-                        .style(Fonts.Bold.footnote, color: Colors.Text.tertiary)
-
-                    Spacer()
-
-                    MarketsPickerView(
-                        marketPriceIntervalType: .constant(.day),
-                        options: [.day, .week, .month],
-                        shouldStretchToFill: false,
-                        style: .init(textVerticalPadding: 2),
-                        titleFactory: { $0.tokenDetailsNameLocalized }
-                    )
-                }
+                skeletonView(width: .infinity, height: 18)
+                    .padding(.bottom, Constants.bottomPaddingTitleConstant)
 
                 HStack {
                     skeletonView(width: 28, height: 18)
@@ -127,10 +91,9 @@ extension TokenMarketsDetailsView {
 
         private var links: some View {
             VStack(alignment: .leading, spacing: 12) {
-                Text(Localization.marketsTokenDetailsLinks)
-                    .style(Fonts.Bold.footnote, color: Colors.Text.tertiary)
-                    .padding(.bottom, 10)
-                    .padding(.horizontal, 16)
+                skeletonView(width: .infinity, height: 18)
+                    .padding(.horizontal, 14)
+                    .padding(.bottom, Constants.bottomPaddingTitleConstant)
 
                 ForEach(0 ... 2) { index in
                     VStack(alignment: .leading, spacing: 12) {
@@ -166,7 +129,7 @@ extension TokenMarketsDetailsView {
                     }
                 }
             }
-            .padding(.vertical, 10)
+            .padding(.top, 10)
         }
 
         private func skeletonView(width: CGFloat, height: CGFloat) -> some View {
@@ -174,6 +137,12 @@ extension TokenMarketsDetailsView {
                 .cornerRadiusContinuous(3)
                 .frame(maxWidth: width, minHeight: height, maxHeight: height)
         }
+    }
+}
+
+extension TokenMarketsDetailsView.ContentBlockSkeletons {
+    enum Constants {
+        static let bottomPaddingTitleConstant: CGFloat = 8
     }
 }
 

--- a/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/TokenMarketsDetailsView+Skeletons.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/TokenMarketsDetailsView+Skeletons.swift
@@ -12,6 +12,8 @@ extension TokenMarketsDetailsView {
     struct ContentBlockSkeletons: View {
         var body: some View {
             VStack(spacing: 14) {
+                description
+
                 insights
 
                 securityScore
@@ -21,6 +23,16 @@ extension TokenMarketsDetailsView {
                 pricePerformance
 
                 links
+            }
+        }
+
+        private var description: some View {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(0 ... 1) { _ in
+                    skeletonView(width: .infinity, height: 18)
+                }
+
+                skeletonView(width: 270, height: 18)
             }
         }
 


### PR DESCRIPTION
Поправил скелетны в соотвествии с дизайном. Скелетон в MyPortfolio сделан в соотвествующим МР как часть доработки загрузки портфолио

https://github.com/tangem/tangem-app-ios/pull/3664


https://github.com/user-attachments/assets/9c7d62cb-fc72-4c20-a099-552fa573206b


<img width="185" alt="Снимок экрана 2024-08-15 в 14 46 49" src="https://github.com/user-attachments/assets/f5386dd7-7df3-4a6e-ab70-35966b85c57e">
