### PR TITLE
IOS-7775: Update mini-chart loading logic

### DIFF
--- a/Tangem/Modules/Markets/Providers/MarketsListChartsPreviewProvider.swift
+++ b/Tangem/Modules/Markets/Providers/MarketsListChartsPreviewProvider.swift
@@ -52,11 +52,7 @@ final class MarketsListChartsHistoryProvider {
 
                 for response in responses {
                     for (key, value) in response {
-                        if copyItems[key] == nil {
-                            copyItems[key] = [interval: value]
-                        } else {
-                            copyItems[key]?[interval] = value
-                        }
+                        copyItems[key, default: [:]][interval] = value
                     }
                 }
 
@@ -105,6 +101,7 @@ private extension MarketsListChartsHistoryProvider {
     func registerLoadedItems(requestedItemsIds: [String], interval: MarketsPriceIntervalType) {
         lock {
             guard var requestedItems = requestedItemsDictionary[interval] else {
+                assertionFailure("Requested items should contains items for provided interval")
                 return
             }
 

--- a/Tangem/Modules/Markets/Providers/MarketsListChartsPreviewProvider.swift
+++ b/Tangem/Modules/Markets/Providers/MarketsListChartsPreviewProvider.swift
@@ -7,15 +7,21 @@
 //
 
 import Foundation
+import TangemFoundation
 
 final class MarketsListChartsHistoryProvider {
+    typealias TokensChartsHistory = [String: [MarketsPriceIntervalType: MarketsChartModel]]
+
     // MARK: Dependencies
 
     @Injected(\.tangemApiService) private var tangemApiService: TangemApiService
 
     // MARK: Published Properties
 
-    @Published var items: [String: [MarketsPriceIntervalType: MarketsChartModel]] = [:]
+    @Published var items: TokensChartsHistory = [:]
+
+    private var requestedItemsDictionary: [MarketsPriceIntervalType: Set<String>] = [:]
+    private let lock = Lock(isRecursive: false)
 
     // MARK: - Private Properties
 
@@ -26,37 +32,40 @@ final class MarketsListChartsHistoryProvider {
     // MARK: - Implementation
 
     func fetch(for coinIds: [String], with interval: MarketsPriceIntervalType) {
-        guard !coinIds.isEmpty else {
+        if coinIds.isEmpty {
             return
         }
 
         runTask(in: self) { provider in
-            let response: MarketsDTO.ChartsHistory.PreviewResponse
+            let filteredItems = provider.filterItemsToRequest(coinIds, interval: interval)
 
             do {
-                // Need for filtered coins already received
-                let filteredCoinIds = coinIds.filter {
-                    !(provider.items[$0]?.keys.contains(interval) ?? false)
-                }
-
-                guard !filteredCoinIds.isEmpty else {
+                if filteredItems.isEmpty {
+                    provider.log("Filtered items list to request is empty. Skip loading")
                     return
                 }
 
-                response = try await provider.loadItems(for: filteredCoinIds, with: interval)
+                provider.log("Filtered items list to request is not empty. Attempting to fetch \(filteredItems.count) items")
+                let responses = try await provider.fetchItems(ids: filteredItems, interval: interval)
+
+                var copyItems: TokensChartsHistory = provider.items
+
+                for response in responses {
+                    for (key, value) in response {
+                        if copyItems[key] == nil {
+                            copyItems[key] = [interval: value]
+                        } else {
+                            copyItems[key]?[interval] = value
+                        }
+                    }
+                }
+
+                provider.items = copyItems
             } catch {
-                AppLog.shared.debug("\(String(describing: provider)) loaded charts history preview list tokens did receive error \(error.localizedDescription)")
-                return
+                provider.log("Loaded charts history preview list tokens did receive error \(error.localizedDescription)")
             }
 
-            // It is necessary in order to set the value once in the value of items
-            var copyItems: [String: [MarketsPriceIntervalType: MarketsChartModel]] = provider.items
-
-            for (key, value) in response {
-                copyItems[key] = [interval: value]
-            }
-
-            provider.items = copyItems
+            provider.registerLoadedItems(requestedItemsIds: filteredItems, interval: interval)
         }
     }
 
@@ -65,9 +74,83 @@ final class MarketsListChartsHistoryProvider {
     }
 }
 
+private extension MarketsListChartsHistoryProvider {
+    var maxNumberOfItemsPerRequest: Int { 200 }
+}
+
 // MARK: Private
 
 private extension MarketsListChartsHistoryProvider {
+    func log<T>(_ message: @autoclosure () -> T) {
+        AppLog.shared.debug("[\(String(describing: self))] - \(message())")
+    }
+
+    func filterItemsToRequest(_ newItemsToRequest: [String], interval: MarketsPriceIntervalType) -> [String] {
+        let notLoadedItems = newItemsToRequest.filter { items[$0]?[interval] == nil }
+        return lock {
+            guard let alreadyRequestedItemsForInterval = requestedItemsDictionary[interval] else {
+                requestedItemsDictionary[interval] = notLoadedItems.toSet()
+                return notLoadedItems
+            }
+
+            let filteredList = notLoadedItems.filter { tokenId in
+                let alreadyRequested = alreadyRequestedItemsForInterval.contains(tokenId)
+                return !alreadyRequested
+            }
+            requestedItemsDictionary[interval] = alreadyRequestedItemsForInterval.union(filteredList)
+            return filteredList
+        }
+    }
+
+    func registerLoadedItems(requestedItemsIds: [String], interval: MarketsPriceIntervalType) {
+        lock {
+            guard var requestedItems = requestedItemsDictionary[interval] else {
+                return
+            }
+
+            requestedItemsIds.forEach { requestedItems.remove($0) }
+            if requestedItems.isEmpty {
+                requestedItemsDictionary.removeValue(forKey: interval)
+            } else {
+                requestedItemsDictionary[interval] = requestedItems
+            }
+        }
+    }
+
+    func fetchItems(ids: [String], interval: MarketsPriceIntervalType) async throws -> [MarketsDTO.ChartsHistory.PreviewResponse] {
+        var idsToRequest: [[String]] = []
+
+        var offset = 0
+        log("Attempt to fetch items for interval: \(interval.rawValue). Number of items: \(ids.count)")
+        while offset < ids.count {
+            if ids.count - offset <= maxNumberOfItemsPerRequest {
+                log("Number of items is less than or equal to max items per request. Executing one request")
+                idsToRequest.append(Array(ids[offset...]))
+                break
+            } else {
+                let lowerBound = offset
+                offset += maxNumberOfItemsPerRequest
+                let range = lowerBound ..< offset
+                idsToRequest.append(Array(ids[range]))
+                log("Number of items is more than max per request. Adding to request list range: \(range)")
+            }
+        }
+
+        return try await withThrowingTaskGroup(of: MarketsDTO.ChartsHistory.PreviewResponse.self, returning: [MarketsDTO.ChartsHistory.PreviewResponse].self) { [weak self] group in
+            guard let self else { return [] }
+
+            for idsList in idsToRequest {
+                group.addTask { try await self.loadItems(for: idsList, with: interval) }
+            }
+
+            var responses = [MarketsDTO.ChartsHistory.PreviewResponse]()
+            for try await taskResult in group {
+                responses.append(taskResult)
+            }
+            return responses
+        }
+    }
+
     func loadItems(
         for coinIds: [String],
         with interval: MarketsPriceIntervalType
@@ -78,7 +161,7 @@ private extension MarketsListChartsHistoryProvider {
             interval: interval
         )
 
-        AppLog.shared.debug("\(String(describing: self)) loading market list tokens with request \(requestModel.parameters.debugDescription)")
+        log("Loading market list tokens with request \(requestModel.parameters.debugDescription)")
 
         return try await tangemApiService.loadCoinsHistoryChartPreview(requestModel: requestModel)
     }

--- a/Tangem/Modules/Markets/TokenList/MarketsListDataController.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsListDataController.swift
@@ -19,7 +19,7 @@ class MarketsListDataController {
         hotAreaSubject
     }
 
-    var currentHotArea: VisibleArea {
+    var hotArea: VisibleArea {
         hotAreaSubject.value
     }
 
@@ -93,7 +93,7 @@ class MarketsListDataController {
             .compactMap { dataController, newVisibleArea in
                 guard
                     let dataFetcher = dataController.dataFetcher,
-                    dataFetcher.totalItems > 0 
+                    dataFetcher.totalItems > 0
                 else {
                     return nil
                 }

--- a/Tangem/Modules/Markets/TokenList/MarketsListDataController.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsListDataController.swift
@@ -12,7 +12,15 @@ import CombineExt
 
 class MarketsListDataController {
     var visibleRangeAreaPublisher: some Publisher<VisibleArea, Never> {
-        visibleRangeAreaSubject.eraseToAnyPublisher()
+        visibleRangeAreaSubject
+    }
+
+    var hotAreaPublisher: some Publisher<VisibleArea, Never> {
+        hotAreaSubject
+    }
+
+    var currentHotArea: VisibleArea {
+        hotAreaSubject.value
     }
 
     // MARK: - Private Properties
@@ -81,10 +89,19 @@ class MarketsListDataController {
 
         visibleRangeAreaSubject.dropFirst().removeDuplicates()
             .debounce(for: 0.5, scheduler: DispatchQueue.main)
-            .map { newVisibleArea in
+            .withWeakCaptureOf(self)
+            .compactMap { dataController, newVisibleArea in
+                guard
+                    let dataFetcher = dataController.dataFetcher,
+                    dataFetcher.totalItems > 0 
+                else {
+                    return nil
+                }
                 let numberOfItemsInBufferZone = Constants.itemsInBufferZone
+                let lowerBound = max(0, newVisibleArea.range.lowerBound - numberOfItemsInBufferZone)
+                let upperBound = min(dataFetcher.totalItems - 1, newVisibleArea.range.upperBound + numberOfItemsInBufferZone)
                 return .init(
-                    range: max(0, newVisibleArea.range.lowerBound - numberOfItemsInBufferZone) ... newVisibleArea.range.upperBound + numberOfItemsInBufferZone,
+                    range: lowerBound ... upperBound,
                     direction: newVisibleArea.direction
                 )
             }

--- a/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
@@ -73,6 +73,7 @@ final class MarketsViewModel: ObservableObject {
         searchFilterBind(filterPublisher: filterProvider.filterPublisher)
 
         dataProviderBind()
+        bindToHotArea()
 
         // Need for preload markets list, when bottom sheet it has not been opened yet
         fetch(with: "", by: filterProvider.currentFilterValue)
@@ -167,13 +168,36 @@ private extension MarketsViewModel {
                 if Constants.filterRequiredReloadInterval.contains(value.order) {
                     viewModel.fetch(with: viewModel.dataProvider.lastSearchTextValue ?? "", by: viewModel.filterProvider.currentFilterValue)
                 } else {
-                    viewModel.chartsHistoryProvider.fetch(
-                        for: viewModel.dataProvider.items.map { $0.id },
-                        with: viewModel.filterProvider.currentFilterValue.interval
-                    )
+                    let hotAreaRange = viewModel.listDataController.currentHotArea
+                    viewModel.requestMiniCharts(forRange: hotAreaRange.range)
                 }
             }
             .store(in: &bag)
+    }
+
+    func bindToHotArea() {
+        listDataController.hotAreaPublisher
+            .dropFirst()
+            .debounce(for: 0.3, scheduler: DispatchQueue.main)
+            .removeDuplicates()
+            .map { $0.range }
+            .withWeakCaptureOf(self)
+            .sink { viewModel, hotAreaRange in
+                viewModel.requestMiniCharts(forRange: hotAreaRange)
+            }
+            .store(in: &bag)
+    }
+
+    func requestMiniCharts(forRange range: ClosedRange<Int>) {
+        let items = tokenViewModels
+        let itemsToFetch: Array<MarketsItemViewModel>.SubSequence
+        if items.count <= range.upperBound {
+            itemsToFetch = items[range.lowerBound...]
+        } else {
+            itemsToFetch = items[range]
+        }
+        let idsToFetch = Array(itemsToFetch).map { $0.tokenId }
+        chartsHistoryProvider.fetch(for: idsToFetch, with: filterProvider.currentFilterValue.interval)
     }
 
     func dataProviderBind() {
@@ -263,14 +287,12 @@ private extension MarketsViewModel {
             .store(in: &bag)
     }
 
-    // MARK: - Private Implementation
-
-    private func mapToItemViewModel(_ list: [MarketsTokenModel], offset: Int) -> [MarketsItemViewModel] {
+    func mapToItemViewModel(_ list: [MarketsTokenModel], offset: Int) -> [MarketsItemViewModel] {
         let listToProcess = filterItemsBelowMarketCapIfNeeded(list)
         return listToProcess.enumerated().map { mapToTokenViewModel(index: $0 + offset, tokenItemModel: $1) }
     }
 
-    private func filterItemsBelowMarketCapIfNeeded(_ list: [MarketsTokenModel]) -> [MarketsTokenModel] {
+    func filterItemsBelowMarketCapIfNeeded(_ list: [MarketsTokenModel]) -> [MarketsTokenModel] {
         guard filterItemsBelowMarketCapThreshold else {
             return list
         }
@@ -284,7 +306,7 @@ private extension MarketsViewModel {
         }
     }
 
-    private func mapToTokenViewModel(index: Int, tokenItemModel: MarketsTokenModel) -> MarketsItemViewModel {
+    func mapToTokenViewModel(index: Int, tokenItemModel: MarketsTokenModel) -> MarketsItemViewModel {
         return MarketsItemViewModel(
             index: index,
             tokenModel: tokenItemModel,
@@ -297,11 +319,11 @@ private extension MarketsViewModel {
         )
     }
 
-    private func onAppearPrepareImageCache() {
+    func onAppearPrepareImageCache() {
         imageCache.memoryStorage.config.countLimit = 250
     }
 
-    private func resetUI() {
+    func resetUI() {
         showItemsBelowCapThreshold = false
     }
 }

--- a/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
@@ -168,7 +168,7 @@ private extension MarketsViewModel {
                 if Constants.filterRequiredReloadInterval.contains(value.order) {
                     viewModel.fetch(with: viewModel.dataProvider.lastSearchTextValue ?? "", by: viewModel.filterProvider.currentFilterValue)
                 } else {
-                    let hotAreaRange = viewModel.listDataController.currentHotArea
+                    let hotAreaRange = viewModel.listDataController.hotArea
                     viewModel.requestMiniCharts(forRange: hotAreaRange.range)
                 }
             }


### PR DESCRIPTION
Сейчас в приложении если загружено больше 200 монет и мы переключаем интервал - происходит перезапрос по всем токенам, в тоге бэк присылает ошибку, что слишком много элементов. В андроиде перезапрашиваются только видимые страницы, у них все по страницам считается, видимая область тоже определяет какие страницы сейчас отображаются. Графики для новых страниц при скролле как и раньше грузятся сразу после загрузки страницы (в андроиде такая же логика)

* добавил подписку на видимую область, чтобы при переключении интервала происходила перезагрузка только для видимой области + буфер
* обновил логику загрузки мини-графиков, теперь дата провайдер отслеживает для кого он сейчас загружает информацию и не перезапрашивает эти данные.
* так же подкрутил сохранение графиков, был бажок, что графики не сохранялись и при каждом переключении интервалов постоянно перезапрашивались графики.
* так же сделал на всякий случай загрузку мини-графиков группами, если вдруг запросили больше 200 элементов
* если какой-то мини-график не загрузился из-за ошибки, при сдвиге видимой области перезапросится ещё разок и появится, если не будет ошибки снова.