### PR TITLE
IOS-8068: Fix for search with only under market cap tokens

### DIFF
--- a/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
@@ -348,7 +348,7 @@ private extension MarketsViewModel {
 
                 viewModel.tokenViewModels.append(contentsOf: items)
 
-                if viewModel.tokenViewModels.isEmpty {
+                if viewModel.dataProvider.items.isEmpty {
                     viewModel.tokenListLoadingState = .noResults
                     return
                 }


### PR DESCRIPTION
обновил логику, теперь отображается кнопка для поисков, когда приходят только токены с капитализацией ниже 100к

https://github.com/user-attachments/assets/78a3b7a0-0584-49e3-a052-006957a6c840

