### PR TITLE
IOS-7951: Update markets token details null values parsing rules

### DIFF
--- a/Tangem/App/Models/Markets/Mappers/MarketsTokenDetailsLinksMapper.swift
+++ b/Tangem/App/Models/Markets/Mappers/MarketsTokenDetailsLinksMapper.swift
@@ -13,13 +13,26 @@ struct MarketsTokenDetailsLinksMapper {
 
     let openLinkAction: (MarketsTokenDetailsLinks.LinkInfo) -> Void
 
-    func mapToSections(_ links: MarketsTokenDetailsLinks) -> [TokenMarketsDetailsLinkSection] {
-        return [
-            .init(section: .officialLinks, chips: mapLinksToChips(links.officialLinks)),
-            .init(section: .social, chips: mapLinksToChips(links.social)),
-            .init(section: .repository, chips: mapLinksToChips(links.repository)),
-            .init(section: .blockchainSite, chips: mapLinksToChips(links.blockchainSite)),
-        ]
+    func mapToSections(_ links: MarketsTokenDetailsLinks?) -> [TokenMarketsDetailsLinkSection] {
+        guard let links else {
+            return []
+        }
+
+        var sections = [TokenMarketsDetailsLinkSection]()
+        if let officialLinks = links.officialLinks {
+            sections.append(.init(section: .officialLinks, chips: mapLinksToChips(officialLinks)))
+        }
+        if let socialLinks = links.social {
+            sections.append(.init(section: .social, chips: mapLinksToChips(socialLinks)))
+        }
+        if let repositoryLinks = links.repository {
+            sections.append(.init(section: .repository, chips: mapLinksToChips(repositoryLinks)))
+        }
+        if let blockchainSiteLinks = links.blockchainSite {
+            sections.append(.init(section: .blockchainSite, chips: mapLinksToChips(blockchainSiteLinks)))
+        }
+
+        return sections
     }
 
     private func mapLinksToChips(_ links: [MarketsTokenDetailsLinks.LinkInfo]) -> [MarketsTokenDetailsLinkChipsData] {

--- a/Tangem/App/Models/Markets/Mappers/TokenMarketsDetailsMapper.swift
+++ b/Tangem/App/Models/Markets/Mappers/TokenMarketsDetailsMapper.swift
@@ -40,20 +40,16 @@ struct TokenMarketsDetailsMapper {
     // MARK: - Private Implementation
 
     private func mapPriceChangePercentage(response: MarketsDTO.Coins.Response) throws -> [String: Decimal] {
-        var percentage = response.priceChangePercentage
-
-        guard let allTimeValue = percentage[MarketsPriceIntervalType.all.rawValue] else {
+        // We need to specify that our target type is Decimal, otherwise it will be Decimal?
+        guard let allTimeValue = response.priceChangePercentage[MarketsPriceIntervalType.all.rawValue] as? Decimal else {
             throw MapperError.missingAllTimePriceChangeValue
         }
 
-        MarketsPriceIntervalType.allCases.forEach {
-            guard percentage[$0.rawValue] == nil else {
-                return
-            }
-
-            percentage[$0.rawValue] = allTimeValue
+        return MarketsPriceIntervalType.allCases.reduce(into: [:]) {
+            let key = $1.rawValue
+            // We need to specify that our target type is Decimal, otherwise it will be Decimal?
+            $0[key] = (response.priceChangePercentage[key] as? Decimal) ?? allTimeValue
         }
-        return percentage
     }
 
     private func mapPricePerformance(response: MarketsDTO.Coins.Response) -> [MarketsPriceIntervalType: MarketsPricePerformanceData]? {

--- a/Tangem/App/Models/Markets/MarketsDTO+Coin.swift
+++ b/Tangem/App/Models/Markets/MarketsDTO+Coin.swift
@@ -30,9 +30,9 @@ extension MarketsDTO.Coins {
         let shortDescription: String?
         let fullDescription: String?
         let insights: Insights?
-        let links: MarketsTokenDetailsLinks
+        let links: MarketsTokenDetailsLinks?
         let metrics: MarketsTokenDetailsMetrics?
-        let pricePerformance: [String: MarketsPricePerformanceData]
+        let pricePerformance: [String: MarketsPricePerformanceData]?
     }
 
     struct Insights: Codable {

--- a/Tangem/App/Models/Markets/MarketsDTO+Coin.swift
+++ b/Tangem/App/Models/Markets/MarketsDTO+Coin.swift
@@ -25,7 +25,8 @@ extension MarketsDTO.Coins {
         let symbol: String
         let active: Bool
         let currentPrice: Decimal
-        let priceChangePercentage: [String: Decimal]
+        // We need to use here Decimal? otherwise iOS 17.6 and iOS 18 Beta can't parse response with null values
+        let priceChangePercentage: [String: Decimal?]
         let networks: [NetworkModel]?
         let shortDescription: String?
         let fullDescription: String?

--- a/Tangem/App/Models/Markets/MarketsPricePerformanceData.swift
+++ b/Tangem/App/Models/Markets/MarketsPricePerformanceData.swift
@@ -9,6 +9,6 @@
 import Foundation
 
 struct MarketsPricePerformanceData: Codable, Equatable {
-    let lowPrice: Decimal
-    let highPrice: Decimal
+    let lowPrice: Decimal?
+    let highPrice: Decimal?
 }

--- a/Tangem/App/Models/Markets/MarketsTokenDetailsLinks.swift
+++ b/Tangem/App/Models/Markets/MarketsTokenDetailsLinks.swift
@@ -9,10 +9,10 @@
 import Foundation
 
 struct MarketsTokenDetailsLinks: Codable, Equatable {
-    let officialLinks: [LinkInfo]
-    let social: [LinkInfo]
-    let repository: [LinkInfo]
-    let blockchainSite: [LinkInfo]
+    let officialLinks: [LinkInfo]?
+    let social: [LinkInfo]?
+    let repository: [LinkInfo]?
+    let blockchainSite: [LinkInfo]?
 }
 
 extension MarketsTokenDetailsLinks {

--- a/Tangem/App/Models/Markets/TokenMarketsDetailsModel.swift
+++ b/Tangem/App/Models/Markets/TokenMarketsDetailsModel.swift
@@ -19,8 +19,8 @@ struct TokenMarketsDetailsModel: Identifiable {
     let priceChangePercentage: [String: Decimal]
     let insights: TokenMarketsDetailsInsights?
     let metrics: MarketsTokenDetailsMetrics?
-    let pricePerformance: [MarketsPriceIntervalType: MarketsPricePerformanceData]
-    let links: MarketsTokenDetailsLinks
+    let pricePerformance: [MarketsPriceIntervalType: MarketsPricePerformanceData]?
+    let links: MarketsTokenDetailsLinks?
     let availableNetworks: [NetworkModel]
 }
 

--- a/Tangem/Modules/Markets/Providers/MarketsTokenDetailsDataProvider.swift
+++ b/Tangem/Modules/Markets/Providers/MarketsTokenDetailsDataProvider.swift
@@ -33,7 +33,7 @@ struct MarketsTokenDetailsDataProvider {
             language: languageCode ?? defaultLanguageCode
         )
         let result = try await tangemAPIService.loadTokenMarketsDetails(requestModel: request)
-        let model = mapper.map(response: result)
+        let model = try mapper.map(response: result)
         return model
     }
 }

--- a/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/PricePerformance/MarketsTokenDetailsPricePerformanceViewModel.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/PricePerformance/MarketsTokenDetailsPricePerformanceViewModel.swift
@@ -60,13 +60,20 @@ class MarketsTokenDetailsPricePerformanceViewModel: ObservableObject {
     }
 
     private func updateProgressUI(currentPrice: Decimal, selectedInterval: MarketsPriceIntervalType) {
-        guard let performanceData = pricePerformanceData[selectedInterval] else {
+        guard
+            let performanceData = pricePerformanceData[selectedInterval],
+            let lowPrice = performanceData.lowPrice,
+            let highPrice = performanceData.highPrice
+        else {
+            pricePerformanceProgress = 0
+            lowValue = priceFormatter.formatPrice(nil)
+            highValue = priceFormatter.formatPrice(nil)
             return
         }
 
-        let decimalProgress = Math().inverseLerp(from: performanceData.lowPrice, to: performanceData.highPrice, value: currentPrice) as NSDecimalNumber
+        lowValue = priceFormatter.formatPrice(lowPrice)
+        highValue = priceFormatter.formatPrice(highPrice)
+        let decimalProgress = Math().inverseLerp(from: lowPrice, to: highPrice, value: currentPrice) as NSDecimalNumber
         pricePerformanceProgress = CGFloat(decimalProgress.doubleValue)
-        lowValue = priceFormatter.formatPrice(performanceData.lowPrice)
-        highValue = priceFormatter.formatPrice(performanceData.highPrice)
     }
 }

--- a/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsViewModel.swift
@@ -380,15 +380,17 @@ private extension TokenMarketsDetailsViewModel {
             )
         }
 
-        let pricePerformanceCurrentPricePublisher = currentPricePublisher
-            .compactMap { $0 }
-            .eraseToAnyPublisher()
+        if let pricePerformance = model.pricePerformance {
+            let pricePerformanceCurrentPricePublisher = currentPricePublisher
+                .compactMap { $0 }
+                .eraseToAnyPublisher()
 
-        pricePerformanceViewModel = .init(
-            tokenSymbol: model.symbol,
-            pricePerformanceData: model.pricePerformance,
-            currentPricePublisher: pricePerformanceCurrentPricePublisher
-        )
+            pricePerformanceViewModel = .init(
+                tokenSymbol: model.symbol,
+                pricePerformanceData: pricePerformance,
+                currentPricePublisher: pricePerformanceCurrentPricePublisher
+            )
+        }
 
         linksSections = MarketsTokenDetailsLinksMapper(
             openLinkAction: weakify(self, forFunction: TokenMarketsDetailsViewModel.openLinkAction(_:))


### PR DESCRIPTION
Обновил парсинг данных, если пришли null для разных блоков. Изменения:
* Если в процентах приходит `null` для какого-либо значения, подставляем туда всегда из `all_time`
* Блок ссылок может не прийти, или какие-то части его могут не прийти, поэтому обновился парсинг и правила отображения
* блок `Price Performance` может не содержать данные по каким-то интервалам и внутри интервалов может не быть одного значения, в таком случае оба значения отображаются прочерками и прогресс на 0
* если не пришло значение изменения цены в процентах за все время - показываем что не удалось загрузить данные