### PR TITLE
IOS-7593: Do not clip currency on the send summary screen

### DIFF
--- a/Tangem/Modules/Send/Amount/Interactor/SendAmount.swift
+++ b/Tangem/Modules/Send/Amount/Interactor/SendAmount.swift
@@ -24,29 +24,6 @@ struct SendAmount: Hashable {
         }
     }
 
-    func format(
-        currencySymbol: String,
-        balanceFormatter: BalanceFormatter = .init(),
-        decimalCount: Int
-    ) -> String? {
-        switch type {
-        case .typical(let crypto, _):
-            guard let crypto else {
-                return BalanceFormatter.defaultEmptyBalanceString
-            }
-
-            let formatter = SendCryptoValueFormatter(
-                decimals: decimalCount,
-                currencySymbol: currencySymbol,
-                trimFractions: true
-            )
-
-            return formatter.string(from: crypto)
-        case .alternative(let fiat, _):
-            return fiat.map { balanceFormatter.formatFiatBalance($0) }
-        }
-    }
-
     func formatAlternative(
         currencySymbol: String,
         balanceFormatter: BalanceFormatter = .init(),

--- a/Tangem/Modules/Send/Amount/Interactor/SendAmountConverter.swift
+++ b/Tangem/Modules/Send/Amount/Interactor/SendAmountConverter.swift
@@ -27,7 +27,7 @@ struct SendAmountConverter {
             return nil
         }
 
-        let formatter = DecimalNumberFormatter(maximumFractionDigits: 2) // Fiat has 2 FractionDigits
+        let formatter = DecimalNumberFormatter(maximumFractionDigits: SendAmountStep.Constants.fiatMaximumFractionDigits)
         return formatter.format(value: fiatValue)
     }
 }

--- a/Tangem/Modules/Send/Amount/Interactor/SendCryptoValueFormatter.swift
+++ b/Tangem/Modules/Send/Amount/Interactor/SendCryptoValueFormatter.swift
@@ -11,7 +11,7 @@ import Foundation
 /// Formatter that can work around NumberFormatter's limitations on Decimal numbers with currency
 struct SendCryptoValueFormatter {
     private let decimalNumberFormatter: DecimalNumberFormatter
-    private let preffixSuffixOptions: SendDecimalNumberTextField.PrefixSuffixOptions
+    private let prefixSuffixOptions: SendDecimalNumberTextField.PrefixSuffixOptions
     private let trimFractions: Bool
     private let locale: Locale
 
@@ -26,7 +26,7 @@ struct SendCryptoValueFormatter {
             fiatCurrencyCode: "",
             locale: locale
         )
-        preffixSuffixOptions = optionsFactory.makeCryptoOptions()
+        prefixSuffixOptions = optionsFactory.makeCryptoOptions()
 
         self.trimFractions = trimFractions
         self.locale = locale
@@ -38,7 +38,7 @@ struct SendCryptoValueFormatter {
         let formattedAmount = decimalNumberFormatter.format(value: formatterInput)
         let nbsp = AppConstants.unbreakableSpace
 
-        switch preffixSuffixOptions {
+        switch prefixSuffixOptions {
         case .prefix(let text, let hasSpace):
             guard let text else { return nil }
             return text + (hasSpace ? nbsp : "") + formattedAmount

--- a/Tangem/Modules/Send/Amount/SendAmountCompactView/SendAmountCompactView.swift
+++ b/Tangem/Modules/Send/Amount/SendAmountCompactView/SendAmountCompactView.swift
@@ -42,14 +42,13 @@ struct SendAmountCompactView: View {
 
             VStack(alignment: .center, spacing: 6) {
                 ZStack {
-                    Text(viewModel.amount ?? " ")
-                        .style(
-                            DecimalNumberTextField.Appearance().font,
-                            color: DecimalNumberTextField.Appearance().textColor
-                        )
-                        .infinityFrame(axis: .horizontal, alignment: .center)
-                        .minimumScaleFactor(SendAmountStep.Constants.amountMinTextScale)
+                    SendDecimalNumberTextField(viewModel: viewModel.amountDecimalNumberTextFieldViewModel)
+                        .initialFocusBehavior(.noFocus)
+                        .alignment(.center)
+                        .prefixSuffixOptions(viewModel.amountFieldOptions)
+                        .minTextScale(SendAmountStep.Constants.amountMinTextScale)
                         .matchedGeometryEffect(id: namespace.names.amountCryptoText, in: namespace.id)
+                        .allowsHitTesting(false) // This text field is read-only
                 }
                 // We have to keep frame until SendDecimalNumberTextField size fix
                 // Just on appear it has the zero height. Is cause break animation

--- a/Tangem/Modules/Send/Amount/SendAmountViewModel.swift
+++ b/Tangem/Modules/Send/Amount/SendAmountViewModel.swift
@@ -19,7 +19,6 @@ class SendAmountViewModel: ObservableObject {
     let currencyPickerData: SendCurrencyPickerData
 
     @Published var id: UUID = .init()
-    @Published var text: String = ""
 
     @Published var auxiliaryViewsVisible: Bool = true
     @Published var isEditMode: Bool = false

--- a/Tangem/Modules/Send/Amount/SendAmountViewModel.swift
+++ b/Tangem/Modules/Send/Amount/SendAmountViewModel.swift
@@ -172,7 +172,7 @@ private extension SendAmountViewModel {
             decimalNumberTextFieldViewModel.update(value: amount?.crypto)
         case .fiat:
             currentFieldOptions = prefixSuffixOptionsFactory.makeFiatOptions()
-            decimalNumberTextFieldViewModel.update(maximumFractionDigits: 2)
+            decimalNumberTextFieldViewModel.update(maximumFractionDigits: SendAmountStep.Constants.fiatMaximumFractionDigits)
             decimalNumberTextFieldViewModel.update(value: amount?.fiat)
         }
     }

--- a/Tangem/Modules/Send/Destination/SendDestinationViewModel.swift
+++ b/Tangem/Modules/Send/Destination/SendDestinationViewModel.swift
@@ -117,6 +117,7 @@ class SendDestinationViewModel: ObservableObject, Identifiable {
         interactor
             .destinationValid
             .removeDuplicates()
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] destinationValid in
                 self?.showSuggestedDestinations = !destinationValid
             }

--- a/Tangem/Modules/Send/SendSteps/SendAmountStep.swift
+++ b/Tangem/Modules/Send/SendSteps/SendAmountStep.swift
@@ -69,5 +69,7 @@ extension SendAmountStep: SendStep {
 extension SendAmountStep {
     enum Constants {
         static let amountMinTextScale = 0.5
+        /// Fiat always has 2 fraction digits.
+        static let fiatMaximumFractionDigits = 2
     }
 }


### PR DESCRIPTION
[IOS-7593](https://tangem.atlassian.net/browse/IOS-7593)
<img width="350" src="https://github.com/user-attachments/assets/32bfeb1a-1729-41cf-b70a-11134f792ae1">
<img width="350" src="https://github.com/user-attachments/assets/38bba950-082a-47c0-aee4-7d7ec4b95962">


[IOS-7593]: https://tangem.atlassian.net/browse/IOS-7593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ