### PR TITLE
IOS-8045: Display skeletons when reloading markets list

### DIFF
--- a/Tangem/Modules/Markets/TokenList/MarketsView.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsView.swift
@@ -253,7 +253,7 @@ struct MarketsView: View {
 
     private var errorStateView: some View {
         MarketsUnableToLoadDataView(
-            isButtonBusy: viewModel.isDataProviderBusy,
+            isButtonBusy: false,
             retryButtonAction: viewModel.onTryLoadList
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
@@ -22,7 +22,6 @@ final class MarketsViewModel: MarketsBaseViewModel {
     @Published private(set) var headerViewModel: MainBottomSheetHeaderViewModel
     @Published private(set) var marketsRatingHeaderViewModel: MarketsRatingHeaderViewModel
     @Published private(set) var tokenListLoadingState: MarketsView.ListLoadingState = .idle
-    @Published private(set) var isDataProviderBusy: Bool = false
 
     @Injected(\.mainBottomSheetUIManager) private var mainBottomSheetUIManager: MainBottomSheetUIManager
 
@@ -150,6 +149,7 @@ final class MarketsViewModel: MarketsBaseViewModel {
     }
 
     func onTryLoadList() {
+        tokenListLoadingState = .loading
         resetShowItemsBelowCapFlag()
         fetch(with: currentSearchValue, by: filterProvider.currentFilterValue)
     }
@@ -289,11 +289,9 @@ private extension MarketsViewModel {
                     if oldEvent != .failedToFetchData {
                         viewModel.tokenListLoadingState = .loading
                     }
-                    viewModel.isDataProviderBusy = true
                 case .idle:
-                    viewModel.isDataProviderBusy = false
+                    break
                 case .failedToFetchData:
-                    viewModel.isDataProviderBusy = false
                     if viewModel.dataProvider.items.isEmpty {
                         Analytics.log(.marketsDataError)
                         viewModel.tokenListLoadingState = .error
@@ -305,7 +303,6 @@ private extension MarketsViewModel {
                     viewModel.tokenListLoadingState = .loading
                     viewModel.tokenViewModels.removeAll()
                     viewModel.resetScrollPositionPublisher.send(())
-                    viewModel.isDataProviderBusy = true
                     viewModel.quotesUpdatesScheduler.saveQuotesUpdateDate(Date())
 
                     guard viewModel.isBottomSheetExpanded else {


### PR DESCRIPTION
переключение на скелетоны, когда не удалось загрузить инфу. Попробовал быстренько добавить анимации между переходами, но появляются лишние анимации других элементов, поэтому если и будем что-то менять - будем менять отдельной задачей аккуратно. 

https://github.com/user-attachments/assets/721f2634-761f-4324-b9e8-f26d66e2a0d0

