### PR TITLE
IOS-8024 mini chart crash

### DIFF
--- a/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
@@ -246,6 +246,7 @@ private extension MarketsViewModel {
             .dropFirst()
             .debounce(for: 0.3, scheduler: DispatchQueue.main)
             .removeDuplicates()
+            .receive(on: DispatchQueue.global(qos: .userInitiated))
             .map { $0.range }
             .withWeakCaptureOf(self)
             .sink { viewModel, hotAreaRange in


### PR DESCRIPTION
стэк краша указывает на старт таски загрузки мини-графиков, а таска может стартовать и на основном потоке, немного понизил приоритет загрузки мини-графиков. Судя по логам пользователь не делал ничего сверхестественного, просто переключил интервал.