### PR TITLE
IOS-8020: Fix BTC RU locale links layout issue

### DIFF
--- a/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/Links/MarketsTokenDetailsChipsContainer.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/Subviews/Links/MarketsTokenDetailsChipsContainer.swift
@@ -26,6 +26,8 @@ struct MarketsTokenDetailsChipsContainer: View {
         var height = CGFloat.zero
         ZStack(alignment: .topLeading, content: {
             ForEach(chipsData) { data in
+                let isFirstItem = data.id == chipsData.first?.id
+                let isLastItem = data.id == chipsData.last?.id
                 MarketsTokenDetailsLinkChipsView(
                     text: data.text,
                     icon: data.icon,
@@ -33,12 +35,15 @@ struct MarketsTokenDetailsChipsContainer: View {
                     action: data.action
                 )
                 .alignmentGuide(.leading) { dimension in
+                    if isFirstItem {
+                        width = 0
+                    }
                     if abs(width - dimension.width) > parentWidth {
                         width = 0
                         height -= dimension.height + verticalItemsSpacing
                     }
                     let result = width
-                    if data.id == chipsData.last?.id {
+                    if isLastItem {
                         width = 0
                     } else {
                         width -= dimension.width + horizontalItemsSpacing
@@ -46,8 +51,11 @@ struct MarketsTokenDetailsChipsContainer: View {
                     return result
                 }
                 .alignmentGuide(.top) { dimension in
+                    if isFirstItem {
+                        height = 0
+                    }
                     let result = height
-                    if data.id == chipsData.last?.id {
+                    if isLastItem {
                         height = 0
                     }
                     return result


### PR DESCRIPTION
Почему-то для битка на русской локали не сбрасывалась рассчитываемая высота, в результате получалась большая дырка под блоками с больше чем одной строкой. Причем что забавно было только у битка, смотрел ещё у эфира, usdt, solana... В общем, магия...

до фикса
<img width="300" src="https://github.com/user-attachments/assets/c3f1b86c-f2ad-450f-a8a8-5b2766100b31">

после фикса
<img width="300" src="https://github.com/user-attachments/assets/831283db-04f2-4096-9b9d-883f6f37bd0b">
