### PR TITLE
IOS-8288 [Staking] Fix 'No fee info ..." error display

### DIFF
--- a/Tangem/Modules/Send/StakingModel.swift
+++ b/Tangem/Modules/Send/StakingModel.swift
@@ -95,10 +95,9 @@ private extension StakingModel {
                 model.update(state: .loading)
                 let newState = try await model.state(amount: amount, validator: validator, approvePolicy: model._approvePolicy.value)
                 model.update(state: newState)
+            } catch _ as CancellationError {
+                // Do nothing
             } catch {
-                guard error as? CancellationError == nil else {
-                    return
-                }
                 model.update(state: .networkError(error))
             }
         }

--- a/Tangem/Modules/Send/StakingModel.swift
+++ b/Tangem/Modules/Send/StakingModel.swift
@@ -96,6 +96,9 @@ private extension StakingModel {
                 let newState = try await model.state(amount: amount, validator: validator, approvePolicy: model._approvePolicy.value)
                 model.update(state: newState)
             } catch {
+                guard error as? CancellationError == nil else {
+                    return
+                }
                 model.update(state: .networkError(error))
             }
         }


### PR DESCRIPTION
При попытке загрузки estimate fee можем нарваться на loading state у менеджера (похожая ситуация с исполнением транзакции пофикшена здесь https://github.com/tangem/tangem-app-ios/pull/4045). Также поправил косяк с неудалением "Approve in progress" баннера если после аппрува получаем состояние validationErrorEvent.