### PR TITLE
IOS-8214: Fix bottom sheet header not hidden on logout

### DIFF
--- a/Tangem/Modules/Main/MainViewModel.swift
+++ b/Tangem/Modules/Main/MainViewModel.swift
@@ -120,6 +120,11 @@ final class MainViewModel: ObservableObject {
 
     /// Handles `UIKit.UIViewController.viewDidAppear(_:)`.
     func onDidAppear() {
+        // The application is already in a locked state, so no attempts to show bottom sheet should be made
+        guard !isLoggingOut else {
+            return
+        }
+
         let uiManager = mainBottomSheetUIManager
         /// On a `cold start` (e.g., after launching the app or after coming back from the background in a `locked` state:
         /// in both cases a new VM is created), the bottom sheet should become visible with some delay to prevent it from


### PR DESCRIPTION
[IOS-8214](https://tangem.atlassian.net/browse/IOS-8214)

Причина бага в том, что SUI при грохании всей иерархии вьюх главного экрана (`MainView` и все, что на ней) сначала грохает все дочерние вьюхи, которые запрезенчены с этой вьюхи (`MainView`) пушом - а потом уже саму эту вьюху

Что в свою очередь вызывает срабатывание `UIViewController.viewDidAppear(_:)` на `MainView` и показ хедера шита после того, как в `AppCoordinator` его скрыли по причине лока приложения

И из-за этой же причины баг не проявляется, если уйти в бг находясь на главном экране, а не на любом другом, презентованном пушом с главного экрана, экране - потому что в таком случае нет никаких дочерних вьюх, при грохании которых сработал бы `UIViewController.viewDidAppear(_:)` на `MainView` 

[IOS-8214]: https://tangem.atlassian.net/browse/IOS-8214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ