### PR TITLE
IOS-7995: [Markets] Search input and clear events update

### DIFF
--- a/Tangem/Modules/Main/MainBottomSheet/Header/MainBottomSheetHeaderViewModel.swift
+++ b/Tangem/Modules/Main/MainBottomSheet/Header/MainBottomSheetHeaderViewModel.swift
@@ -10,14 +10,23 @@ import Foundation
 import Combine
 
 final class MainBottomSheetHeaderViewModel: ObservableObject {
-    var enteredSearchTextPublisher: AnyPublisher<String, Never> {
-        return $enteredSearchText.eraseToAnyPublisher()
+    var enteredSearchInputPublisher: AnyPublisher<SearchInput, Never> {
+        searchInputSubject.eraseToAnyPublisher()
     }
 
     @Published var enteredSearchText = ""
     @Published var inputShouldBecomeFocused = false
 
+    private let searchInputSubject = CurrentValueSubject<SearchInput, Never>(.textInput(""))
+    private var shouldSkipNextTextInput = false
+
+    private var inputSubscription: AnyCancellable?
+
     weak var delegate: MainBottomSheetHeaderViewModelDelegate?
+
+    init() {
+        bind()
+    }
 
     func onBottomSheetExpand(isTapGesture: Bool) {
         guard
@@ -31,7 +40,53 @@ final class MainBottomSheetHeaderViewModel: ObservableObject {
     }
 
     func clearSearchBarAction() {
-        delegate?.clearSearchInput()
+        if enteredSearchText.isEmpty {
+            return
+        }
+
+        searchInputSubject.send(.clearInput)
+        shouldSkipNextTextInput = true
         enteredSearchText = ""
+    }
+
+    private func bind() {
+        inputSubscription = $enteredSearchText
+            .removeDuplicates()
+            .withWeakCaptureOf(self)
+            .filter { viewModel, input in
+                if viewModel.shouldSkipNextTextInput {
+                    viewModel.shouldSkipNextTextInput = false
+                    return false
+                }
+
+                return true
+            }
+            .map { SearchInput.textInput($1) }
+            .assign(to: \.value, on: searchInputSubject, ownership: .weak)
+    }
+}
+
+extension MainBottomSheetHeaderViewModel {
+    enum SearchInput: Equatable {
+        case textInput(String)
+        case clearInput
+
+        var textValue: String? {
+            switch self {
+            case .textInput(let textInput): return textInput
+            case .clearInput: return nil
+            }
+        }
+
+        static func == (lhs: SearchInput, rhs: SearchInput) -> Bool {
+            switch (lhs, rhs) {
+            case (.textInput(let lhsText), .textInput(let rhsText)):
+                return lhsText.compare(rhsText) == .orderedSame
+            case (.clearInput, .clearInput):
+                return true
+            default:
+                return false
+            }
+        }
     }
 }

--- a/Tangem/Modules/Main/MainBottomSheet/Header/MainBottomSheetHeaderViewModelDelegate.swift
+++ b/Tangem/Modules/Main/MainBottomSheet/Header/MainBottomSheetHeaderViewModelDelegate.swift
@@ -9,6 +9,5 @@
 import Foundation
 
 protocol MainBottomSheetHeaderViewModelDelegate: AnyObject {
-    func clearSearchInput()
     func isViewVisibleForHeaderViewModel(_ viewModel: MainBottomSheetHeaderViewModel) -> Bool
 }

--- a/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
@@ -13,6 +13,8 @@ import CombineExt
 import Kingfisher
 
 final class MarketsViewModel: BaseMarketsViewModel {
+    private typealias SearchInput = MainBottomSheetHeaderViewModel.SearchInput
+
     // MARK: - Injected & Published Properties
 
     @Published var alert: AlertBinder?
@@ -91,7 +93,7 @@ final class MarketsViewModel: BaseMarketsViewModel {
         headerViewModel.delegate = self
         marketsRatingHeaderViewModel.delegate = self
 
-        searchTextBind(searchTextPublisher: headerViewModel.enteredSearchTextPublisher)
+        searchTextBind(publisher: headerViewModel.enteredSearchInputPublisher)
         searchFilterBind(filterPublisher: filterProvider.filterPublisher)
 
         bindToCurrencyCodeUpdate()
@@ -148,7 +150,7 @@ final class MarketsViewModel: BaseMarketsViewModel {
     }
 
     func onTryLoadList() {
-        resetUI()
+        resetShowItemsBelowCapFlag()
         fetch(with: currentSearchValue, by: filterProvider.currentFilterValue)
     }
 
@@ -164,29 +166,43 @@ private extension MarketsViewModel {
         dataProvider.fetch(searchText, with: filter)
     }
 
-    func searchTextBind(searchTextPublisher: (some Publisher<String, Never>)?) {
-        searchTextPublisher?
-            .dropFirst()
+    private func searchTextBind(publisher: some Publisher<SearchInput, Never>) {
+        publisher
             .debounce(for: 0.5, scheduler: DispatchQueue.main)
+            /// Ensure that clear input event will be delivered immediately
+            .merge(with: publisher.filter { $0 == .clearInput })
             .removeDuplicates()
             .withWeakCaptureOf(self)
-            .sink { viewModel, value in
-                guard viewModel.isBottomSheetExpanded else {
-                    return
+            .sink { viewModel, searchInput in
+                switch searchInput {
+                case .textInput(let value):
+                    guard viewModel.isBottomSheetExpanded else {
+                        return
+                    }
+
+                    if viewModel.currentSearchValue != value {
+                        viewModel.resetShowItemsBelowCapFlag()
+                    }
+
+                    viewModel.currentSearchValue = value
+                    let currentFilter = viewModel.dataProvider.lastFilterValue ?? viewModel.filterProvider.currentFilterValue
+
+                    // Always use rating sorting for search
+                    let searchFilter = MarketsListDataProvider.Filter(
+                        interval: currentFilter.interval,
+                        order: value.isEmpty ? currentFilter.order : .rating
+                    )
+
+                    viewModel.fetch(with: value, by: searchFilter)
+                case .clearInput:
+                    if viewModel.currentSearchValue.isEmpty {
+                        return
+                    }
+
+                    viewModel.resetShowItemsBelowCapFlag()
+                    viewModel.currentSearchValue = ""
+                    viewModel.fetch(with: "", by: viewModel.filterProvider.currentFilterValue)
                 }
-
-                if viewModel.currentSearchValue != value {
-                    viewModel.resetUI()
-                }
-
-                viewModel.currentSearchValue = value
-
-                let currentFilter = viewModel.dataProvider.lastFilterValue ?? viewModel.filterProvider.currentFilterValue
-
-                // Always use rating sorting for search
-                let searchFilter = MarketsListDataProvider.Filter(interval: currentFilter.interval, order: value.isEmpty ? currentFilter.order : .rating)
-
-                viewModel.fetch(with: value, by: searchFilter)
             }
             .store(in: &bag)
     }
@@ -395,7 +411,7 @@ private extension MarketsViewModel {
         imageCache.memoryStorage.config.countLimit = 250
     }
 
-    func resetUI() {
+    func resetShowItemsBelowCapFlag() {
         showItemsBelowCapThreshold = false
     }
 }
@@ -415,11 +431,6 @@ extension MarketsViewModel: MarketsListDataFetcher {
 }
 
 extension MarketsViewModel: MainBottomSheetHeaderViewModelDelegate {
-    func clearSearchInput() {
-        dataProvider.reset()
-        currentSearchValue = ""
-    }
-
     func isViewVisibleForHeaderViewModel(_ viewModel: MainBottomSheetHeaderViewModel) -> Bool {
         return isViewVisible
     }

--- a/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
@@ -168,6 +168,7 @@ private extension MarketsViewModel {
 
     private func searchTextBind(publisher: some Publisher<SearchInput, Never>) {
         publisher
+            .dropFirst()
             .debounce(for: 0.5, scheduler: DispatchQueue.main)
             /// Ensure that clear input event will be delivered immediately
             .merge(with: publisher.filter { $0 == .clearInput })
@@ -176,11 +177,7 @@ private extension MarketsViewModel {
             .sink { viewModel, searchInput in
                 switch searchInput {
                 case .textInput(let value):
-                    guard viewModel.isBottomSheetExpanded else {
-                        return
-                    }
-
-                    if viewModel.currentSearchValue != value {
+                    if viewModel.currentSearchValue.compare(value) != .orderedSame {
                         viewModel.resetShowItemsBelowCapFlag()
                     }
 


### PR DESCRIPTION
Поменял подход к обработке событий от поля ввода
* нам надо знать когда пользователь очищает через крестик или кнопку `Cancel`, если таким способом - надо сразу сбрасывать результаты и перезапрашивать данные
* был бажок, что если набирать текст и быстро сбросить поиск через крестик - текст поиска очищался, но запрос отправлялся и в итоге при пустом поиске приходили данные по введенному тексту, поэтому добавилось несколько фильтраций
* добавил несколько фильтраций пустых значений, чтобы лишнее не спамилось. Проверял через проксю вроде все хорошо, без лишних запросов одной и той же инфы и загрузки лишних страниц на старте.

https://github.com/user-attachments/assets/b129ecb9-a435-4d98-936e-08f706bd75b3

https://github.com/user-attachments/assets/34565356-6276-4a07-91e0-b0883884f929

