### PR TITLE
IOS-7737: [Markets] Remove reloading on sheet close

### DIFF
--- a/Tangem/Modules/Main/MainBottomSheet/Header/MainBottomSheetHeaderViewModel.swift
+++ b/Tangem/Modules/Main/MainBottomSheet/Header/MainBottomSheetHeaderViewModel.swift
@@ -23,8 +23,5 @@ final class MainBottomSheetHeaderViewModel: ObservableObject {
         }
     }
 
-    func onBottomSheetDisappear() {
-        // Needed to clear the token search field after the bottom sheet is collapsed
-        enteredSearchText = ""
-    }
+    func onBottomSheetDisappear() {}
 }

--- a/Tangem/Modules/Markets/TokenList/MarketsListDataController.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsListDataController.swift
@@ -26,29 +26,20 @@ class MarketsListDataController {
     private let hotAreaSubject: CurrentValueSubject<VisibleArea, Never> = .init(VisibleArea(range: 0 ... 1, direction: .down))
 
     private var bag = Set<AnyCancellable>()
-    private var isViewVisible: Bool = false
 
     // MARK: - Init
 
     init(
         dataFetcher: MarketsListDataFetcher,
-        viewVisibilityPublisher: any Publisher<Bool, Never>,
         cellsStateUpdater: MarketsListStateUpdater?
     ) {
         self.dataFetcher = dataFetcher
         self.cellsStateUpdater = cellsStateUpdater
 
-        bind(viewVisibilityPublisher: viewVisibilityPublisher)
         bind()
     }
 
     // MARK: - Private Implementation
-
-    private func bind(viewVisibilityPublisher: any Publisher<Bool, Never>) {
-        viewVisibilityPublisher
-            .assign(to: \.isViewVisible, on: self, ownership: .weak)
-            .store(in: &bag)
-    }
 
     private func bind() {
         lastAppearedIndexSubject.dropFirst().removeDuplicates()

--- a/Tangem/Modules/Markets/TokenList/MarketsView.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsView.swift
@@ -68,6 +68,10 @@ struct MarketsView: View {
         )
         .onOverlayContentProgressChange { progress in
             overlayContentProgress = progress
+
+            if progress < 1 {
+                UIResponder.current?.resignFirstResponder()
+            }
         }
         .animation(.easeInOut(duration: 0.2), value: viewOpacity)
     }

--- a/Tangem/UIComponents/Common/CustomSearchBar.swift
+++ b/Tangem/UIComponents/Common/CustomSearchBar.swift
@@ -50,10 +50,10 @@ struct CustomSearchBar: View {
                     .keyboardType(keyboardType)
                     .autocorrectionDisabled()
                     .focused($isFocused)
-                    .onChange(of: searchText) { _ in
-                        isEditing = isFocused
-                        onEditingChanged?(isFocused)
-                    }
+                    .onChange(of: isFocused, perform: { newValue in
+                        isEditing = newValue
+                        onEditingChanged?(newValue)
+                    })
 
                 clearButton
             }


### PR DESCRIPTION
* убрал очистку состояния шторки при закрытии
* добавил перезагрузку квот, при открытии шторки
* исправил нарабочую кнопку `Cancel` в поиске, при переездке на `FocusedState` она не работала
* добавил скрытие клавы при потягивании шторки

задал вопрос в треде на счет частого перезапроса квот, при открытии шторки, пока жду ответа, не знаю как долго будет утверждаться функционал, если будет долго другой задачей сделаю