### PR TITLE
IOS-7704 Use `cachedAmount` in `CommonSendAmountInteractor`

### DIFF
--- a/Tangem/Modules/Send/Amount/SendAmountViewModel.swift
+++ b/Tangem/Modules/Send/Amount/SendAmountViewModel.swift
@@ -90,6 +90,7 @@ class SendAmountViewModel: ObservableObject {
 private extension SendAmountViewModel {
     func bind() {
         $amountType
+            .dropFirst()
             .removeDuplicates()
             .withWeakCaptureOf(self)
             .receive(on: DispatchQueue.main)


### PR DESCRIPTION
Была проблема что амаунт терялся если у нас была ошибка, и при нажатии на переключатель неоткуда было брать данные