### PR TITLE
IOS-8319: [Markets] Fix broken safe area on markets detail

### DIFF
--- a/Tangem/Common/UI/NavigationBarHiddingContainerVIew/NavigationBarHidingView.swift
+++ b/Tangem/Common/UI/NavigationBarHiddingContainerVIew/NavigationBarHidingView.swift
@@ -1,5 +1,5 @@
 //
-//  NavigationBarHiddingView.swift
+//  NavigationBarHidingView.swift
 //  Tangem
 //
 //  Created by Andrew Son on 08.10.24.
@@ -8,7 +8,7 @@
 
 import SwiftUI
 
-struct NavigationBarHiddingView<Content: View>: View {
+struct NavigationBarHidingView<Content: View>: View {
     var shouldWrapInNavigationView: Bool
     var content: Content
 
@@ -16,7 +16,7 @@ struct NavigationBarHiddingView<Content: View>: View {
         if #available(iOS 16.0, *) {
             wrappedContent
         } else {
-            UIAppearanceBoundaryContainerView(boundaryMarker: NavigationBarHiddingViewUIAppearanceBoundaryMarker.self) {
+            UIAppearanceBoundaryContainerView(boundaryMarker: NavigationBarHidingViewUIAppearanceBoundaryMarker.self) {
                 wrappedContent
             }
         }
@@ -41,7 +41,7 @@ struct NavigationBarHiddingView<Content: View>: View {
         } else {
             content
                 .onAppear {
-                    NavigationBarHiddingViewUIAppearanceBoundaryMarker.setupUIAppearanceIfNeeded()
+                    NavigationBarHidingViewUIAppearanceBoundaryMarker.setupUIAppearanceIfNeeded()
                 }
         }
     }
@@ -52,7 +52,7 @@ struct NavigationBarHiddingView<Content: View>: View {
     }
 }
 
-private class NavigationBarHiddingViewUIAppearanceBoundaryMarker: UIViewController {
+private class NavigationBarHidingViewUIAppearanceBoundaryMarker: UIViewController {
     static var didSetupUIAppearance = false
 
     @available(iOS, obsoleted: 16.0, message: "Use native 'toolbarBackground(_:for:)' instead")
@@ -62,7 +62,7 @@ private class NavigationBarHiddingViewUIAppearanceBoundaryMarker: UIViewControll
             navBarAppearance.configureWithTransparentBackground()
 
             let uiAppearance = UINavigationBar.appearance(
-                whenContainedInInstancesOf: [NavigationBarHiddingViewUIAppearanceBoundaryMarker.self]
+                whenContainedInInstancesOf: [NavigationBarHidingViewUIAppearanceBoundaryMarker.self]
             )
             uiAppearance.compactAppearance = navBarAppearance
             uiAppearance.standardAppearance = navBarAppearance

--- a/Tangem/Modules/Main/MainCoordinatorView.swift
+++ b/Tangem/Modules/Main/MainCoordinatorView.swift
@@ -82,7 +82,7 @@ struct MainCoordinatorView: CoordinatorView {
                     })
             }
             .sheet(item: $coordinator.organizeTokensViewModel) { viewModel in
-                NavigationBarHiddingView(shouldWrapInNavigationView: true) {
+                NavigationBarHidingView(shouldWrapInNavigationView: true) {
                     OrganizeTokensView(viewModel: viewModel)
                         .navigationTitle(Localization.organizeTokensTitle)
                         .navigationBarTitleDisplayMode(.inline)

--- a/Tangem/Modules/Markets/MarketsTokenDetails/MarketsTokenDetailsCoordinatorView.swift
+++ b/Tangem/Modules/Markets/MarketsTokenDetails/MarketsTokenDetailsCoordinatorView.swift
@@ -63,7 +63,7 @@ struct MarketsTokenDetailsCoordinatorView: CoordinatorView {
     private var links: some View {
         NavHolder()
             .navigation(item: $coordinator.exchangesListViewModel) { viewModel in
-                let container = NavigationBarHiddingView(shouldWrapInNavigationView: false) {
+                let container = NavigationBarHidingView(shouldWrapInNavigationView: false) {
                     MarketsTokenDetailsExchangesListView(viewModel: viewModel)
                 }
 

--- a/Tangem/Modules/Markets/MarketsTokenDetails/MarketsTokenDetailsView.swift
+++ b/Tangem/Modules/Markets/MarketsTokenDetails/MarketsTokenDetailsView.swift
@@ -47,6 +47,7 @@ struct MarketsTokenDetailsView: View {
             }
             .background {
                 backgroundColor
+                    .ignoresSafeArea(edges: .vertical)
             }
     }
 

--- a/Tangem/UIComponents/DescriptionBottomSheet/DescriptionBottomSheetView.swift
+++ b/Tangem/UIComponents/DescriptionBottomSheet/DescriptionBottomSheetView.swift
@@ -24,7 +24,6 @@ struct DescriptionBottomSheetView: View {
     let info: DescriptionBottomSheetInfo
 
     @Environment(\.dismiss) private var dismissSheetAction
-    @State private var containerHeight: CGFloat = 0
 
     var body: some View {
         content

--- a/Tangem/UIComponents/DescriptionBottomSheet/TokenDescriptionBottomSheetView.swift
+++ b/Tangem/UIComponents/DescriptionBottomSheet/TokenDescriptionBottomSheetView.swift
@@ -15,6 +15,9 @@ struct TokenDescriptionBottomSheetView: View {
 
     @Environment(\.dismiss) private var dismissSheetAction
 
+    // No additional padding is needed on devices with a notch, native safe area works fine.
+    private var bottomInset: CGFloat { UIDevice.current.hasHomeScreenIndicator ? 0.0 : 10.0 }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             DescriptionBottomSheetView(info: info)
@@ -27,6 +30,7 @@ struct TokenDescriptionBottomSheetView: View {
             .padding(.horizontal, 16)
             .disabled(generatedWithAIAction == nil)
         }
+        .padding(.bottom, bottomInset)
     }
 }
 

--- a/Tangem/UIComponents/DescriptionBottomSheet/TokenDescriptionBottomSheetView.swift
+++ b/Tangem/UIComponents/DescriptionBottomSheet/TokenDescriptionBottomSheetView.swift
@@ -14,7 +14,6 @@ struct TokenDescriptionBottomSheetView: View {
     var generatedWithAIAction: (() -> Void)? = nil
 
     @Environment(\.dismiss) private var dismissSheetAction
-    @State private var containerHeight: CGFloat = 0
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {

--- a/Tangem/UIComponents/DescriptionBottomSheet/View+DescriptionBottomSheet.swift
+++ b/Tangem/UIComponents/DescriptionBottomSheet/View+DescriptionBottomSheet.swift
@@ -10,19 +10,6 @@ import SwiftUI
 
 extension View {
     @ViewBuilder
-    func descriptionBottomSheet(
-        info: Binding<DescriptionBottomSheetInfo?>,
-        backgroundColor: Color?
-    ) -> some View {
-        sheet(item: info) { info in
-            DescriptionBottomSheetView(info: info)
-                .padding(.bottom, 10)
-                .adaptivePresentationDetents()
-                .background(backgroundColor.ignoresSafeArea(.all, edges: .bottom))
-        }
-    }
-
-    @ViewBuilder
     func tokenDescriptionBottomSheet(
         info: Binding<DescriptionBottomSheetInfo?>,
         backgroundColor: Color?,

--- a/Tangem/UIComponents/DescriptionBottomSheet/View+DescriptionBottomSheet.swift
+++ b/Tangem/UIComponents/DescriptionBottomSheet/View+DescriptionBottomSheet.swift
@@ -18,8 +18,10 @@ extension View {
         sheet(item: info) { info in
             TokenDescriptionBottomSheetView(info: info, generatedWithAIAction: onGeneratedAITapAction)
                 .adaptivePresentationDetents()
-                .padding(.bottom, 10)
-                .background(backgroundColor.ignoresSafeArea(.all, edges: .bottom))
+                .background(
+                    backgroundColor
+                        .ignoresSafeArea(edges: .bottom)
+                )
         }
     }
 }

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -612,7 +612,7 @@
 		B0D51C862C2400810043D792 /* visaTestnet.json in Resources */ = {isa = PBXBuildFile; fileRef = B0D51C842C2400810043D792 /* visaTestnet.json */; };
 		B0D51C872C2400810043D792 /* visa.json in Resources */ = {isa = PBXBuildFile; fileRef = B0D51C852C2400810043D792 /* visa.json */; };
 		B0D622FE2A9E33E5001FA044 /* SingleTokenNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D622FD2A9E33E5001FA044 /* SingleTokenNotificationManager.swift */; };
-		B0D6B2542CB52B090068D310 /* NavigationBarHiddingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D6B2532CB52B090068D310 /* NavigationBarHiddingView.swift */; };
+		B0D6B2542CB52B090068D310 /* NavigationBarHidingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D6B2532CB52B090068D310 /* NavigationBarHidingView.swift */; };
 		B0D7F896295EDCBE00497139 /* ReferralErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D7F895295EDCBE00497139 /* ReferralErrors.swift */; };
 		B0D9FDCA2A9336920047A1C0 /* IconViewSizeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D9FDC92A9336920047A1C0 /* IconViewSizeSettings.swift */; };
 		B0DB73FC2A8CA28800F6376E /* UnlockUserWalletBottomSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0DB73FB2A8CA28800F6376E /* UnlockUserWalletBottomSheetViewModel.swift */; };
@@ -2578,7 +2578,7 @@
 		B0D51C842C2400810043D792 /* visaTestnet.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = visaTestnet.json; path = "tangem-app-config/visaTestnet.json"; sourceTree = SOURCE_ROOT; };
 		B0D51C852C2400810043D792 /* visa.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = visa.json; path = "tangem-app-config/visa.json"; sourceTree = SOURCE_ROOT; };
 		B0D622FD2A9E33E5001FA044 /* SingleTokenNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleTokenNotificationManager.swift; sourceTree = "<group>"; };
-		B0D6B2532CB52B090068D310 /* NavigationBarHiddingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarHiddingView.swift; sourceTree = "<group>"; };
+		B0D6B2532CB52B090068D310 /* NavigationBarHidingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarHidingView.swift; sourceTree = "<group>"; };
 		B0D7F895295EDCBE00497139 /* ReferralErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralErrors.swift; sourceTree = "<group>"; };
 		B0D9FDC92A9336920047A1C0 /* IconViewSizeSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconViewSizeSettings.swift; sourceTree = "<group>"; };
 		B0DB73FB2A8CA28800F6376E /* UnlockUserWalletBottomSheetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockUserWalletBottomSheetViewModel.swift; sourceTree = "<group>"; };
@@ -6126,7 +6126,7 @@
 		B0D6B2522CB52AE20068D310 /* NavigationBarHiddingContainerVIew */ = {
 			isa = PBXGroup;
 			children = (
-				B0D6B2532CB52B090068D310 /* NavigationBarHiddingView.swift */,
+				B0D6B2532CB52B090068D310 /* NavigationBarHidingView.swift */,
 			);
 			path = NavigationBarHiddingContainerVIew;
 			sourceTree = "<group>";
@@ -11496,7 +11496,7 @@
 				B01B2D752BD2924F00D8A6A1 /* CommonAPIListProvider.swift in Sources */,
 				B0AF2DF12B1DAACD001A8696 /* PendingExpressTransactionStatus.swift in Sources */,
 				EF032C512955C59E006C1FF3 /* DefaultSelectableRowView.swift in Sources */,
-				B0D6B2542CB52B090068D310 /* NavigationBarHiddingView.swift in Sources */,
+				B0D6B2542CB52B090068D310 /* NavigationBarHidingView.swift in Sources */,
 				EFC84B0F2C37FAB500546882 /* SendFlowFactory.swift in Sources */,
 				EF4662222924DEEE00346B6C /* DefaultToggleRowView.swift in Sources */,
 				EF46621B2924DEEE00346B6C /* DefaultHeaderView.swift in Sources */,


### PR DESCRIPTION
[IOS-8319](https://tangem.atlassian.net/browse/IOS-8319)

Не копал глубоко, где именно сломалось - в exchanges или же в оверскролле
Поправил для девайс с челкой/без

<img width="350" src="https://github.com/user-attachments/assets/0a0c64d5-d198-48f5-b297-b648244f9738">


<img width="350" src="https://github.com/user-attachments/assets/d4d9c8be-7fe5-46ae-bc3b-a764389feb91">




[IOS-8319]: https://tangem.atlassian.net/browse/IOS-8319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ