### PR TITLE
IOS-8260: Rename Markets router functions

### DIFF
--- a/Tangem/Modules/Markets/Navigation/MarketsCoordinator.swift
+++ b/Tangem/Modules/Markets/Navigation/MarketsCoordinator.swift
@@ -56,7 +56,7 @@ extension MarketsCoordinator: MarketsRoutable {
         })
     }
 
-    func openTokenMarketsDetails(for tokenInfo: MarketsTokenModel) {
+    func openMarketsTokenDetails(for tokenInfo: MarketsTokenModel) {
         let tokenDetailsCoordinator = MarketsTokenDetailsCoordinator(
             dismissAction: { [weak self] in
                 self?.tokenDetailsCoordinator = nil

--- a/Tangem/Modules/Markets/Navigation/MarketsRoutable.swift
+++ b/Tangem/Modules/Markets/Navigation/MarketsRoutable.swift
@@ -10,5 +10,5 @@ import Foundation
 
 protocol MarketsRoutable: AnyObject {
     func openFilterOrderBottonSheet(with provider: MarketsListDataFilterProvider)
-    func openTokenMarketsDetails(for tokenInfo: MarketsTokenModel)
+    func openMarketsTokenDetails(for tokenInfo: MarketsTokenModel)
 }

--- a/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
@@ -401,7 +401,7 @@ private extension MarketsViewModel {
 
                 Analytics.log(event: .marketsChartScreenOpened, params: analyticsParams)
 
-                self?.coordinator?.openTokenMarketsDetails(for: tokenItemModel)
+                self?.coordinator?.openMarketsTokenDetails(for: tokenItemModel)
             }
         )
     }

--- a/Tangem/Modules/Markets/TokensNetworkSelector/MarketsTokenNetworkSelectorCoordinator.swift
+++ b/Tangem/Modules/Markets/TokensNetworkSelector/MarketsTokenNetworkSelectorCoordinator.swift
@@ -1,5 +1,5 @@
 //
-//  TokenMarketsNetworkSelectorCoordinator.swift
+//  MarketsTokenNetworkSelectorCoordinator.swift
 //  Tangem
 //
 //  Created by skibinalexander on 21.08.2024.

--- a/Tangem/Modules/Markets/TokensNetworkSelector/MarketsTokenNetworkSelectorCoordinatorView.swift
+++ b/Tangem/Modules/Markets/TokensNetworkSelector/MarketsTokenNetworkSelectorCoordinatorView.swift
@@ -1,5 +1,5 @@
 //
-//  TokenMarketsNetworkSelectorCoordinatorView.swift
+//  MarketsTokenNetworkSelectorCoordinatorView.swift
 //  Tangem
 //
 //  Created by skibinalexander on 21.08.2024.

--- a/Tangem/Modules/Markets/Utilities/MarketsQuotesUpdateHelper.swift
+++ b/Tangem/Modules/Markets/Utilities/MarketsQuotesUpdateHelper.swift
@@ -15,9 +15,9 @@ protocol MarketsQuotesUpdateHelper {
     ///   - baseCurrencyCode: Currency selected in App. It can be fiat or crypto currency
     func updateQuotes(marketsTokens: [MarketsTokenModel], for baseCurrencyCode: String)
 
-    /// Create single `TokenQuote`for provided `TokenMarketsDetailModel` and update data  in `TokenQuotesRepository`
+    /// Create single `TokenQuote`for provided `MarketsTokenDetailsModel` and update data  in `TokenQuotesRepository`
     /// - Parameters:
-    ///   - marketToken: Details about single Token represented in `TokenMarketsDetailsModel`
+    ///   - marketToken: Details about single Token represented in `MarketsTokenDetailsModel`
     ///   - baseCurrencyCode: Currency selected in App. It can be fiat or crypto currency
     func updateQuote(marketToken: MarketsTokenDetailsModel, for baseCurrencyCode: String)
 }


### PR DESCRIPTION
таргеты в апишке пока не меняю название, т.к. надо все таргеты тогда подводить под один формат, сейчас в апишке все именуется по типа загружаемого контента, а не по модулям, поэтому только функцию и несколько комментов