### PR TITLE
IOS-8021: Add reloading logic when mini chart didn't loaded

### DIFF
--- a/Tangem/Modules/SingleTokenBase/SingleTokenBaseViewModel.swift
+++ b/Tangem/Modules/SingleTokenBase/SingleTokenBaseViewModel.swift
@@ -69,6 +69,8 @@ class SingleTokenBaseViewModel: NotificationTapDelegate {
     lazy var pendingTransactionRecordMapper = PendingTransactionRecordMapper(formatter: BalanceFormatter())
     lazy var miniChartsProvider = MarketsListChartsHistoryProvider()
 
+    private let miniChartPriceIntervalType = MarketsPriceIntervalType.day
+
     init(
         userWalletModel: UserWalletModel,
         walletModel: WalletModel,
@@ -128,7 +130,7 @@ class SingleTokenBaseViewModel: NotificationTapDelegate {
         Analytics.log(.refreshed)
 
         if let id = walletModel.tokenItem.id, miniChartsProvider.items.isEmpty {
-            miniChartsProvider.fetch(for: [id], with: .day)
+            miniChartsProvider.fetch(for: [id], with: miniChartPriceIntervalType)
         }
 
         isReloadingTransactionHistory = true
@@ -313,12 +315,15 @@ extension SingleTokenBaseViewModel {
             miniChartData = .failedToLoad(error: "")
             return
         }
-        miniChartsProvider.fetch(for: [id], with: .day)
+        miniChartsProvider.fetch(for: [id], with: miniChartPriceIntervalType)
 
         miniChartsProvider.$items
             .dropFirst()
             .receive(on: DispatchQueue.main)
-            .compactMap { $0[id]?[.day] }
+            .withWeakCaptureOf(self)
+            .compactMap { viewModel, items in
+                items[id]?[viewModel.miniChartPriceIntervalType]
+            }
             .withWeakCaptureOf(self)
             .sink { viewModel, chartsData in
                 viewModel.updateMiniChartState(using: chartsData)

--- a/Tangem/Modules/SingleTokenBase/SingleTokenBaseViewModel.swift
+++ b/Tangem/Modules/SingleTokenBase/SingleTokenBaseViewModel.swift
@@ -127,6 +127,10 @@ class SingleTokenBaseViewModel: NotificationTapDelegate {
 
         Analytics.log(.refreshed)
 
+        if let id = walletModel.tokenItem.id, miniChartsProvider.items.isEmpty {
+            miniChartsProvider.fetch(for: [id], with: .day)
+        }
+
         isReloadingTransactionHistory = true
         updateSubscription = walletModel.generalUpdate(silent: false)
             .receive(on: DispatchQueue.main)


### PR DESCRIPTION
добавил перезагрузку данных по мини-графику на ptr, если данные не были загружены. Сам по себе график не обновляем, если он загрузился

https://github.com/user-attachments/assets/d46fde87-827d-4725-9b3a-f30963cbb23f

