### PR TITLE
IOS-7917: Fix issue with two coins/list requests on launch

### DIFF
--- a/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
@@ -182,6 +182,7 @@ private extension MarketsViewModel {
 
     func bindToCurrencyCodeUpdate() {
         AppSettings.shared.$selectedCurrencyCode
+            .dropFirst()
             .withWeakCaptureOf(self)
             .sink { viewModel, newCurrencyCode in
                 viewModel.marketCapFormatter = .init(divisorsList: AmountNotationSuffixFormatter.Divisor.defaultList, baseCurrencyCode: newCurrencyCode, notationFormatter: .init())


### PR DESCRIPTION
дважды запрашивался список, эта подписка нужна на случай если пользователь поменяет валюту приложения и надо будет перезапросить список, чтобы обновить маркет капы на новую валюту приложения