### PR TITLE
IOS-8294 Fix scan card navigation

### DIFF
--- a/Tangem/Modules/Markets/TokensNetworkSelector/MarketsTokenNetworkSelectorCoordinatorView.swift
+++ b/Tangem/Modules/Markets/TokensNetworkSelector/MarketsTokenNetworkSelectorCoordinatorView.swift
@@ -26,5 +26,6 @@ struct MarketsTokenNetworkSelectorCoordinatorView: CoordinatorView {
             .navigation(item: $coordinator.walletSelectorViewModel) {
                 WalletSelectorView(viewModel: $0)
             }
+            .emptyNavigationLink()
     }
 }

--- a/Tangem/Modules/ScanCardSettings/ScanCardSettingsCoordinator.swift
+++ b/Tangem/Modules/ScanCardSettings/ScanCardSettingsCoordinator.swift
@@ -1,0 +1,54 @@
+//
+//  ScanCardSettingsCoordinator.swift
+//  Tangem
+//
+//  Created by Alexander Osokin on 17.10.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+class ScanCardSettingsCoordinator: CoordinatorObject {
+    // MARK: - Dependencies
+
+    let dismissAction: Action<Void>
+    let popToRootAction: Action<PopToRootOptions>
+
+    // MARK: - Root view model
+
+    @Published private(set) var rootViewModel: ScanCardSettingsViewModel?
+
+    // MARK: - Child coordinators
+
+    @Published var cardSettingsCoordinator: CardSettingsCoordinator?
+
+    required init(dismissAction: @escaping Action<Void>, popToRootAction: @escaping Action<PopToRootOptions>) {
+        self.dismissAction = dismissAction
+        self.popToRootAction = popToRootAction
+    }
+
+    func start(with options: Options) {
+        rootViewModel = ScanCardSettingsViewModel(
+            input: options.input,
+            coordinator: self
+        )
+    }
+}
+
+// MARK: - Options
+
+extension ScanCardSettingsCoordinator {
+    struct Options {
+        let input: ScanCardSettingsViewModel.Input
+    }
+}
+
+// MARK: - ScanCardSettingsRoutable
+
+extension ScanCardSettingsCoordinator: ScanCardSettingsRoutable {
+    func openCardSettings(with input: CardSettingsViewModel.Input) {
+        let coordinator = CardSettingsCoordinator(dismissAction: dismissAction, popToRootAction: popToRootAction)
+        coordinator.start(with: .init(input: input))
+        cardSettingsCoordinator = coordinator
+    }
+}

--- a/Tangem/Modules/ScanCardSettings/ScanCardSettingsCoordinatorView.swift
+++ b/Tangem/Modules/ScanCardSettings/ScanCardSettingsCoordinatorView.swift
@@ -1,0 +1,29 @@
+//
+//  ScanCardSettingsCoordinatorView.swift
+//  Tangem
+//
+//  Created by Alexander Osokin on 17.10.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+struct ScanCardSettingsCoordinatorView: CoordinatorView {
+    @ObservedObject var coordinator: ScanCardSettingsCoordinator
+
+    var body: some View {
+        if let rootViewModel = coordinator.rootViewModel {
+            ScanCardSettingsView(viewModel: rootViewModel)
+                .navigationLinks(links)
+        }
+    }
+
+    @ViewBuilder
+    private var links: some View {
+        NavHolder()
+            .navigation(item: $coordinator.cardSettingsCoordinator) {
+                CardSettingsCoordinatorView(coordinator: $0)
+            }
+    }
+}

--- a/Tangem/Modules/ScanCardSettings/ScanCardSettingsCoordinatorView.swift
+++ b/Tangem/Modules/ScanCardSettings/ScanCardSettingsCoordinatorView.swift
@@ -25,5 +25,6 @@ struct ScanCardSettingsCoordinatorView: CoordinatorView {
             .navigation(item: $coordinator.cardSettingsCoordinator) {
                 CardSettingsCoordinatorView(coordinator: $0)
             }
+            .emptyNavigationLink()
     }
 }

--- a/Tangem/Modules/ScanCardSettings/ScanCardSettingsView.swift
+++ b/Tangem/Modules/ScanCardSettings/ScanCardSettingsView.swift
@@ -90,7 +90,7 @@ struct ScanCardSettingsView_Preview: PreviewProvider {
             cardImagePublisher: .just(output: .embedded(Assets.Onboarding.walletCard.uiImage)),
             cardScanner: CommonCardScanner()
         ),
-        coordinator: UserWalletSettingsCoordinator()
+        coordinator: ScanCardSettingsCoordinator()
     )
 
     static var previews: some View {

--- a/Tangem/Modules/UserWalletSettings/UserWalletSettingsCoordinator.swift
+++ b/Tangem/Modules/UserWalletSettings/UserWalletSettingsCoordinator.swift
@@ -20,13 +20,11 @@ class UserWalletSettingsCoordinator: CoordinatorObject {
     // MARK: - Child coordinators
 
     @Published var modalOnboardingCoordinator: OnboardingCoordinator?
-    @Published var cardSettingsCoordinator: CardSettingsCoordinator?
     @Published var referralCoordinator: ReferralCoordinator?
     @Published var manageTokensCoordinator: ManageTokensCoordinator?
+    @Published var scanCardSettingsCoordinator: ScanCardSettingsCoordinator?
 
     // MARK: - Child view models
-
-    @Published var scanCardSettingsViewModel: ScanCardSettingsViewModel?
 
     // MARK: - Helpers
 
@@ -73,7 +71,13 @@ extension UserWalletSettingsCoordinator: UserWalletSettingsRoutable {
     }
 
     func openScanCardSettings(with input: ScanCardSettingsViewModel.Input) {
-        scanCardSettingsViewModel = ScanCardSettingsViewModel(input: input, coordinator: self)
+        let dismissAction: Action<Void> = { [weak self] _ in
+            self?.scanCardSettingsCoordinator = nil
+        }
+
+        let coordinator = ScanCardSettingsCoordinator(dismissAction: dismissAction)
+        coordinator.start(with: .init(input: input))
+        scanCardSettingsCoordinator = coordinator
     }
 
     func openReferral(input: ReferralInputModel) {
@@ -95,17 +99,5 @@ extension UserWalletSettingsCoordinator: UserWalletSettingsRoutable {
         let coordinator = ManageTokensCoordinator(dismissAction: dismissAction)
         coordinator.start(with: .init(userWalletModel: userWalletModel))
         manageTokensCoordinator = coordinator
-    }
-}
-
-// MARK: - ScanCardSettingsRoutable
-
-extension UserWalletSettingsCoordinator: ScanCardSettingsRoutable {
-    func openCardSettings(with input: CardSettingsViewModel.Input) {
-        scanCardSettingsViewModel = nil
-
-        let coordinator = CardSettingsCoordinator(dismissAction: dismissAction, popToRootAction: popToRootAction)
-        coordinator.start(with: .init(input: input))
-        cardSettingsCoordinator = coordinator
     }
 }

--- a/Tangem/Modules/UserWalletSettings/UserWalletSettingsCoordinatorView.swift
+++ b/Tangem/Modules/UserWalletSettings/UserWalletSettingsCoordinatorView.swift
@@ -32,14 +32,11 @@ struct UserWalletSettingsCoordinatorView: CoordinatorView {
             .navigation(item: $coordinator.manageTokensCoordinator) {
                 ManageTokensCoordinatorView(coordinator: $0)
             }
-            .navigation(item: $coordinator.cardSettingsCoordinator) {
-                CardSettingsCoordinatorView(coordinator: $0)
-            }
             .navigation(item: $coordinator.referralCoordinator) {
                 ReferralCoordinatorView(coordinator: $0)
             }
-            .navigation(item: $coordinator.scanCardSettingsViewModel) {
-                ScanCardSettingsView(viewModel: $0)
+            .navigation(item: $coordinator.scanCardSettingsCoordinator) {
+                ScanCardSettingsCoordinatorView(coordinator: $0)
             }
     }
 

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -1288,6 +1288,8 @@
 		DCE61E452B5EE05E005A8D2E /* SafariConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE61E442B5EE05E005A8D2E /* SafariConfiguration.swift */; };
 		DCE940BA2C3ECC2500B67398 /* StakingFeatureProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE940B92C3ECC2500B67398 /* StakingFeatureProvider.swift */; };
 		DCEC71F52B8683FB00B3847E /* BackupValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCEC71F42B8683FB00B3847E /* BackupValidator.swift */; };
+		DCEFF6842CC1509A00A49878 /* ScanCardSettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCEFF6832CC1509A00A49878 /* ScanCardSettingsCoordinator.swift */; };
+		DCEFF6862CC150AA00A49878 /* ScanCardSettingsCoordinatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCEFF6852CC150AA00A49878 /* ScanCardSettingsCoordinatorView.swift */; };
 		DCF2369129924C0900FE1855 /* AnalyticsContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF2369029924C0900FE1855 /* AnalyticsContext.swift */; };
 		DCF23693299257EB00FE1855 /* AnalyticsContextData.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF23692299257EB00FE1855 /* AnalyticsContextData.swift */; };
 		DCF8972D28ACF8CA002A85F6 /* TangemSdkConfigFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF8972C28ACF8CA002A85F6 /* TangemSdkConfigFactory.swift */; };
@@ -3282,6 +3284,8 @@
 		DCE61E442B5EE05E005A8D2E /* SafariConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariConfiguration.swift; sourceTree = "<group>"; };
 		DCE940B92C3ECC2500B67398 /* StakingFeatureProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingFeatureProvider.swift; sourceTree = "<group>"; };
 		DCEC71F42B8683FB00B3847E /* BackupValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupValidator.swift; sourceTree = "<group>"; };
+		DCEFF6832CC1509A00A49878 /* ScanCardSettingsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCardSettingsCoordinator.swift; sourceTree = "<group>"; };
+		DCEFF6852CC150AA00A49878 /* ScanCardSettingsCoordinatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanCardSettingsCoordinatorView.swift; sourceTree = "<group>"; };
 		DCF2369029924C0900FE1855 /* AnalyticsContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsContext.swift; sourceTree = "<group>"; };
 		DCF23692299257EB00FE1855 /* AnalyticsContextData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsContextData.swift; sourceTree = "<group>"; };
 		DCF8972C28ACF8CA002A85F6 /* TangemSdkConfigFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TangemSdkConfigFactory.swift; sourceTree = "<group>"; };
@@ -7968,6 +7972,7 @@
 				B0DD16182A331BF300CB23AA /* TokenDetails */,
 				B0E1564926B9417E005B33E4 /* Onboarding */,
 				EF9CFC1B2890223F00329BE0 /* AppSettings */,
+				EFEE23AF2BFF69790099917E /* ScanCardSettings */,
 				EF7B9CED286C6B95004C33A9 /* CardSettings */,
 				EFA580642893F89000110DB0 /* ResetToFactory */,
 				B04CD33A29122C25001EA84A /* Referral */,
@@ -8896,7 +8901,6 @@
 		EF7B9CED286C6B95004C33A9 /* CardSettings */ = {
 			isa = PBXGroup;
 			children = (
-				EFEE23AF2BFF69790099917E /* ScanCardSettings */,
 				B05D063029DEA0C70031C6AB /* AccessCodeRecoverySettingsView */,
 				EF7B9CEE286C6BD7004C33A9 /* CardSettingsView.swift */,
 				EF7B9CF0286C6BE2004C33A9 /* CardSettingsViewModel.swift */,
@@ -9861,6 +9865,8 @@
 				EFEE23AD2BFF69790099917E /* ScanCardSettingsRoutable.swift */,
 				EFEE23AE2BFF69790099917E /* ScanCardSettingsView.swift */,
 				EFEE23B22BFF69FE0099917E /* ScanCardSettingsViewModel.swift */,
+				DCEFF6832CC1509A00A49878 /* ScanCardSettingsCoordinator.swift */,
+				DCEFF6852CC150AA00A49878 /* ScanCardSettingsCoordinatorView.swift */,
 			);
 			name = ScanCardSettings;
 			path = Tangem/Modules/ScanCardSettings;
@@ -10912,6 +10918,7 @@
 				B67DC1E62B7C45DD008ACB0E /* UserDefaultsBlockchainDataStorage.swift in Sources */,
 				B0C171CE264C173400E4BA5C /* CameraAccessDeniedModifier.swift in Sources */,
 				B09446122CAC3EFD008F43D8 /* MarketsDTO+ExchangesList.swift in Sources */,
+				DCEFF6842CC1509A00A49878 /* ScanCardSettingsCoordinator.swift in Sources */,
 				B0D9FDCA2A9336920047A1C0 /* IconViewSizeSettings.swift in Sources */,
 				B600F4D72C50F73E008E53FE /* MarketsHistoryChartViewModel.swift in Sources */,
 				B67DC1EC2B7C4CB9008ACB0E /* FakeBlockchainDataStorage.swift in Sources */,
@@ -11672,6 +11679,7 @@
 				DA7B2C512B6B893500FB9622 /* SendNotificationManager.swift in Sources */,
 				5D119E85256BF1E50046CAD2 /* Option.swift in Sources */,
 				5DF2522D24F95E390015B429 /* UIScreen+.swift in Sources */,
+				DCEFF6862CC150AA00A49878 /* ScanCardSettingsCoordinatorView.swift in Sources */,
 				B0A596562992A5B700C7C512 /* FixedSizeButtonWithIconInfo.swift in Sources */,
 				B6210DEF2A94708700F885D5 /* OrganizeTokensListFactory.swift in Sources */,
 				B0C370812C6CDCAA00439263 /* MarketsQuotesUpdateHelper.swift in Sources */,


### PR DESCRIPTION
https://tangem.atlassian.net/browse/IOS-8294

При изменении презентации scan card settings с модалки на пуш не был протестирован переход дальше, после скана. А там пуш-навигация, которая сломалась, потому что вью модель не была обернута в координатор, который должен держать линку