### PR TITLE
IOS-8006: [Markets] Do not update footer snapshots on logout

### DIFF
--- a/Tangem/Modules/App/AppCoordinator.swift
+++ b/Tangem/Modules/App/AppCoordinator.swift
@@ -178,7 +178,7 @@ class AppCoordinator: CoordinatorObject {
 
         if FeatureProvider.isAvailable(.markets) {
             marketsCoordinator = nil
-            mainBottomSheetUIManager.hide()
+            mainBottomSheetUIManager.hide(shouldUpdateFooterSnapshot: false)
         }
 
         let options = AppCoordinator.Options(newScan: newScan)

--- a/Tangem/Modules/Main/MainBottomSheet/Other/MainBottomSheetUIManager.swift
+++ b/Tangem/Modules/Main/MainBottomSheet/Other/MainBottomSheetUIManager.swift
@@ -30,8 +30,15 @@ extension MainBottomSheetUIManager {
         isShownSubject.send(true)
     }
 
-    func hide() {
+    func hide(shouldUpdateFooterSnapshot: Bool = true) {
         ensureOnMainQueue()
+
+        let isShown = false
+
+        guard shouldUpdateFooterSnapshot else {
+            isShownSubject.send(isShown)
+            return
+        }
 
         setFooterSnapshotNeedsUpdate { [weak self] in
             // Workaround: delaying hiding main bottom sheet roughly for the duration of one frame so that the UI
@@ -39,7 +46,7 @@ extension MainBottomSheetUIManager {
             // Dispatching to the next runloop tick (via `DispatchQueue.main.async`) doesn't work reliably enough
             // because not every runloop tick is used for rendering.
             DispatchQueue.main.asyncAfter(deadline: .now() + Constants.mainBottomSheetHidingDelay) {
-                self?.isShownSubject.send(false)
+                self?.isShownSubject.send(isShown)
             }
         }
     }


### PR DESCRIPTION
[IOS-8006](https://tangem.atlassian.net/browse/IOS-8006)

Фикс в слепую, но внутри CALayer есть несколько эксепшенов, которые тригеррятся при невалидной геометрии (inf или ноль) и креши по симптомам похож на них

[IOS-8006]: https://tangem.atlassian.net/browse/IOS-8006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ