### PR TITLE
IOS-7642: [Markets] Fix short description alignment

### DIFF
--- a/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsView.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsView.swift
@@ -158,7 +158,7 @@ struct TokenMarketsDetailsView: View {
                 ContentBlockSkeletons()
             case .loaded(let model):
                 description(shortDescription: model.shortDescription, fullDescription: model.fullDescription)
-                    .frame(maxWidth: .infinity)
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
                 portfolioView
 


### PR DESCRIPTION
подкрутил выравнивание, была проблема что текст не выравнивался в контейнере, из-за того что переходил на новую строку

<img width="300" src="https://github.com/user-attachments/assets/d91d66cf-ab37-4960-b5a9-747cec58b8e9">
