### PR TITLE
IOS-7944: Remove quotes update logic before markets list opened

### DIFF
--- a/Tangem/App/Services/TangemApiService/TangemApiTarget.swift
+++ b/Tangem/App/Services/TangemApiService/TangemApiTarget.swift
@@ -235,7 +235,7 @@ extension TangemApiTarget {
 extension TangemApiTarget: CachePolicyProvider {
     var cachePolicy: URLRequest.CachePolicy {
         switch type {
-        case .geo, .features, .apiList:
+        case .geo, .features, .apiList, .quotes, .coinsList, .tokenMarketsDetails:
             return .reloadIgnoringLocalAndRemoteCacheData
         default:
             return .useProtocolCachePolicy

--- a/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
@@ -272,8 +272,13 @@ private extension MarketsViewModel {
                     viewModel.tokenViewModels.removeAll()
                     viewModel.resetScrollPositionPublisher.send(())
                     viewModel.isDataProviderBusy = true
-                    viewModel.quotesUpdatesScheduler.resetUpdates()
                     viewModel.quotesUpdatesScheduler.saveQuotesUpdateDate(Date())
+
+                    guard viewModel.isBottomSheetExpanded else {
+                        return
+                    }
+
+                    viewModel.quotesUpdatesScheduler.resetUpdates()
                 default:
                     break
                 }


### PR DESCRIPTION
До открытия шторки запускался перезапрос квот, хотя должен только при открытой шторке.
так же запрос на квоты не каждый раз улетал, т.к. данные брались из кэша. Убрал кэш для квот, списка маркетсов и деталки токена, чтобы всегда актуальная инфа загружалась
@m3g0byt3 думаю для графиков не обязательно прям форсить перезагрузку, т.к. эта инфа не так часто обновляется