### PR TITLE
IOS-7633 Update `Default` views to new `callout` font

### DIFF
--- a/Tangem/Common/UI/DefaultListViews/DefaultPickerRowView/DefaultPickerRowView.swift
+++ b/Tangem/Common/UI/DefaultListViews/DefaultPickerRowView/DefaultPickerRowView.swift
@@ -20,7 +20,7 @@ struct DefaultPickerRowView: View {
     var body: some View {
         VStack(alignment: .leading) {
             Text(viewModel.title)
-                .style(Fonts.Bold.body, color: Colors.Text.primary1)
+                .style(Fonts.Bold.callout, color: Colors.Text.primary1)
 
             Picker("", selection: $selection) {
                 ForEach(viewModel.options, id: \.self) {
@@ -30,7 +30,7 @@ struct DefaultPickerRowView: View {
             .labelsHidden()
             .pickerStyle(.segmented)
         }
-        .padding(.vertical, 12)
+        .padding(.vertical, 14)
         .connect(state: $selection, to: viewModel.selection)
     }
 }

--- a/Tangem/Common/UI/DefaultListViews/DefaultRowView/DefaultRowView.swift
+++ b/Tangem/Common/UI/DefaultListViews/DefaultRowView/DefaultRowView.swift
@@ -19,10 +19,8 @@ struct DefaultRowView: View {
     private var isTappable: Bool { viewModel.action != nil }
 
     var body: some View {
-        if isTappable {
-            Button {
-                viewModel.action?()
-            } label: {
+        if let action = viewModel.action {
+            Button(action: action) {
                 content
             }
             .buttonStyle(PlainButtonStyle())
@@ -52,10 +50,11 @@ struct DefaultRowView: View {
         HStack(spacing: 0) {
             Text(viewModel.title)
                 .style(appearance.font, color: appearance.textColor)
+
             if let secondaryAction = viewModel.secondaryAction {
                 Button(action: secondaryAction) {
                     Assets.infoCircle16.image
-                        .padding(4)
+                        .padding(.horizontal, 4)
                         .foregroundColor(Colors.Icon.informative)
                 }
             }
@@ -103,7 +102,7 @@ extension DefaultRowView {
 
         init(
             isChevronVisible: Bool = true,
-            font: Font = Fonts.Regular.body,
+            font: Font = Fonts.Regular.callout,
             textColor: Color = Colors.Text.primary1,
             detailsColor: Color = Colors.Text.tertiary
         ) {

--- a/Tangem/Common/UI/DefaultListViews/DefaultSelectableRowView/DefaultSelectableRowView.swift
+++ b/Tangem/Common/UI/DefaultListViews/DefaultSelectableRowView/DefaultSelectableRowView.swift
@@ -22,7 +22,7 @@ struct DefaultSelectableRowView<ID: Hashable>: View {
             HStack(alignment: .center) {
                 VStack(alignment: .leading, spacing: 6) {
                     Text(data.title)
-                        .style(Fonts.Regular.body, color: Colors.Text.primary1)
+                        .style(Fonts.Regular.callout, color: Colors.Text.primary1)
                         .multilineTextAlignment(.leading)
 
                     if let subtitle = data.subtitle {

--- a/Tangem/Common/UI/DefaultListViews/DefaultToggleRowView/DefaultToggleRowView.swift
+++ b/Tangem/Common/UI/DefaultListViews/DefaultToggleRowView/DefaultToggleRowView.swift
@@ -21,7 +21,7 @@ struct DefaultToggleRowView: View {
         HStack {
             Text(viewModel.title)
                 .style(
-                    Fonts.Regular.body,
+                    Fonts.Regular.callout,
                     color: viewModel.isDisabled ? Colors.Text.disabled : Colors.Text.primary1
                 )
 

--- a/Tangem/Modules/Details/WalletConnectRow/WalletConnectRowView.swift
+++ b/Tangem/Modules/Details/WalletConnectRow/WalletConnectRowView.swift
@@ -20,14 +20,14 @@ struct WalletConnectRowView: View {
             HStack(spacing: 12) {
                 Assets.walletConnect.image
                     .resizable()
-                    .frame(width: 48, height: 48)
+                    .frame(width: 36, height: 36)
 
-                VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: 2) {
                     Text(viewModel.title)
-                        .style(Fonts.Regular.body, color: Colors.Text.primary1)
+                        .style(Fonts.Bold.subheadline, color: Colors.Text.primary1)
 
                     Text(viewModel.subtitle)
-                        .style(Fonts.Regular.footnote, color: Colors.Text.tertiary)
+                        .style(Fonts.Regular.caption1, color: Colors.Text.tertiary)
                 }
                 .lineLimit(1)
 

--- a/Tangem/Modules/StakingDetails/StakingDetailsView.swift
+++ b/Tangem/Modules/StakingDetails/StakingDetailsView.swift
@@ -23,8 +23,11 @@ struct StakingDetailsView: View {
                     banner
                 }
 
-                GroupedSection(viewModel.detailsViewModels) {
-                    DefaultRowView(viewModel: $0)
+                GroupedSection(viewModel.detailsViewModels) { data in
+                    DefaultRowView(viewModel: data)
+                        .if(viewModel.detailsViewModels.first?.id == data.id) {
+                            $0.appearance(.init(detailsColor: Colors.Text.accent))
+                        }
                 }
 
                 rewardView

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -8128,8 +8128,8 @@
 		EF032C4D2955C59E006C1FF3 /* DefaultSelectableRowView */ = {
 			isa = PBXGroup;
 			children = (
-				EF032C4E2955C59E006C1FF3 /* DefaultSelectableRowViewModel.swift */,
 				EF032C4F2955C59E006C1FF3 /* DefaultSelectableRowView.swift */,
+				EF032C4E2955C59E006C1FF3 /* DefaultSelectableRowViewModel.swift */,
 			);
 			path = DefaultSelectableRowView;
 			sourceTree = "<group>";
@@ -8462,8 +8462,8 @@
 		EF4662182924DEEE00346B6C /* DefaultToggleRowView */ = {
 			isa = PBXGroup;
 			children = (
-				EF4662192924DEEE00346B6C /* DefaultToggleRowViewModel.swift */,
 				EF46621A2924DEEE00346B6C /* DefaultToggleRowView.swift */,
+				EF4662192924DEEE00346B6C /* DefaultToggleRowViewModel.swift */,
 			);
 			path = DefaultToggleRowView;
 			sourceTree = "<group>";


### PR DESCRIPTION
Старый момент, тянется еще с переделки сеттингов

На всех наших "обычных" строках теперь по Figma используется `callout` вместо `body`. 
Не крит, но лить нужно, сравнил Details / AppSettings / CardSettings / StakingDetails с макетами, стало более похоже

Правда есть момент что местами там идут паддинги 13, а у нас везде 14