### PR TITLE
IOS-8022: Add minimum scale for picker item

### DIFF
--- a/Tangem/UIComponents/SegmentPickerView/SegmentedPicker.swift
+++ b/Tangem/UIComponents/SegmentPickerView/SegmentedPicker.swift
@@ -36,6 +36,7 @@ struct SegmentedPicker<Option: Hashable & Identifiable>: View {
     private func segmentView(title: String, isSelected: Bool) -> some View {
         ZStack(alignment: .center) {
             Text(title)
+                .minimumScaleFactor(0.9)
                 .font(Fonts.Bold.footnote)
                 .foregroundStyle(Colors.Text.primary1)
                 .opacity(isSelected ? 1.0 : 0.0)


### PR DESCRIPTION
На маленьких устройствах (mini, se, 11 pro) текстовка могла не влезать в пикер, когда он растянут на весь экран и много кейсов. Добавил небольшой скейл для жирного текста

<img width="300" alt="image" src="https://github.com/user-attachments/assets/d072bc42-ad11-4cca-886a-59de7c65551c">
