### PR TITLE
IOS-7528: [Markets] Update failed to load page behaviour

### DIFF
--- a/Tangem/Common/Extensions/SwiftConcurrency+.swift
+++ b/Tangem/Common/Extensions/SwiftConcurrency+.swift
@@ -68,7 +68,7 @@ func runOnMain<T>(_ code: () throws -> T) rethrows -> T {
 
 extension Task where Success == Never, Failure == Never {
     static func sleep(seconds: Double) async throws {
-        let duration = UInt64(seconds * nanoMultiplier)
+        let duration = UInt64(abs(seconds) * nanoMultiplier)
         try await Task.sleep(nanoseconds: duration)
     }
 }
@@ -126,7 +126,6 @@ enum TaskError: Error {
 
 extension Task where Success == Never, Failure == Never {
     static var defaultCancellationCheckInterval: TimeInterval { 0.1 }
-    static var nanoMultiplier: Double { 1_000_000_000 }
 
     /// Like `Task.sleep` but with cancellation support.
     ///
@@ -153,6 +152,8 @@ extension Task where Success == Never, Failure == Never {
 }
 
 extension Task {
+    static var nanoMultiplier: Double { 1_000_000_000 }
+
     func eraseToAnyCancellable() -> AnyCancellable {
         return AnyCancellable(cancel)
     }
@@ -165,7 +166,7 @@ extension Task where Failure == Error {
         operation: @escaping @Sendable () async throws -> Success
     ) -> Task {
         Task(priority: priority) {
-            let nanosecondsDelay = UInt64(delaySeconds * 1_000_000_000)
+            let nanosecondsDelay = UInt64(abs(delaySeconds) *  nanoMultiplier)
             try await Task<Never, Never>.sleep(nanoseconds: nanosecondsDelay)
             try Task<Never, Never>.checkCancellation()
             return try await operation()

--- a/Tangem/Common/Extensions/SwiftConcurrency+.swift
+++ b/Tangem/Common/Extensions/SwiftConcurrency+.swift
@@ -68,7 +68,7 @@ func runOnMain<T>(_ code: () throws -> T) rethrows -> T {
 
 extension Task where Success == Never, Failure == Never {
     static func sleep(seconds: Double) async throws {
-        let duration = UInt64(abs(seconds) * nanoMultiplier)
+        let duration = UInt64(abs(seconds)) * NSEC_PER_SEC
         try await Task.sleep(nanoseconds: duration)
     }
 }
@@ -140,7 +140,7 @@ extension Task where Success == Never, Failure == Never {
     /// - Parameter deadline: Sleep at least until this time. The actual time the sleep ends can be later.
     /// - Parameter cancellationCheckInterval: The interval in seconds between cancellation checks.
     static func sleepCancellable(until deadline: Date, cancellationCheckInterval: TimeInterval = defaultCancellationCheckInterval) async throws {
-        let cancellationCheckIntervalUint64 = UInt64(cancellationCheckInterval * nanoMultiplier)
+        let cancellationCheckIntervalUint64 = UInt64(cancellationCheckInterval) * NSEC_PER_SEC
         while Date() < deadline {
             if Task.isCancelled {
                 break
@@ -152,8 +152,6 @@ extension Task where Success == Never, Failure == Never {
 }
 
 extension Task {
-    static var nanoMultiplier: Double { 1_000_000_000 }
-
     func eraseToAnyCancellable() -> AnyCancellable {
         return AnyCancellable(cancel)
     }
@@ -166,8 +164,7 @@ extension Task where Failure == Error {
         operation: @escaping @Sendable () async throws -> Success
     ) -> Task {
         Task(priority: priority) {
-            let nanosecondsDelay = UInt64(abs(delaySeconds) *  nanoMultiplier)
-            try await Task<Never, Never>.sleep(nanoseconds: nanosecondsDelay)
+            try await Task<Never, Never>.sleep(seconds: delaySeconds)
             try Task<Never, Never>.checkCancellation()
             return try await operation()
         }

--- a/Tangem/Common/Extensions/SwiftConcurrency+.swift
+++ b/Tangem/Common/Extensions/SwiftConcurrency+.swift
@@ -157,3 +157,18 @@ extension Task {
         return AnyCancellable(cancel)
     }
 }
+
+extension Task where Failure == Error {
+    static func delayed(
+        withDelay delaySeconds: TimeInterval,
+        priority: TaskPriority? = nil,
+        operation: @escaping @Sendable () async throws -> Success
+    ) -> Task {
+        Task(priority: priority) {
+            let nanosecondsDelay = UInt64(delaySeconds * 1_000_000_000)
+            try await Task<Never, Never>.sleep(nanoseconds: nanosecondsDelay)
+            try Task<Never, Never>.checkCancellation()
+            return try await operation()
+        }
+    }
+}

--- a/Tangem/Modules/Markets/Providers/MarketsListDataProvider.swift
+++ b/Tangem/Modules/Markets/Providers/MarketsListDataProvider.swift
@@ -53,12 +53,15 @@ final class MarketsListDataProvider {
     // Limit of records per page
     private let limitPerPage: Int = 40
 
+    private let repeatRequestDelayInSeconds: TimeInterval = 10
+
     // Total tokens value by pages
     private var totalTokensCount: Int?
 
     private var lastSearchText: String?
     private var lastFilter: Filter?
     private var taskCancellable: AnyCancellable?
+    private var scheduledFetchTask: AnyCancellable?
 
     private var selectedCurrencyCode: String {
         AppSettings.shared.selectedCurrencyCode
@@ -84,37 +87,25 @@ final class MarketsListDataProvider {
             clearSearchResults()
         }
 
+        guard scheduledFetchTask == nil else {
+            log("Ignoring fetch request. Waiting for scheduled task")
+            return
+        }
+
         lastSearchText = searchText
         lastFilter = filter
 
         taskCancellable?.cancel()
 
         taskCancellable = runTask(in: self) { provider in
-            defer {
-                provider.isLoading = false
-            }
-            let response: MarketsDTO.General.Response
-
             do {
                 let searchText = searchText.trimmed()
 
-                response = try await provider.loadItems(searchText, with: filter)
+                let response = try await provider.loadItems(searchText, with: filter)
+                await provider.handleFetchResult(.success(response))
             } catch {
-                if error.isCancellationError {
-                    return
-                }
-
-                provider.log("Failed to load next page. Error: \(error)")
-                provider.showError = true
-                return
+                await provider.handleFetchResult(.failure(error))
             }
-
-            provider.currentOffset = response.offset + response.limit
-            provider.totalTokensCount = response.total
-
-            provider.showError = false
-
-            provider.items.append(contentsOf: response.tokens)
         }.eraseToAnyCancellable()
     }
 
@@ -122,12 +113,12 @@ final class MarketsListDataProvider {
         if let lastSearchText, let lastFilter {
             fetch(lastSearchText, with: lastFilter)
         } else {
-            log("Error optional parameter lastSearchText or lastFilter")
+            log("Failed to fetch more items for Markets list. Reason: missing lastSearchText or lastFilter")
         }
     }
 
     private func log<T>(_ message: @autoclosure () -> T) {
-        AppLog.shared.debug("[\(String(describing: self))] - \(message())")
+        AppLog.shared.debug("[MarketsListDataProvider] - \(message())")
     }
 
     private func clearSearchResults() {
@@ -135,7 +126,58 @@ final class MarketsListDataProvider {
         currentOffset = 0
         totalTokensCount = nil
 
+        if scheduledFetchTask != nil {
+            scheduledFetchTask?.cancel()
+            scheduledFetchTask = nil
+        }
+
         showError = false
+    }
+}
+
+// MARK: - Handling fetch response
+
+private extension MarketsListDataProvider {
+    func handleFetchResult(_ result: Result<MarketsDTO.General.Response, Error>) async {
+        do {
+            let response = try result.get()
+            currentOffset = response.offset + response.limit
+            totalTokensCount = response.total
+
+            log("Loaded new items for market list. New total tokens count: \(items.count + response.tokens.count)")
+            items.append(contentsOf: response.tokens)
+
+            showError = false
+            isLoading = false
+        } catch {
+            if error.isCancellationError {
+                return
+            }
+
+            log("Failed to load next page. Error: \(error)")
+            if items.isEmpty {
+                showError = true
+                isLoading = false
+            } else {
+                scheduleRetryForFailedFetchRequest()
+            }
+        }
+    }
+
+    func scheduleRetryForFailedFetchRequest() {
+        log("Scheduling fetch more task")
+        guard scheduledFetchTask == nil else {
+            log("Task was previously scheduled. Ignoring request")
+            return
+        }
+
+        log("Retry fetch more task scheduled. Request delay: \(repeatRequestDelayInSeconds)")
+        scheduledFetchTask = Task.delayed(withDelay: repeatRequestDelayInSeconds, operation: { [weak self] in
+            guard let self else { return }
+
+            scheduledFetchTask = nil
+            fetchMore()
+        }).eraseToAnyCancellable()
     }
 }
 

--- a/Tangem/Modules/Markets/TokenList/MarketsView.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsView.swift
@@ -133,7 +133,7 @@ struct MarketsView: View {
 
     private var errorStateView: some View {
         MarketsUnableToLoadDataView(
-            isButtonBusy: viewModel.tokenListLoadingState == .loading,
+            isButtonBusy: viewModel.isDataProviderBusy,
             retryButtonAction: viewModel.onTryLoadList
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
@@ -22,6 +22,7 @@ final class MarketsViewModel: ObservableObject {
     // MARK: - Properties
 
     @Published var isViewVisible: Bool = false
+    @Published var isDataProviderBusy: Bool = false
 
     let resetScrollPositionPublisher = PassthroughSubject<Void, Never>()
 
@@ -228,6 +229,8 @@ private extension MarketsViewModel {
             .receive(on: DispatchQueue.main)
             .withWeakCaptureOf(self)
             .sink(receiveValue: { viewModel, isLoading in
+                viewModel.isDataProviderBusy = isLoading
+
                 if viewModel.dataProvider.showError {
                     return
                 }


### PR DESCRIPTION
была проблема, что если 2 страница не загрузилась поверх списка появлялась плашка, что не удалось загрузить данные, а сейчас обновились требования, теперь эта плашка должна появляться только если первая страница не загрузилась, а если со 2 и дальше не загрузилось - просто скелетоны висят и усе. Если 2 и дальше запросы зафейлились - надо каждые 10 секунд перезапрашивать по страницу.