### PR TITLE
IOS-7855: [Markets] Add delay to token quotes repo cleanup

### DIFF
--- a/Tangem/App/Services/TokenQuotesRepository/CommonTokenQuotesRepository.swift
+++ b/Tangem/App/Services/TokenQuotesRepository/CommonTokenQuotesRepository.swift
@@ -134,11 +134,17 @@ private extension CommonTokenQuotesRepository {
             .store(in: &bag)
 
         userWalletRepository.eventProvider
-            .withWeakCaptureOf(self)
-            .sink { repository, event in
-                if case .locked = event {
-                    repository.clearRepository()
+            .filter {
+                if case .locked = $0 {
+                    return true
                 }
+
+                return false
+            }
+            .delay(for: 0.5, scheduler: DispatchQueue.main)
+            .withWeakCaptureOf(self)
+            .sink { repository, _ in
+                repository.clearRepository()
             }
             .store(in: &bag)
     }

--- a/Tangem/App/Services/TokenQuotesRepository/CommonTokenQuotesRepository.swift
+++ b/Tangem/App/Services/TokenQuotesRepository/CommonTokenQuotesRepository.swift
@@ -141,6 +141,8 @@ private extension CommonTokenQuotesRepository {
 
                 return false
             }
+            // We need to postpone repository cleanup because currently all rows are depends on this data
+            // and logout logic is not triggering immediately, so on main screen missing values can appear
             .delay(for: 0.5, scheduler: DispatchQueue.main)
             .withWeakCaptureOf(self)
             .sink { repository, _ in


### PR DESCRIPTION
Из-за логаута у нас в приложении очищаются ранее загруженные квоты, поэтому все токены сбрасывают свой стейт и показывают прочерки, во время логаута. Добавил небольшую задержку, чтобы успел произойти переход на экран авторизации