### PR TITLE
IOS-7817: Fix links layout issue, fix empty links array

### DIFF
--- a/Tangem/App/Models/Markets/Mappers/MarketsTokenDetailsLinksMapper.swift
+++ b/Tangem/App/Models/Markets/Mappers/MarketsTokenDetailsLinksMapper.swift
@@ -19,16 +19,16 @@ struct MarketsTokenDetailsLinksMapper {
         }
 
         var sections = [TokenMarketsDetailsLinkSection]()
-        if let officialLinks = links.officialLinks {
+        if let officialLinks = links.officialLinks, !officialLinks.isEmpty {
             sections.append(.init(section: .officialLinks, chips: mapLinksToChips(officialLinks)))
         }
-        if let socialLinks = links.social {
+        if let socialLinks = links.social, !socialLinks.isEmpty {
             sections.append(.init(section: .social, chips: mapLinksToChips(socialLinks)))
         }
-        if let repositoryLinks = links.repository {
+        if let repositoryLinks = links.repository, !repositoryLinks.isEmpty {
             sections.append(.init(section: .repository, chips: mapLinksToChips(repositoryLinks)))
         }
-        if let blockchainSiteLinks = links.blockchainSite {
+        if let blockchainSiteLinks = links.blockchainSite, !blockchainSiteLinks.isEmpty {
             sections.append(.init(section: .blockchainSite, chips: mapLinksToChips(blockchainSiteLinks)))
         }
 

--- a/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/Links/MarketsTokenDetailsChipsContainer.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/Links/MarketsTokenDetailsChipsContainer.swift
@@ -53,6 +53,11 @@ struct MarketsTokenDetailsChipsContainer: View {
                     return result
                 }
             }
+
+            // We need this view to fix items vertical alignment.
+            // SwiftUI on iOS 18 not correctly align elements in ZStack, it moves items up O_o
+            Color.clear
+                .frame(width: 1)
         })
     }
 }


### PR DESCRIPTION
* Исправлен бажок верстки для 18 оси, проверил на остальных все нормально
* Так же убрал пустые блоки ссылок

https://github.com/user-attachments/assets/43d92382-8f1f-4763-ad63-a0b1f1892af7

