### PR TITLE
IOS-8013: Fix manage tokens loader and selection coloring

### DIFF
--- a/Tangem/Modules/LegacyTokenList/ListDataLoader.swift
+++ b/Tangem/Modules/LegacyTokenList/ListDataLoader.swift
@@ -35,7 +35,7 @@ class ListDataLoader {
     // MARK: Private Properties
 
     // Tracks last page loaded. Used to load next page (current + 1)
-    private var currentPage = 0
+    private var currentPageIndex = 0
 
     // Limit of records per page
     private let perPage = 50
@@ -61,7 +61,7 @@ class ListDataLoader {
 
         canFetchMore = true
         items = []
-        currentPage = 0
+        currentPageIndex = 0
         lastSearchText = searchText
         cachedSearch = [:]
     }
@@ -96,8 +96,8 @@ class ListDataLoader {
             try Task.checkCancellation()
 
             // If count of data received is less than perPage value then it is last page.
-            if currentPage < totalPages {
-                currentPage += 1
+            if (currentPageIndex + 1) < totalPages {
+                currentPageIndex += 1
             } else {
                 canFetchMore = false
             }
@@ -187,7 +187,7 @@ private extension ListDataLoader {
     }
 
     func getPage(for items: [CoinModel]) -> [CoinModel] {
-        Array(items.dropFirst(currentPage * perPage).prefix(perPage))
+        Array(items.dropFirst(currentPageIndex * perPage).prefix(perPage))
     }
 
     func map(

--- a/Tangem/UIComponents/ManageTokensListView/ListItems/ManageTokensListItemView.swift
+++ b/Tangem/UIComponents/ManageTokensListView/ListItems/ManageTokensListItemView.swift
@@ -19,18 +19,13 @@ struct ManageTokensListItemView: View {
     @State private var isExpanded = false
 
     private var symbolFormatted: String { "  \(viewModel.symbol)" }
-    private var isSaturated: Bool {
-        isReadOnly ||
-            isExpanded ||
-            viewModel.items.contains(where: { $0.isSelected })
-    }
 
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 0) {
                 IconView(url: viewModel.imageURL, size: CGSize(width: iconWidth, height: iconWidth), forceKingfisher: true)
                     .padding(.trailing, 12)
-                    .saturation(isSaturated ? 1.0 : 0.0)
+                    .saturation((isReadOnly || viewModel.atLeastOneTokenSelected) ? 1.0 : 0.0)
 
                 VStack(alignment: .leading, spacing: 2) {
                     Group {


### PR DESCRIPTION
* неправильно считались есть ещё что загрузить или нет, называлось страницей, а являлось индексом, поменял название на `currentPageIndex` и обновил проверку, чтобы сильно не переделывать
* так же обновил логику покраски иконок в `Manage Tokens`, чтобы иконки становились цветными только если выбрана хотя бы одна сеть

https://github.com/user-attachments/assets/815ce536-172c-470d-be0e-3a3fc8b2b3a0

