### PR TITLE
IOS-7873 Fix swap issues

### DIFF
--- a/Tangem/App/Factories/ExpressModulesFactory/CommonExpressModulesFactory.swift
+++ b/Tangem/App/Factories/ExpressModulesFactory/CommonExpressModulesFactory.swift
@@ -190,8 +190,6 @@ private extension CommonExpressModulesFactory {
             analyticsLogger: analyticsLogger
         )
 
-        let transactionDispatcher = SendTransactionDispatcherFactory(walletModel: initialWalletModel, signer: signer).makeSendDispatcher()
-
         let interactor = ExpressInteractor(
             userWalletId: userWalletId,
             initialWallet: initialWalletModel,
@@ -203,7 +201,7 @@ private extension CommonExpressModulesFactory {
             expressDestinationService: expressDestinationService,
             expressTransactionBuilder: expressTransactionBuilder,
             expressAPIProvider: expressAPIProvider,
-            transactionDispatcher: transactionDispatcher,
+            signer: signer,
             logger: logger
         )
 

--- a/Tangem/Modules/ExpressApprove/ExpressApproveViewModel.swift
+++ b/Tangem/Modules/ExpressApprove/ExpressApproveViewModel.swift
@@ -185,7 +185,7 @@ private extension ExpressApproveViewModel {
             do {
                 try await viewModel.expressInteractor.sendApproveTransaction()
                 await viewModel.didSendApproveTransaction()
-            } catch TangemSdkError.userCancelled {
+            } catch SendTransactionDispatcherResult.Error.userCancelled {
                 // Do nothing
             } catch {
                 viewModel.logger.error(error)

--- a/Tangem/Modules/ExpressView/ExpressViewModel.swift
+++ b/Tangem/Modules/ExpressView/ExpressViewModel.swift
@@ -619,7 +619,7 @@ private extension ExpressViewModel {
                 try Task.checkCancellation()
 
                 await root.openSuccessView(sentTransactionData: sentTransactionData)
-            } catch TangemSdkError.userCancelled {
+            } catch SendTransactionDispatcherResult.Error.userCancelled {
                 root.restartTimer()
             } catch let error as ExpressAPIError {
                 await runOnMain {

--- a/Tangem/Modules/Send/SendTransactionDispatcher/SendTransactionDispatcher.swift
+++ b/Tangem/Modules/Send/SendTransactionDispatcher/SendTransactionDispatcher.swift
@@ -31,7 +31,7 @@ struct SendTransactionDispatcherResult: Hashable {
 }
 
 extension SendTransactionDispatcherResult {
-    enum Error: Swift.Error {
+    enum Error: Swift.Error, LocalizedError {
         case informationRelevanceServiceError
         case informationRelevanceServiceFeeWasIncreased
 
@@ -41,5 +41,24 @@ extension SendTransactionDispatcherResult {
 
         case demoAlert
         case stakingUnsupported
+
+        var errorDescription: String? {
+            switch self {
+            case .sendTxError(_, let error):
+                return error.localizedDescription
+            case .demoAlert:
+                return "Demo mode"
+            case .informationRelevanceServiceError:
+                return "Service error"
+            case .informationRelevanceServiceFeeWasIncreased:
+                return "Fee was increased"
+            case .stakingUnsupported:
+                return "Staking unsupported"
+            case .transactionNotFound:
+                return "Transaction not found"
+            case .userCancelled:
+                return "User cancelled"
+            }
+        }
     }
 }

--- a/Tangem/Preview Content/Mocks/Express/ExpressModulesFactoryMock.swift
+++ b/Tangem/Preview Content/Mocks/Express/ExpressModulesFactoryMock.swift
@@ -179,7 +179,7 @@ private extension ExpressModulesFactoryMock {
             expressDestinationService: expressDestinationService,
             expressTransactionBuilder: expressTransactionBuilder,
             expressAPIProvider: expressAPIProvider,
-            transactionDispatcher: CommonSendTransactionDispatcher(walletModel: initialWalletModel, transactionSigner: signer),
+            signer: signer,
             logger: logger
         )
 


### PR DESCRIPTION
- При смене токенов местами, нужно пересоздавать диспатчер. Он не пересоздавался и использовался от initialWaleltModel
- Изменился тип ошибки userCancelled, поэтому не игнорировался alert
- Description ошибки от сенд диспатчера не учитывал вложенную ошибку, поэтому это путало на скринах