### PR TITLE
IOS-7997: [Markets] Disable unnecessary keyboard avoidance

### DIFF
--- a/Tangem/Modules/App/AppCoordinatorView.swift
+++ b/Tangem/Modules/App/AppCoordinatorView.swift
@@ -45,7 +45,8 @@ struct AppCoordinatorView: CoordinatorView {
                 boundaryMarker: { viewHierarchySnapshotter },
                 content: { marketsCoordinatorView }
             )
-            .ignoresSafeArea(.container, edges: .bottom)
+            // Ensures that this is a full-screen container and keyboard avoidance is disabled to mitigate IOS-7997
+            .ignoresSafeArea(.all, edges: .bottom)
         }
         .bottomSheet(
             item: $sensitiveTextVisibilityViewModel.informationHiddenBalancesViewModel,


### PR DESCRIPTION
[IOS-7997](https://tangem.atlassian.net/browse/IOS-7997)

Привнеслось с добавлением `ViewHierarchySnapshottingContainerViewController` и `UIAppearanceBoundaryContainerView`

Чекнул - на обоих экранах все ок с safe area
<img width="350" src="https://github.com/user-attachments/assets/fda94345-b111-4800-96d2-be4731493ef7">
<img width="350" src="https://github.com/user-attachments/assets/259cf1ab-be72-44c5-a9a2-7c82fea3f1b3">
<img width="350" src="https://github.com/user-attachments/assets/8ad6fca3-fabe-404a-8212-2789da8df4ff">


[IOS-7997]: https://tangem.atlassian.net/browse/IOS-7997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ