### PR TITLE
IOS-7583: [Markets] Refactor list items creation logic

### DIFF
--- a/Tangem/App/Models/Markets/MarketsTokenModel.swift
+++ b/Tangem/App/Models/Markets/MarketsTokenModel.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct MarketsTokenModel: Identifiable, Decodable {
+struct MarketsTokenModel: Identifiable, Decodable, Equatable {
     let id: String
     let name: String
     let symbol: String

--- a/Tangem/Modules/Markets/TokenList/MarketsItemView.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsItemView.swift
@@ -125,20 +125,11 @@ extension MarketsItemView {
 
     return ScrollView(.vertical) {
         ForEach(tokens.indexed(), id: \.1.id) { index, token in
-            let inputData = MarketsItemViewModel.InputData(
-                index: index,
-                id: token.id,
-                name: token.name,
-                symbol: token.symbol,
-                marketCap: token.marketCap,
-                marketRating: token.marketRating,
-                priceValue: token.currentPrice,
-                priceChangeStateValues: [:]
-            )
-
-            return MarketsItemView(
+            MarketsItemView(
                 viewModel: .init(
-                    inputData, prefetchDataSource: nil,
+                    index: index,
+                    tokenModel: token,
+                    prefetchDataSource: nil,
                     chartsProvider: .init(),
                     filterProvider: .init(),
                     onTapAction: nil

--- a/Tangem/Modules/Markets/TokenList/MarketsItemViewModel.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsItemViewModel.swift
@@ -45,7 +45,8 @@ class MarketsItemViewModel: Identifiable, ObservableObject {
     // MARK: - Init
 
     init(
-        _ data: InputData,
+        index: Int,
+        tokenModel: MarketsTokenModel,
         prefetchDataSource: MarketsListPrefetchDataSource?,
         chartsProvider: MarketsListChartsHistoryProvider,
         filterProvider: MarketsListDataFilterProvider,
@@ -54,25 +55,25 @@ class MarketsItemViewModel: Identifiable, ObservableObject {
         self.filterProvider = filterProvider
         self.prefetchDataSource = prefetchDataSource
 
-        index = data.index
-        tokenId = data.id
-        imageURL = IconURLBuilder().tokenIconURL(id: tokenId, size: .large)
-        name = data.name
-        symbol = data.symbol.uppercased()
+        self.index = index
+        tokenId = tokenModel.id
+        imageURL = IconURLBuilder().tokenIconURL(id: tokenModel.id, size: .large)
+        name = tokenModel.name
+        symbol = tokenModel.symbol.uppercased()
 
         didTapAction = onTapAction
 
-        if let marketRating = data.marketRating {
+        if let marketRating = tokenModel.marketRating {
             self.marketRating = "\(marketRating)"
         }
 
-        if let marketCap = data.marketCap {
+        if let marketCap = tokenModel.marketCap {
             self.marketCap = marketCapFormatter.formatDecimal(marketCap)
         }
 
         setupPriceInfo(
-            price: data.priceValue,
-            priceChangePercent: data.priceChangeStateValues[filterProvider.currentFilterValue.interval.rawValue]
+            price: tokenModel.currentPrice,
+            priceChangePercent: tokenModel.priceChangePercentage[filterProvider.currentFilterValue.interval.rawValue]
         )
         bindToIntervalUpdates()
         bindToQuotesUpdates()
@@ -189,18 +190,5 @@ class MarketsItemViewModel: Identifiable, ObservableObject {
         }
 
         setupPriceInfo(price: newQuote.price, priceChangePercent: priceChangePercent)
-    }
-}
-
-extension MarketsItemViewModel {
-    struct InputData: Identifiable {
-        let index: Int
-        let id: String
-        let name: String
-        let symbol: String
-        let marketCap: Decimal?
-        let marketRating: Int?
-        let priceValue: Decimal?
-        let priceChangeStateValues: [String: Decimal]
     }
 }

--- a/Tangem/Modules/Markets/TokenList/MarketsListDataController.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsListDataController.swift
@@ -17,7 +17,7 @@ class MarketsListDataController {
 
     // MARK: - Private Properties
 
-    private let dataProvider: MarketsListDataProvider
+    private weak var dataFetcher: MarketsListDataFetcher?
     private weak var cellsStateUpdater: MarketsListStateUpdater?
 
     private let lastAppearedIndexSubject: CurrentValueSubject<Int, Never> = .init(0)
@@ -30,8 +30,12 @@ class MarketsListDataController {
 
     // MARK: - Init
 
-    init(dataProvider: MarketsListDataProvider, viewVisibilityPublisher: any Publisher<Bool, Never>, cellsStateUpdater: MarketsListStateUpdater?) {
-        self.dataProvider = dataProvider
+    init(
+        dataFetcher: MarketsListDataFetcher,
+        viewVisibilityPublisher: any Publisher<Bool, Never>,
+        cellsStateUpdater: MarketsListStateUpdater?
+    ) {
+        self.dataFetcher = dataFetcher
         self.cellsStateUpdater = cellsStateUpdater
 
         bind(viewVisibilityPublisher: viewVisibilityPublisher)
@@ -142,13 +146,16 @@ class MarketsListDataController {
     }
 
     private func fetchMoreIfPossible(with range: ClosedRange<Int>) {
-        guard dataProvider.canFetchMore else {
+        guard
+            let dataFetcher,
+            dataFetcher.canFetchMore
+        else {
             return
         }
 
-        let itemsInUpperBufferZone = dataProvider.items.count - range.upperBound
+        let itemsInUpperBufferZone = dataFetcher.totalItems - range.upperBound
         if itemsInUpperBufferZone < Constants.itemsInBufferZone {
-            dataProvider.fetchMore()
+            dataFetcher.fetchMore()
         }
     }
 }

--- a/Tangem/Modules/Markets/TokenList/MarketsListDataFetcher.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsListDataFetcher.swift
@@ -1,0 +1,15 @@
+//
+//  MarketsListDataFetcher.swift
+//  Tangem
+//
+//  Created by Andrew Son on 20.08.24.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+protocol MarketsListDataFetcher: AnyObject {
+    var canFetchMore: Bool { get }
+    var totalItems: Int { get }
+    func fetchMore()
+}

--- a/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
@@ -46,7 +46,7 @@ final class MarketsViewModel: ObservableObject {
     private let quotesUpdatesScheduler = MarketsQuotesUpdatesScheduler()
     private let imageCache = KingfisherManager.shared.cache
 
-    private lazy var listDataController: MarketsListDataController = .init(dataProvider: dataProvider, viewVisibilityPublisher: $isViewVisible, cellsStateUpdater: self)
+    private lazy var listDataController: MarketsListDataController = .init(dataFetcher: self, viewVisibilityPublisher: $isViewVisible, cellsStateUpdater: self)
 
     private var bag = Set<AnyCancellable>()
     private var currentSearchValue: String = ""
@@ -101,10 +101,6 @@ final class MarketsViewModel: ObservableObject {
         onDisappearPrepareImageCache()
     }
 
-    func fetchMore() {
-        dataProvider.fetchMore()
-    }
-
     func onShowUnderCapAction() {
         showItemsBelowCapThreshold = true
 
@@ -113,7 +109,9 @@ final class MarketsViewModel: ObservableObject {
             return
         }
 
-        tokenViewModels = mapToItemViewModel(dataProvider.items)
+        let slicedArray = Array(dataProvider.items[tokenViewModels.count ..< dataProvider.items.count])
+        let itemsUnderCap = mapToItemViewModel(slicedArray, offset: tokenViewModels.count)
+        tokenViewModels.append(contentsOf: itemsUnderCap)
     }
 
     func onTryLoadList() {
@@ -197,80 +195,109 @@ private extension MarketsViewModel {
     }
 
     func dataProviderBind() {
-        dataProvider.$items
-            .dropFirst()
-            .handleEvents(receiveOutput: { [weak self] items in
-                self?.quotesRepositoryUpdateHelper.updateQuotes(marketsTokens: items, for: AppSettings.shared.selectedCurrencyCode)
-            })
-            .receive(on: DispatchQueue.main)
-            .withWeakCaptureOf(self)
-            .sink(receiveValue: { viewModel, items in
-                viewModel.chartsHistoryProvider.fetch(for: items.map { $0.id }, with: viewModel.filterProvider.currentFilterValue.interval)
+        let dataProviderEventPipeline = dataProvider.$lastEvent
+            .removeDuplicates()
+            .share(replay: 2)
 
-                // TODO: IOS-7583
-                // Refactor this. Each time data provider receive next page - whole item models list recreated.
-                viewModel.tokenViewModels = viewModel.mapToItemViewModel(items)
-            })
-            .store(in: &bag)
+        dataProviderEventPipeline
+            .filter {
+                if case .appendedItems = $0 {
+                    return false
+                }
 
-        dataProvider.$isLoading
-            .combineLatest($tokenListLoadingState, $tokenViewModels)
-            .filter { $0.0 && $0.1 == .loading && $0.2.isEmpty }
+                return true
+            }
             .receive(on: DispatchQueue.main)
-            .mapToVoid()
+            .withPrevious()
             .withWeakCaptureOf(self)
-            .sink { viewModel, _ in
-                viewModel.resetScrollPositionPublisher.send(())
+            .sink { viewModel, events in
+                let (oldEvent, newEvent) = events
+                switch newEvent {
+                case .loading:
+                    if oldEvent != .failedToFetchData {
+                        viewModel.tokenListLoadingState = .loading
+                    }
+                    viewModel.isDataProviderBusy = true
+                case .idle:
+                    viewModel.isDataProviderBusy = false
+                case .failedToFetchData:
+                    viewModel.isDataProviderBusy = false
+                    if viewModel.dataProvider.items.isEmpty {
+                        viewModel.tokenListLoadingState = .error
+                    } else {
+                        viewModel.tokenListLoadingState = .loading
+                    }
+                case .startInitialFetch, .cleared:
+                    viewModel.tokenListLoadingState = .loading
+                    viewModel.tokenViewModels.removeAll()
+                    viewModel.resetScrollPositionPublisher.send(())
+                    viewModel.isDataProviderBusy = true
+                default:
+                    break
+                }
             }
             .store(in: &bag)
 
-        dataProvider.$isLoading
-            .removeDuplicates()
+        dataProviderEventPipeline
+            .filter {
+                if case .appendedItems = $0 {
+                    return true
+                }
+
+                return false
+            }
+            .handleEvents(receiveOutput: { [weak self] event in
+                guard
+                    let self,
+                    case .appendedItems(let items, _) = event
+                else {
+                    return
+                }
+
+                let idsToFetchMiniCharts = items.map { $0.id }
+                chartsHistoryProvider.fetch(
+                    for: idsToFetchMiniCharts,
+                    with: filterProvider.currentFilterValue.interval
+                )
+
+                quotesRepositoryUpdateHelper.updateQuotes(marketsTokens: items, for: AppSettings.shared.selectedCurrencyCode)
+            })
+            .withWeakCaptureOf(self)
+            .compactMap { viewModel, event in
+                guard case .appendedItems(let items, let lastPage) = event else {
+                    return nil
+                }
+
+                let tokenViewModelsToAppend = viewModel.mapToItemViewModel(items, offset: viewModel.tokenViewModels.count)
+                return (tokenViewModelsToAppend, lastPage)
+            }
             .receive(on: DispatchQueue.main)
             .withWeakCaptureOf(self)
-            .sink(receiveValue: { viewModel, isLoading in
-                viewModel.isDataProviderBusy = isLoading
+            .sink { (viewModel: MarketsViewModel, mappedEvent: ([MarketsItemViewModel], Bool)) in
+                let (items, lastPage) = mappedEvent
 
-                if viewModel.dataProvider.showError {
-                    return
-                }
+                viewModel.tokenViewModels.append(contentsOf: items)
 
-                if isLoading {
-                    viewModel.tokenListLoadingState = .loading
-                    return
-                }
-
-                if viewModel.dataProvider.items.isEmpty {
+                if viewModel.tokenViewModels.isEmpty {
                     viewModel.tokenListLoadingState = .noResults
                     return
                 }
 
-                if !viewModel.dataProvider.canFetchMore {
+                if lastPage {
                     viewModel.tokenListLoadingState = .allDataLoaded
                     return
                 }
 
                 viewModel.tokenListLoadingState = .idle
-            })
-            .store(in: &bag)
-
-        dataProvider.$showError
-            .receive(on: DispatchQueue.main)
-            .withWeakCaptureOf(self)
-            .sink(receiveValue: { viewModel, showError in
-                if showError {
-                    viewModel.resetUI()
-                    viewModel.tokenListLoadingState = .error
-                }
-            })
+            }
             .store(in: &bag)
     }
 
     // MARK: - Private Implementation
 
-    private func mapToItemViewModel(_ list: [MarketsTokenModel]) -> [MarketsItemViewModel] {
+    private func mapToItemViewModel(_ list: [MarketsTokenModel], offset: Int) -> [MarketsItemViewModel] {
         let listToProcess = filterItemsBelowMarketCapIfNeeded(list)
-        return listToProcess.enumerated().map { mapToTokenViewModel(index: $0, tokenItemModel: $1) }
+        return listToProcess.enumerated().map { mapToTokenViewModel(index: $0 + offset, tokenItemModel: $1) }
     }
 
     private func filterItemsBelowMarketCapIfNeeded(_ list: [MarketsTokenModel]) -> [MarketsTokenModel] {
@@ -288,19 +315,9 @@ private extension MarketsViewModel {
     }
 
     private func mapToTokenViewModel(index: Int, tokenItemModel: MarketsTokenModel) -> MarketsItemViewModel {
-        let inputData = MarketsItemViewModel.InputData(
-            index: index,
-            id: tokenItemModel.id,
-            name: tokenItemModel.name,
-            symbol: tokenItemModel.symbol,
-            marketCap: tokenItemModel.marketCap,
-            marketRating: tokenItemModel.marketRating,
-            priceValue: tokenItemModel.currentPrice,
-            priceChangeStateValues: tokenItemModel.priceChangePercentage
-        )
-
         return MarketsItemViewModel(
-            inputData,
+            index: index,
+            tokenModel: tokenItemModel,
             prefetchDataSource: listDataController,
             chartsProvider: chartsHistoryProvider,
             filterProvider: filterProvider,
@@ -321,6 +338,20 @@ private extension MarketsViewModel {
 
     private func resetUI() {
         showItemsBelowCapThreshold = false
+    }
+}
+
+extension MarketsViewModel: MarketsListDataFetcher {
+    var canFetchMore: Bool {
+        dataProvider.canFetchMore && tokenListLoadingState == .idle
+    }
+
+    var totalItems: Int {
+        tokenViewModels.count
+    }
+
+    func fetchMore() {
+        dataProvider.fetchMore()
     }
 }
 

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -310,6 +310,7 @@
 		B03662662B638BBC0064E073 /* visaSingleTransaction.json in Resources */ = {isa = PBXBuildFile; fileRef = B03662632B63851B0064E073 /* visaSingleTransaction.json */; };
 		B03662692B63D7660064E073 /* iso4217Codes.plist in Resources */ = {isa = PBXBuildFile; fileRef = B03662682B63D7660064E073 /* iso4217Codes.plist */; };
 		B036626B2B63D77D0064E073 /* ISO4217CodeConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B036626A2B63D77D0064E073 /* ISO4217CodeConverter.swift */; };
+		B036881E2C74B79300D418FB /* MarketsListDataFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B036881D2C74B79300D418FB /* MarketsListDataFetcher.swift */; };
 		B037B1EE256E747F0022EFFF /* TwinsFinalizeWalletCreationTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = B037B1ED256E747F0022EFFF /* TwinsFinalizeWalletCreationTask.swift */; };
 		B03A9339259877790061FB2D /* WarningsContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B03A9338259877790061FB2D /* WarningsContainer.swift */; };
 		B03AC9932BD8DB26000CBC50 /* APIListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B03AC9922BD8DB26000CBC50 /* APIListTests.swift */; };
@@ -2258,6 +2259,7 @@
 		B03662642B6385C70064E073 /* VisaTransactionDetailsViewModelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisaTransactionDetailsViewModelMock.swift; sourceTree = "<group>"; };
 		B03662682B63D7660064E073 /* iso4217Codes.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = iso4217Codes.plist; sourceTree = "<group>"; };
 		B036626A2B63D77D0064E073 /* ISO4217CodeConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ISO4217CodeConverter.swift; sourceTree = "<group>"; };
+		B036881D2C74B79300D418FB /* MarketsListDataFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketsListDataFetcher.swift; sourceTree = "<group>"; };
 		B037B1ED256E747F0022EFFF /* TwinsFinalizeWalletCreationTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwinsFinalizeWalletCreationTask.swift; sourceTree = "<group>"; };
 		B03A9338259877790061FB2D /* WarningsContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarningsContainer.swift; sourceTree = "<group>"; };
 		B03AC9922BD8DB26000CBC50 /* APIListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIListTests.swift; sourceTree = "<group>"; };
@@ -4078,6 +4080,7 @@
 				2DC5675D2B0DFFAF00B0244F /* MarketsView.swift */,
 				2DC5675E2B0DFFAF00B0244F /* MarketsViewModel.swift */,
 				B0A7DB4F2C58E56F00986D95 /* MarketsListStateUpdater.swift */,
+				B036881D2C74B79300D418FB /* MarketsListDataFetcher.swift */,
 			);
 			path = TokenList;
 			sourceTree = "<group>";
@@ -10759,6 +10762,7 @@
 				B0BB972A2B18653B00053954 /* ExpressInteractor.swift in Sources */,
 				2DB648842C35877000DA100D /* MarketsWalletSelectorViewModel.swift in Sources */,
 				B0ADFD40298A70FF00EF2869 /* WalletConnectV2SignTransactionHandler.swift in Sources */,
+				B036881E2C74B79300D418FB /* MarketsListDataFetcher.swift in Sources */,
 				B09FA3362C25595700A608C9 /* ManageTokensListItemView.swift in Sources */,
 				B0BA7BC526C4F96B00D7066F /* NonDismissableModalView.swift in Sources */,
 				EFC84B0D2C37FAB500546882 /* SendFinishStepBuilder.swift in Sources */,


### PR DESCRIPTION
Была проблема что вью модели создавались на главном потоке и каждый раз весь список пересоздавался, что конечно же вызывало глюки и тормоза при завершении загрузки новой страницы. Сейчас дата провайдер будет публиковать события и вью модель списка подписывается на них и реагирует соответствующим образом. Изначально думал сделать 2 подписки, чтобы раздельно трекать какие-то события типа стейта загрузки или ошибок и отдельно публикацию списка, но тогда получается то же что и сейчас и есть сложности в синхронизации событий, если несколько источников. Поэтому остановился пока на таком варианте. Старался обойтись без переделывания всего дата провайдера. Изначально вообще думалось перенести запрос в сервис и все разруливать во вью модели все стейты и списки, но это лишняя ответственность для вью модели и вроде норм получилось.

https://github.com/user-attachments/assets/5de0cdaf-3357-4ec9-99f1-3784459a9c92

