### PR TITLE
IOS-7910: [Markets] Fix App freezes on navigation to main

### DIFF
--- a/Tangem/Modules/Markets/TokenList/MarketsItemView.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsItemView.swift
@@ -12,27 +12,30 @@ import SwiftUI
 struct MarketsItemView: View {
     @ObservedObject var viewModel: MarketsItemViewModel
 
-    @State private var textBlockSize: CGSize = .zero
-    private let iconSize = CGSize(bothDimensions: 36)
+    let cellWidth: CGFloat
+
+    private var textBlockWidth: CGFloat {
+        let textWidth = cellWidth - Constants.widthNeededForItemsExceptTextBlock
+        return textWidth
+    }
 
     var body: some View {
         Button(action: {
             viewModel.didTapAction?()
         }) {
-            HStack(spacing: 10) {
-                IconView(url: viewModel.imageURL, size: iconSize, forceKingfisher: true)
-                    .padding(.trailing, 2)
+            HStack(spacing: Constants.itemsHorizontalSpacing) {
+                IconView(url: viewModel.imageURL, size: Constants.imageSize, forceKingfisher: true)
+                    .padding(.trailing, Constants.imageTrailingPadding)
 
                 VStack(spacing: 3) {
                     tokenInfoView
 
                     tokenMarketPriceView
                 }
-                .readGeometry(\.size, bindTo: $textBlockSize)
 
                 priceHistoryView
             }
-            .padding(.horizontal, 16)
+            .padding(.horizontal, Constants.horizontalViewPadding)
             .padding(.vertical, 14)
             .onAppear {
                 viewModel.onAppear()
@@ -44,7 +47,7 @@ struct MarketsItemView: View {
     }
 
     private var tokenInfoView: some View {
-        HStack(alignment: .firstTextBaseline, spacing: .zero) {
+        HStack(alignment: .firstTextBaseline, spacing: Constants.textBlockItemsSpacing) {
             HStack(alignment: .firstTextBaseline, spacing: 4) {
                 Text(viewModel.name)
                     .lineLimit(1)
@@ -55,9 +58,7 @@ struct MarketsItemView: View {
                     .lineLimit(1)
                     .style(Fonts.Regular.caption1, color: Colors.Text.tertiary)
             }
-            .frame(minWidth: 0.3 * textBlockSize.width, alignment: .leading)
-
-            Spacer(minLength: Constants.spacerLength)
+            .frame(minWidth: 0.3 * textBlockWidth, maxWidth: .infinity, alignment: .leading)
 
             Text(viewModel.priceValue)
                 .lineLimit(1)
@@ -73,7 +74,7 @@ struct MarketsItemView: View {
 
     private var tokenMarketPriceView: some View {
         HStack(spacing: .zero) {
-            HStack(alignment: .firstTextBaseline, spacing: 6) {
+            HStack(alignment: .firstTextBaseline, spacing: Constants.textBlockItemsSpacing) {
                 if let marketRating = viewModel.marketRating {
                     Text(marketRating)
                         .style(Fonts.Regular.caption1, color: Colors.Text.tertiary)
@@ -83,9 +84,7 @@ struct MarketsItemView: View {
                 Text(viewModel.marketCap)
                     .style(Fonts.Regular.caption1, color: Colors.Text.tertiary)
             }
-            .frame(minWidth: 0.32 * textBlockSize.width, alignment: .leading)
-
-            Spacer(minLength: Constants.spacerLength)
+            .frame(minWidth: 0.32 * textBlockWidth, maxWidth: .infinity, alignment: .leading)
 
             TokenPriceChangeView(state: viewModel.priceChangeState)
         }
@@ -102,7 +101,7 @@ struct MarketsItemView: View {
                 makeSkeletonView(by: Constants.skeletonMediumWidthValue)
             }
         }
-        .frame(width: 56, height: 24, alignment: .center)
+        .frame(size: Constants.chartSize, alignment: .center)
     }
 
     private func makeSkeletonView(by value: String) -> some View {
@@ -114,28 +113,38 @@ struct MarketsItemView: View {
 
 extension MarketsItemView {
     enum Constants {
-        static let spacerLength = 8.0
+        static let textBlockItemsSpacing = 8.0
+        static let horizontalViewPadding: CGFloat = 16.0
+        static let imageSize: CGSize = .init(bothDimensions: 36)
+        static let imageTrailingPadding: CGFloat = 2
+        static let itemsHorizontalSpacing: CGFloat = 12.0
+        static let chartSize: CGSize = .init(width: 56, height: 24)
         static let skeletonMediumWidthValue: String = "---------"
         static let skeletonSmallWidthValue: String = "------"
+
+        static let widthNeededForItemsExceptTextBlock: CGFloat = horizontalViewPadding * 2 + imageSize.width + chartSize.width + itemsHorizontalSpacing * 2 + imageTrailingPadding
     }
 }
 
 #Preview {
     let tokens = DummyMarketTokenModelFactory().list()
 
-    return ScrollView(.vertical) {
-        ForEach(tokens.indexed(), id: \.1.id) { index, token in
-            MarketsItemView(
-                viewModel: .init(
-                    index: index,
-                    tokenModel: token,
-                    marketCapFormatter: .init(divisorsList: AmountNotationSuffixFormatter.Divisor.defaultList, baseCurrencyCode: "USD", notationFormatter: .init()),
-                    prefetchDataSource: nil,
-                    chartsProvider: .init(),
-                    filterProvider: .init(),
-                    onTapAction: nil
+    return GeometryReader { proxy in
+        ScrollView(.vertical) {
+            ForEach(tokens.indexed(), id: \.1.id) { index, token in
+                MarketsItemView(
+                    viewModel: .init(
+                        index: index,
+                        tokenModel: token,
+                        marketCapFormatter: .init(divisorsList: AmountNotationSuffixFormatter.Divisor.defaultList, baseCurrencyCode: "USD", notationFormatter: .init()),
+                        prefetchDataSource: nil,
+                        chartsProvider: .init(),
+                        filterProvider: .init(),
+                        onTapAction: nil
+                    ),
+                    cellWidth: proxy.size.width
                 )
-            )
+            }
         }
     }
 }

--- a/Tangem/Modules/Markets/TokenList/MarketsView.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsView.swift
@@ -14,6 +14,7 @@ struct MarketsView: View {
     @ObservedObject var viewModel: MarketsViewModel
 
     @Environment(\.overlayContentContainer) private var overlayContentContainer
+    @Environment(\.mainWindowSize) private var mainWindowSize
 
     @StateObject private var navigationControllerConfigurator = MarketsViewNavigationControllerConfigurator()
 
@@ -171,7 +172,7 @@ struct MarketsView: View {
 
                     LazyVStack(spacing: 0) {
                         ForEach(viewModel.tokenViewModels) {
-                            MarketsItemView(viewModel: $0)
+                            MarketsItemView(viewModel: $0, cellWidth: mainWindowSize.width)
                         }
 
                         // Need for display list skeleton view


### PR DESCRIPTION
Проблема была в том, что ридер размера попадал в цикл в моменты навигации на главную и происходили постоянные перерисовки ячейки `MarketsItemView`. Убрал ридер из ячеек. В целом все значения вокруг константы, поэтому сделал статичный расчет места нужного для остальных элементов и отступов, все остальное должен занимать блок текста.
Немного обновил верстку, т.к. то тут то там возникали проблемы обрезания текста, хотя место было для него.

@m3g0byt3 если есть возможность, попробуй с ветки собрать и потыкать. У меня больше не зависало, ни при переходе на главную, ни при скролле в шторке, ни при возвращению на главную