### PR TITLE
[Markets] IOS-7603 fix search markets UI

### DIFF
--- a/Tangem/UIComponents/Common/CustomSearchBar.swift
+++ b/Tangem/UIComponents/Common/CustomSearchBar.swift
@@ -47,7 +47,7 @@ struct CustomSearchBar: View {
                     self.isEditing = isEditing
                     onEditingChanged?(isEditing)
                 })
-                .style(Fonts.Regular.subheadline, color: Colors.Text.primary1)
+                .style(Fonts.Regular.subheadline, color: Colors.Text.tertiary)
                 .keyboardType(keyboardType)
                 .autocorrectionDisabled()
 
@@ -58,7 +58,7 @@ struct CustomSearchBar: View {
         .padding(.horizontal, 12)
         .background(
             RoundedRectangle(cornerRadius: 14)
-                .fill(Colors.Field.focused)
+                .fill(Colors.Field.primary)
         )
     }
 


### PR DESCRIPTION
Поправил цвета в соотвествии замечаний

![Simulator Screenshot - iPhone 15 - 2024-08-16 at 15 10 54](https://github.com/user-attachments/assets/4bd66a70-7235-4376-ba56-5062eba8a268)

Цвета для background: var(--Text-text-tertiary, #909090); не менял, написал в канал дизайн, что-то путаница какая-то