### PR TITLE
IOS-7848: Fix Markets view on click visual issue

### DIFF
--- a/Tangem/UIComponents/MarketPriceView/MarketPriceView.swift
+++ b/Tangem/UIComponents/MarketPriceView/MarketPriceView.swift
@@ -20,8 +20,10 @@ struct MarketPriceView: View {
             Button(action: tapAction) {
                 marketPriceView
             }
+            .defaultRoundedBackground()
         } else {
             marketPriceView
+                .defaultRoundedBackground()
         }
     }
 
@@ -65,9 +67,6 @@ struct MarketPriceView: View {
                 }
             }
         }
-        .padding(14)
-        .background(Colors.Background.primary)
-        .cornerRadiusContinuous(14)
     }
 
     @ViewBuilder


### PR DESCRIPTION
перенес бэкграунд. Запрос был чтобы при нажатии выглядело как нажатие на историю транзакций

https://github.com/user-attachments/assets/26272709-ba19-4d61-98e4-1766eaad287b