### PR TITLE
IOS-8284: [Markets] Fix token details incorrect bg color

### DIFF
--- a/Tangem/Common/Extensions/Color+.swift
+++ b/Tangem/Common/Extensions/Color+.swift
@@ -148,3 +148,22 @@ extension UIColor {
         )
     }
 }
+
+extension UIColor {
+    var forcedLight: UIColor {
+        resolvedColor(with: .dummyLight)
+    }
+
+    var forcedDark: UIColor {
+        resolvedColor(with: .dummyDark)
+    }
+}
+
+// MARK: - Private implementation
+
+private extension UITraitCollection {
+    /// - Warning: Dummy, do not use as a full-fledged trait collection instance.
+    static let dummyLight = UITraitCollection(userInterfaceStyle: .light)
+    /// - Warning: Dummy, do not use as a full-fledged trait collection instance.
+    static let dummyDark = UITraitCollection(userInterfaceStyle: .dark)
+}

--- a/Tangem/Modules/Markets/MarketsTokenDetails/MarketsTokenDetailsView.swift
+++ b/Tangem/Modules/Markets/MarketsTokenDetails/MarketsTokenDetailsView.swift
@@ -22,11 +22,15 @@ struct MarketsTokenDetailsView: View {
 
     /// `UIColor` is used since `Color(uiColor:)` constructor loses Xcode color asset dark/light appearance setting.
     @available(iOS, deprecated: 18.0, message: "Replace 'UIColor' with 'Color' since 'Color.mix(with:by:in:)' is available")
-    private var defaultBackgroundColor: UIColor { isDarkColorScheme ? UIColor.backgroundPrimary : UIColor.backgroundSecondary }
+    private var defaultBackgroundColor: UIColor {
+        isDarkColorScheme ? UIColor.backgroundPrimary.forcedDark : UIColor.backgroundSecondary.forcedLight
+    }
 
     /// `UIColor` is used since `Color(uiColor:)` constructor loses Xcode color asset dark/light appearance setting.
     @available(iOS, deprecated: 18.0, message: "Replace 'UIColor' with 'Color' since 'Color.mix(with:by:in:)' is available")
-    private var overlayContentHidingBackgroundColor: UIColor { isDarkColorScheme ? defaultBackgroundColor : UIColor.backgroundPlain }
+    private var overlayContentHidingBackgroundColor: UIColor {
+        isDarkColorScheme ? defaultBackgroundColor.forcedDark : UIColor.backgroundPlain.forcedLight
+    }
 
     private let scrollViewFrameCoordinateSpaceName = UUID()
 


### PR DESCRIPTION
[IOS-8284](https://tangem.atlassian.net/browse/IOS-8284)

Классическая проблема с тем, что `UIColor` при конвертации в RGB резолвится с использованием `UITraitCollection.current`, а корректное значение в этой проперти не гарантируется за исключением некоторых мест:

https://developer.apple.com/documentation/uikit/uitraitcollection/3238080-currenttraitcollection

>UIColor implicitly uses the current trait collection when it resolves a dynamic color to a static color value, such as a CGColor or an RGB value. To resolve a dynamic color, make sure that current contains a valid collection. Alternatively, the method resolvedColor(with:) resolves a color from a given trait collection and doesn’t rely on current.

Попробовал подход с `resolvedColor(with:)` - он приводит к задержкам при смене цвета если тема меняется при открытой деталке маркетсов
Поэтому вместо этого юзаются фикс цвета

[IOS-8284]: https://tangem.atlassian.net/browse/IOS-8284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ