### PR TITLE
IOS-7669: [Markets] Sync picker action with content switch

### DIFF
--- a/Tangem/Modules/Markets/TokenList/MarketsItemView.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsItemView.swift
@@ -67,10 +67,8 @@ struct MarketsItemView: View {
                         .cornerRadiusContinuous(4)
                 }
 
-                if let marketCap = viewModel.marketCap {
-                    Text(marketCap)
-                        .style(Fonts.Regular.caption1, color: Colors.Text.tertiary)
-                }
+                Text(viewModel.marketCap)
+                    .style(Fonts.Regular.caption1, color: Colors.Text.tertiary)
             }
         }
     }
@@ -129,6 +127,7 @@ extension MarketsItemView {
                 viewModel: .init(
                     index: index,
                     tokenModel: token,
+                    marketCapFormatter: .init(divisorsList: AmountNotationSuffixFormatter.Divisor.defaultList, baseCurrencyCode: "USD", notationFormatter: .init()),
                     prefetchDataSource: nil,
                     chartsProvider: .init(),
                     filterProvider: .init(),

--- a/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
@@ -48,6 +48,7 @@ final class MarketsViewModel: ObservableObject {
 
     private lazy var listDataController: MarketsListDataController = .init(dataFetcher: self, cellsStateUpdater: self)
 
+    private var marketCapFormatter: MarketCapFormatter
     private var bag = Set<AnyCancellable>()
     private var currentSearchValue: String = ""
     private var showItemsBelowCapThreshold: Bool = false
@@ -66,12 +67,15 @@ final class MarketsViewModel: ObservableObject {
         self.quotesRepositoryUpdateHelper = quotesRepositoryUpdateHelper
         self.coordinator = coordinator
 
+        marketCapFormatter = .init(divisorsList: AmountNotationSuffixFormatter.Divisor.defaultList, baseCurrencyCode: AppSettings.shared.selectedCurrencyCode, notationFormatter: DefaultAmountNotationFormatter())
+
         marketsRatingHeaderViewModel = MarketsRatingHeaderViewModel(provider: filterProvider)
         marketsRatingHeaderViewModel.delegate = self
 
         searchTextBind(searchTextPublisher: searchTextPublisher)
         searchFilterBind(filterPublisher: filterProvider.filterPublisher)
 
+        bindToCurrencyCodeUpdate()
         dataProviderBind()
         bindToHotArea()
 
@@ -171,6 +175,17 @@ private extension MarketsViewModel {
                     let hotAreaRange = viewModel.listDataController.hotArea
                     viewModel.requestMiniCharts(forRange: hotAreaRange.range)
                 }
+            }
+            .store(in: &bag)
+    }
+
+    func bindToCurrencyCodeUpdate() {
+        AppSettings.shared.$selectedCurrencyCode
+            .withWeakCaptureOf(self)
+            .sink { viewModel, newCurrencyCode in
+                viewModel.marketCapFormatter = .init(divisorsList: AmountNotationSuffixFormatter.Divisor.defaultList, baseCurrencyCode: newCurrencyCode, notationFormatter: .init())
+                viewModel.dataProvider.reset()
+                viewModel.fetch(with: viewModel.currentSearchValue, by: viewModel.filterProvider.currentFilterValue)
             }
             .store(in: &bag)
     }
@@ -310,6 +325,7 @@ private extension MarketsViewModel {
         return MarketsItemViewModel(
             index: index,
             tokenModel: tokenItemModel,
+            marketCapFormatter: marketCapFormatter,
             prefetchDataSource: listDataController,
             chartsProvider: chartsHistoryProvider,
             filterProvider: filterProvider,


### PR DESCRIPTION
* Убрал задержку, которая не давала сразу переключиться на новый график
* Вынес форматтер маркет капа и заюзал те же сущности, что и в деталке токена
* добавил подписку на изменение валюты приложения, чтобы если пользователь поменяет её можно было сразу загрузить данные с новой валютой.

https://github.com/user-attachments/assets/83b766d9-3c0c-40c4-82df-503d46563892

