### PR TITLE
IOS-8070: [Markets] Fix markets view background

### DIFF
--- a/Tangem/Modules/Markets/TokenList/MarketsView.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsView.swift
@@ -67,7 +67,7 @@ struct MarketsView: View {
             .scrollDismissesKeyboardCompat(.immediately)
         }
         .alert(item: $viewModel.alert, content: { $0.alert })
-        .background(Colors.Background.primary)
+        .background(Colors.Background.primary.ignoresSafeArea())
 
         if #available(iOS 17.0, *) {
             content


### PR DESCRIPTION
[IOS-8070](https://tangem.atlassian.net/browse/IOS-8070)

Долго смотрел в другом месте, пробовал убирать промежуточные container VCs типа `UIAppearanceBoundaryContainerView` - но не ожидал что фикс такой примитивный 😂
Фикс также объясняет почему такого поведения нет в светлой теме - потому что в ней дефолтный бэкграунд вьюхи 0xffffffff, такой же как и `Colors.Background.primary` в светлой теме

[IOS-8070]: https://tangem.atlassian.net/browse/IOS-8070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ