### PR TITLE
IOS-8030: Add text scaling to token details title

### DIFF
--- a/Tangem/Common/UI/Navigation/NavigationBar.swift
+++ b/Tangem/Common/UI/Navigation/NavigationBar.swift
@@ -80,8 +80,8 @@ struct NavigationBar<LeftButtons: View, RightButtons: View>: View {
         struct Title {
             var font: Font = .system(size: 17, weight: .medium)
             var color: Color = Colors.Old.tangemGrayDark6
-            var lineLimit: Int? = nil
-            var minimumScaleFactor: CGFloat = 1
+            var lineLimit: Int? = nil // Default system value
+            var minimumScaleFactor: CGFloat = 1 // Default system value
         }
 
         let title: Title

--- a/Tangem/Common/UI/Navigation/NavigationBar.swift
+++ b/Tangem/Common/UI/Navigation/NavigationBar.swift
@@ -123,7 +123,7 @@ struct NavigationBar<LeftButtons: View, RightButtons: View>: View {
     }
 
     var body: some View {
-        HStack {
+        HStack(alignment: .firstTextBaseline) {
             leftButtons
                 .layoutPriority(1)
 

--- a/Tangem/Common/UI/Navigation/NavigationBar.swift
+++ b/Tangem/Common/UI/Navigation/NavigationBar.swift
@@ -77,23 +77,27 @@ struct SupportButton: View {
 
 struct NavigationBar<LeftButtons: View, RightButtons: View>: View {
     struct Settings {
-        let titleFont: Font
-        let titleColor: Color
+        struct Title {
+            var font: Font = .system(size: 17, weight: .medium)
+            var color: Color = Colors.Old.tangemGrayDark6
+            var lineLimit: Int? = nil
+            var minimumScaleFactor: CGFloat = 1
+        }
+
+        let title: Title
         let backgroundColor: Color
         let horizontalPadding: CGFloat
         let height: CGFloat
         let alignment: Alignment
 
         init(
-            titleFont: Font = .system(size: 17, weight: .medium),
-            titleColor: Color = Colors.Old.tangemGrayDark6,
+            title: Title = .init(),
             backgroundColor: Color = Colors.Old.tangemBgGray,
             horizontalPadding: CGFloat = 0,
             height: CGFloat = 44,
             alignment: Alignment = .center
         ) {
-            self.titleFont = titleFont
-            self.titleColor = titleColor
+            self.title = title
             self.backgroundColor = backgroundColor
             self.horizontalPadding = horizontalPadding
             self.height = height
@@ -119,15 +123,23 @@ struct NavigationBar<LeftButtons: View, RightButtons: View>: View {
     }
 
     var body: some View {
-        ZStack {
-            HStack {
-                leftButtons
+        HStack {
+            leftButtons
+                .layoutPriority(1)
+
+            ZStack {
                 Spacer()
-                rightButtons
+                    .layoutPriority(1)
+
+                Text(title)
+                    .font(settings.title.font)
+                    .foregroundColor(settings.title.color)
+                    .lineLimit(settings.title.lineLimit)
+                    .minimumScaleFactor(settings.title.minimumScaleFactor)
             }
-            Text(title)
-                .font(settings.titleFont)
-                .foregroundColor(settings.titleColor)
+
+            rightButtons
+                .layoutPriority(1)
         }
         .padding(.horizontal, settings.horizontalPadding)
         .frame(height: settings.height, alignment: settings.alignment)

--- a/Tangem/Common/UI/Navigation/NavigationBar.swift
+++ b/Tangem/Common/UI/Navigation/NavigationBar.swift
@@ -123,23 +123,17 @@ struct NavigationBar<LeftButtons: View, RightButtons: View>: View {
     }
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline) {
-            leftButtons
-                .layoutPriority(1)
+        ZStack {
+            HStack {
+                leftButtons
 
-            ZStack {
                 Spacer()
-                    .layoutPriority(1)
 
-                Text(title)
-                    .font(settings.title.font)
-                    .foregroundColor(settings.title.color)
-                    .lineLimit(settings.title.lineLimit)
-                    .minimumScaleFactor(settings.title.minimumScaleFactor)
+                rightButtons
             }
 
-            rightButtons
-                .layoutPriority(1)
+            Text(title)
+                .style(settings.title.font, color: settings.title.color)
         }
         .padding(.horizontal, settings.horizontalPadding)
         .frame(height: settings.height, alignment: settings.alignment)

--- a/Tangem/Common/UI/Navigation/NavigationBar.swift
+++ b/Tangem/Common/UI/Navigation/NavigationBar.swift
@@ -110,6 +110,8 @@ struct NavigationBar<LeftButtons: View, RightButtons: View>: View {
     private let leftButtons: LeftButtons
     private let rightButtons: RightButtons
 
+    @State private var titleHorizontalPadding: CGFloat = 0.0
+
     init(
         title: String,
         settings: Settings = .init(),
@@ -124,16 +126,36 @@ struct NavigationBar<LeftButtons: View, RightButtons: View>: View {
 
     var body: some View {
         ZStack {
-            HStack {
+            HStack(spacing: 0.0) {
                 leftButtons
+                    .readGeometry(\.size.width) { newValue in
+                        if newValue > titleHorizontalPadding {
+                            titleHorizontalPadding = newValue
+                        }
+                    }
 
                 Spacer()
 
                 rightButtons
+                    .readGeometry(\.size.width) { newValue in
+                        if newValue > titleHorizontalPadding {
+                            titleHorizontalPadding = newValue
+                        }
+                    }
             }
 
-            Text(title)
-                .style(settings.title.font, color: settings.title.color)
+            HStack(spacing: 0.0) {
+                FixedSpacer.horizontal(titleHorizontalPadding)
+                    .layoutPriority(1)
+
+                Text(title)
+                    .style(settings.title.font, color: settings.title.color)
+                    .lineLimit(settings.title.lineLimit)
+                    .minimumScaleFactor(settings.title.minimumScaleFactor)
+
+                FixedSpacer.horizontal(titleHorizontalPadding)
+                    .layoutPriority(1)
+            }
         }
         .padding(.horizontal, settings.horizontalPadding)
         .frame(height: settings.height, alignment: settings.alignment)

--- a/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsView.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsView.swift
@@ -68,7 +68,9 @@ struct TokenMarketsDetailsView: View {
             NavigationBar(
                 title: viewModel.tokenName,
                 settings: .init(
-                    titleColor: Colors.Text.primary1,
+                    title: .init(
+                        color: Colors.Text.primary1
+                    ),
                     backgroundColor: .clear, // Controlled by the `background` modifier in the body
                     height: 64.0,
                     alignment: .bottom

--- a/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsView.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsView.swift
@@ -82,7 +82,7 @@ struct TokenMarketsDetailsView: View {
                     makeBackButton(action: viewModel.onBackButtonTap)
                 },
                 rightItems: {
-                    // Invisible view for centering the title label
+                    // Dummy invisible back button for centering the title label
                     makeBackButton(action: {})
                         .hidden()
                 }

--- a/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsView.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsView.swift
@@ -78,13 +78,14 @@ struct TokenMarketsDetailsView: View {
                     height: 64.0,
                     alignment: .bottom
                 ),
-                leftItems: {
-                    makeBackButton(action: viewModel.onBackButtonTap)
-                },
-                rightItems: {
-                    // Dummy invisible back button for centering the title label
-                    makeBackButton(action: {})
-                        .hidden()
+                leftButtons: {
+                    BackButton(
+                        height: 44.0,
+                        isVisible: true,
+                        isEnabled: true,
+                        hPadding: 10.0,
+                        action: viewModel.onBackButtonTap
+                    )
                 }
             )
             .overlay(alignment: .bottom) {
@@ -95,11 +96,6 @@ struct TokenMarketsDetailsView: View {
                 .hidden(!isNavigationBarShadowLineViewVisible)
             }
         }
-    }
-
-    @ViewBuilder
-    private func makeBackButton(action: @escaping () -> Void) -> some View {
-        BackButton(height: 44.0, isVisible: true, isEnabled: true, hPadding: 10.0, action: action)
     }
 
     @ViewBuilder

--- a/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsView.swift
+++ b/Tangem/Modules/Markets/TokenMarketsDetails/TokenMarketsDetailsView.swift
@@ -69,16 +69,23 @@ struct TokenMarketsDetailsView: View {
                 title: viewModel.tokenName,
                 settings: .init(
                     title: .init(
-                        color: Colors.Text.primary1
+                        font: Fonts.Bold.body,
+                        color: Colors.Text.primary1,
+                        lineLimit: 1,
+                        minimumScaleFactor: 0.6
                     ),
                     backgroundColor: .clear, // Controlled by the `background` modifier in the body
                     height: 64.0,
                     alignment: .bottom
                 ),
                 leftItems: {
-                    BackButton(height: 44.0, isVisible: true, isEnabled: true, action: viewModel.onBackButtonTap)
+                    makeBackButton(action: viewModel.onBackButtonTap)
                 },
-                rightItems: {}
+                rightItems: {
+                    // Invisible view for centering the title label
+                    makeBackButton(action: {})
+                        .hidden()
+                }
             )
             .overlay(alignment: .bottom) {
                 Separator(
@@ -88,6 +95,11 @@ struct TokenMarketsDetailsView: View {
                 .hidden(!isNavigationBarShadowLineViewVisible)
             }
         }
+    }
+
+    @ViewBuilder
+    private func makeBackButton(action: @escaping () -> Void) -> some View {
+        BackButton(height: 44.0, isVisible: true, isEnabled: true, hPadding: 10.0, action: action)
     }
 
     @ViewBuilder

--- a/Tangem/Modules/Onboarding/Note/SingleCardOnboardingView.swift
+++ b/Tangem/Modules/Onboarding/Note/SingleCardOnboardingView.swift
@@ -62,7 +62,10 @@ struct SingleCardOnboardingView: View {
                     ZStack(alignment: .center) {
                         NavigationBar(
                             title: viewModel.navbarTitle,
-                            settings: .init(titleFont: .system(size: 17, weight: .semibold), backgroundColor: .clear),
+                            settings: .init(
+                                title: .init(font: .system(size: 17, weight: .semibold)),
+                                backgroundColor: .clear
+                            ),
                             leftItems: {
                                 BackButton(
                                     height: viewModel.navbarSize.height,

--- a/Tangem/Modules/Onboarding/Twins/TwinsOnboardingView.swift
+++ b/Tangem/Modules/Onboarding/Twins/TwinsOnboardingView.swift
@@ -68,7 +68,10 @@ struct TwinsOnboardingView: View {
                         // and cards jumps instead of smooth transition
                         NavigationBar(
                             title: viewModel.navbarTitle,
-                            settings: .init(titleFont: .system(size: 17, weight: .semibold), backgroundColor: .clear),
+                            settings: .init(
+                                title: .init(font: .system(size: 17, weight: .semibold)),
+                                backgroundColor: .clear
+                            ),
                             leftItems: {
                                 BackButton(
                                     height: viewModel.navbarSize.height,

--- a/Tangem/Modules/Onboarding/Wallet/WalletOnboardingView.swift
+++ b/Tangem/Modules/Onboarding/Wallet/WalletOnboardingView.swift
@@ -98,7 +98,10 @@ struct WalletOnboardingView: View {
                         // and cards jumps instead of smooth transition
                         NavigationBar(
                             title: viewModel.navbarTitle,
-                            settings: .init(titleFont: .system(size: 17, weight: .semibold), backgroundColor: .clear),
+                            settings: .init(
+                                title: .init(font: .system(size: 17, weight: .semibold)),
+                                backgroundColor: .clear
+                            ),
                             leftItems: {
                                 BackButton(
                                     height: viewModel.navbarSize.height,


### PR DESCRIPTION
[IOS-8030](https://tangem.atlassian.net/browse/IOS-8030)

Оказалось легче чем я думал, так как я забыл, что на этом экране кастомный навбар)

default
<img width="350" src="https://github.com/user-attachments/assets/45ddb75f-9b59-475d-be90-7936007ebdbe">

scaled
<img width="350" src="https://github.com/user-attachments/assets/4146db2a-066f-45bf-9723-8172b351d5e8">


[IOS-8030]: https://tangem.atlassian.net/browse/IOS-8030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ