### PR TITLE
IOS-7931: Fix bottom sheet layout issue, update markdown rules

### DIFF
--- a/Tangem/UIComponents/DescriptionBottomSheet/DescriptionBottomSheetView.swift
+++ b/Tangem/UIComponents/DescriptionBottomSheet/DescriptionBottomSheetView.swift
@@ -49,8 +49,17 @@ struct DescriptionBottomSheetView: View {
 
             Markdown { info.description }
                 .markdownSoftBreakMode(.lineBreak)
+                .markdownTextStyle(\.text, textStyle: {
+                    FontFamily(.system())
+                    FontWeight(.regular)
+                    FontSize(16)
+                    ForegroundColor(Colors.Text.primary1)
+                })
+                .markdownBlockStyle(\.paragraph, body: { configuration in
+                    configuration.label
+                        .relativeLineSpacing(.em(0.2))
+                })
                 .frame(maxWidth: .infinity, alignment: .topLeading)
-                .style(Fonts.Regular.callout, color: Colors.Text.primary1)
                 .fixedSize(horizontal: false, vertical: true)
                 .multilineTextAlignment(.leading)
         }

--- a/Tangem/UIComponents/DetentBottonSheet/SelfSizeableVariant/SelfSizingBottomSheetContainer.swift
+++ b/Tangem/UIComponents/DetentBottonSheet/SelfSizeableVariant/SelfSizingBottomSheetContainer.swift
@@ -36,8 +36,6 @@ struct SelfSizingDetentBottomSheetContainer<ContentView: View & SelfSizingBottom
             sheetContent
                 .frame(minWidth: mainWindowSize.width)
         }
-        .frame(alignment: .top) // TODO: Remove this frame when migrate to minimum iOS 16.
-        .ignoresSafeArea(edges: .bottom)
         .readGeometry(onChange: { geometry in
             containerHeight = geometry.size.height
         })
@@ -50,15 +48,20 @@ struct SelfSizingDetentBottomSheetContainer<ContentView: View & SelfSizingBottom
         let content = content()
             .setContentHeightBinding($contentHeight)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        let scrollDisabled = bottomSheetHeight <= containerHeight
 
         return Group {
-            if containerHeight < bottomSheetHeight {
-                ScrollView(showsIndicators: false) {
+            if #available(iOS 16.0, *) {
+                ScrollView(.vertical, showsIndicators: false) {
                     content
                         .padding(.bottom, scrollViewBottomOffset)
                 }
+                .scrollDisabled(scrollDisabled)
             } else {
-                content
+                ScrollView(scrollDisabled ? [] : .vertical, showsIndicators: false) {
+                    content
+                        .padding(.bottom, scrollViewBottomOffset)
+                }
             }
         }
     }


### PR DESCRIPTION
Немного поменял иерархию, на самом деле это важно только для 16 оси, т.к. в 15 оси нет возможности использовать sheet с определенной высотой, либо на весь экран, либо на половину. 
Немного подкрутил форматирование в маркдаун тексте, т.к. были проблемы, что он неправильно отображался. Ждем теперь апдейта на бэке, когда новые заголовки начнут присылать

https://github.com/user-attachments/assets/4c968f0e-e487-4311-931b-558cfaad4a92

https://github.com/user-attachments/assets/619d5872-5241-41a5-a134-1b656ab7c7bf

