### PR TITLE
IOS-8099: Improve MarketsList performance

### DIFF
--- a/Tangem/App/Factories/ExpressModulesFactory/ExpressAPIProviderFactory.swift
+++ b/Tangem/App/Factories/ExpressModulesFactory/ExpressAPIProviderFactory.swift
@@ -18,7 +18,7 @@ struct ExpressAPIProviderFactory {
                 return .production
             }
 
-            return ExpressAPIType(rawValue: FeatureStorage().apiExpress) ?? .production
+            return ExpressAPIType(rawValue: FeatureStorage.instance.apiExpress) ?? .production
         }()
 
         let apiKey = apiKey(expressAPIType: expressAPIType)

--- a/Tangem/App/Models/Config/SupportedBlockchains.swift
+++ b/Tangem/App/Models/Config/SupportedBlockchains.swift
@@ -54,7 +54,7 @@ struct SupportedBlockchains {
             return mainnetBlockchains
         }
 
-        let betaTestingBlockchains = FeatureStorage().supportedBlockchainsIds.compactMap { id in
+        let betaTestingBlockchains = FeatureStorage.instance.supportedBlockchainsIds.compactMap { id in
             testableBlockchains().first { $0.networkId == id }
         }
 

--- a/Tangem/App/Models/Visa/VisaWalletModel.swift
+++ b/Tangem/App/Models/Visa/VisaWalletModel.swift
@@ -73,7 +73,7 @@ class VisaWalletModel {
         self.userWalletModel = userWalletModel
 
         let apiService = VisaAPIServiceBuilder().build(
-            isTestnet: FeatureStorage().isVisaTestnet,
+            isTestnet: FeatureStorage.instance.isVisaTestnet,
             urlSessionConfiguration: .defaultConfiguration,
             logger: AppLog.shared
         )

--- a/Tangem/App/Services/EnvironmentProvider/FeatureProvider.swift
+++ b/Tangem/App/Services/EnvironmentProvider/FeatureProvider.swift
@@ -15,7 +15,7 @@ enum FeatureProvider {
             return isAvailableForReleaseVersion(feature)
         }
 
-        let state = FeatureStorage().availableFeatures[feature]
+        let state = FeatureStorage.instance.availableFeatures[feature]
         switch state {
         case .none:
             return isAvailableForReleaseVersion(feature)

--- a/Tangem/App/Services/EnvironmentProvider/FeaturesStorage.swift
+++ b/Tangem/App/Services/EnvironmentProvider/FeaturesStorage.swift
@@ -11,6 +11,8 @@ import Foundation
 // MARK: - Provider
 
 class FeatureStorage {
+    static let instance: FeatureStorage = .init()
+
     @AppStorageCompat(FeatureStorageKeys.testnet)
     var isTestnet: Bool = false
 
@@ -37,6 +39,8 @@ class FeatureStorage {
 
     @AppStorageCompat(FeatureStorageKeys.useVisaTestnet)
     var isVisaTestnet = false
+
+    private init() {}
 }
 
 // MARK: - Keys

--- a/Tangem/App/Services/EnvironmentProvider/StakingFeatureProvider.swift
+++ b/Tangem/App/Services/EnvironmentProvider/StakingFeatureProvider.swift
@@ -43,7 +43,7 @@ class StakingFeatureProvider {
         let item = StakingItem(network: stakingTokenItem.network, contractAddress: stakingTokenItem.contractAddress)
         let itemID = item.id
         let isSupported = StakingFeatureProvider.supportedBlockchainItems.contains(item)
-        let isTesting = FeatureStorage().stakingBlockchainsIds.contains(itemID)
+        let isTesting = FeatureStorage.instance.stakingBlockchainsIds.contains(itemID)
 
         guard isSupported || isTesting else {
             return nil

--- a/Tangem/App/Utilities/InfoDictionaryUtils.swift
+++ b/Tangem/App/Utilities/InfoDictionaryUtils.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+private let infoDictionary = Bundle.main.infoDictionary ?? [:]
+
 enum InfoDictionaryUtils {
     case appName
     case version
@@ -15,9 +17,11 @@ enum InfoDictionaryUtils {
     case bundleURLTypes
     case bundleURLSchemes
     case bundleIdentifier
+    case environmentName
+    case suiteName
+    case bsdkSuiteName
 
     func value<T>() -> T? {
-        let infoDictionary = Bundle.main.infoDictionary ?? [:]
         switch self {
         case .appName:
             return infoDictionary["CFBundleDisplayName"] as? T
@@ -35,6 +39,12 @@ enum InfoDictionaryUtils {
             }
 
             return dictionary.map { $0["CFBundleURLSchemes"] } as? T
+        case .environmentName:
+            return infoDictionary["ENVIRONMENT_NAME"] as? T
+        case .suiteName:
+            return infoDictionary["SUITE_NAME"] as? T
+        case .bsdkSuiteName:
+            return infoDictionary["BSDK_SUITE_NAME"] as? T
         }
     }
 }

--- a/Tangem/App/Utilities/PerformanceMonitorConfigurator.swift
+++ b/Tangem/App/Utilities/PerformanceMonitorConfigurator.swift
@@ -32,7 +32,7 @@ enum PerformanceMonitorConfigurator {
     }
 
     private static var isEnabledUsingFeatureToggle: Bool {
-        return FeatureStorage().isPerformanceMonitorEnabled
+        return FeatureStorage.instance.isPerformanceMonitorEnabled
     }
 
     static func configureIfAvailable() {

--- a/Tangem/App/Utilities/Visa/VisaUtilities+FeatureStorage.swift
+++ b/Tangem/App/Utilities/Visa/VisaUtilities+FeatureStorage.swift
@@ -10,6 +10,6 @@ import TangemVisa
 
 extension VisaUtilities {
     init() {
-        self = VisaUtilities(isTestnet: FeatureStorage().isVisaTestnet)
+        self = VisaUtilities(isTestnet: FeatureStorage.instance.isVisaTestnet)
     }
 }

--- a/Tangem/Common/AppEnvironment.swift
+++ b/Tangem/Common/AppEnvironment.swift
@@ -8,8 +8,6 @@
 
 import Foundation
 
-private let infoDictionary = Bundle.main.infoDictionary ?? [:]
-
 enum AppEnvironment: String {
     case beta = "Beta"
     case production = "Production"
@@ -18,7 +16,7 @@ enum AppEnvironment: String {
 
 extension AppEnvironment {
     static var current: AppEnvironment {
-        guard let environmentName = infoDictionary["ENVIRONMENT_NAME"] as? String else {
+        guard let environmentName: String = InfoDictionaryUtils.environmentName.value() else {
             assertionFailure("ENVIRONMENT_NAME not found")
             return .production
         }
@@ -32,7 +30,7 @@ extension AppEnvironment {
     }
 
     var suiteName: String {
-        guard let identifier = infoDictionary["SUITE_NAME"] as? String else {
+        guard let identifier: String = InfoDictionaryUtils.suiteName.value() else {
             assertionFailure("SUITE_NAME not found")
             return ""
         }
@@ -41,7 +39,7 @@ extension AppEnvironment {
     }
 
     var blockchainDataStorageSuiteName: String {
-        guard let identifier = infoDictionary["BSDK_SUITE_NAME"] as? String else {
+        guard let identifier: String = InfoDictionaryUtils.bsdkSuiteName.value() else {
             assertionFailure("BSDK_SUITE_NAME not found")
             return ""
         }
@@ -50,19 +48,19 @@ extension AppEnvironment {
     }
 
     var apiBaseUrl: URL {
-        FeatureStorage().useDevApi ?
+        FeatureStorage.instance.useDevApi ?
             URL(string: "https://devapi.tangem-tech.com/v1")! :
             URL(string: "https://api.tangem-tech.com/v1")!
     }
 
     var iconBaseUrl: URL {
-        FeatureStorage().useDevApi ?
+        FeatureStorage.instance.useDevApi ?
             URL(string: "https://s3.eu-central-1.amazonaws.com/tangem.api.dev/")! :
             URL(string: "https://s3.eu-central-1.amazonaws.com/tangem.api/")!
     }
 
     var tangemComBaseUrl: URL {
-        if FeatureStorage().useDevApi {
+        if FeatureStorage.instance.useDevApi {
             return URL(string: "https://devweb.tangem.com")!
         } else {
             return URL(string: "https://tangem.com")!
@@ -70,7 +68,7 @@ extension AppEnvironment {
     }
 
     var isTestnet: Bool {
-        FeatureStorage().isTestnet
+        FeatureStorage.instance.isTestnet
     }
 
     var isDebug: Bool {

--- a/Tangem/Common/TangemSdk/CardScanner/CardScannerFactory.swift
+++ b/Tangem/Common/TangemSdk/CardScanner/CardScannerFactory.swift
@@ -15,7 +15,7 @@ class CardScannerFactory {
             return false
         }
 
-        return FeatureStorage().isMockedCardScannerEnabled
+        return FeatureStorage.instance.isMockedCardScannerEnabled
     }
 
     func makeDefaultScanner() -> CardScanner {

--- a/Tangem/Modules/EnvironmentSetup/EnvironmentSetupViewModel.swift
+++ b/Tangem/Modules/EnvironmentSetup/EnvironmentSetupViewModel.swift
@@ -31,7 +31,7 @@ final class EnvironmentSetupViewModel: ObservableObject {
 
     // MARK: - Dependencies
 
-    private let featureStorage = FeatureStorage()
+    private let featureStorage = FeatureStorage.instance
     private weak var coordinator: EnvironmentSetupRoutable?
     private var bag: Set<AnyCancellable> = []
 

--- a/Tangem/Modules/Markets/TokenList/MarketsItemViewModel.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsItemViewModel.swift
@@ -68,10 +68,10 @@ class MarketsItemViewModel: Identifiable, ObservableObject {
             self.marketRating = "\(marketRating)"
         }
 
-        setupPriceInfo(
-            price: tokenModel.currentPrice,
-            priceChangePercent: tokenModel.priceChangePercentage[filterProvider.currentFilterValue.interval.rawValue]
-        )
+        setupPriceInfo(input: formatViewUpdateInput(
+            forPrice: tokenModel.currentPrice,
+            priceChange: tokenModel.priceChangePercentage[filterProvider.currentFilterValue.interval.rawValue]
+        ))
         findAndAssignChartsValue(from: chartsProvider.items, with: filterProvider.currentFilterValue.interval)
 
         bindToIntervalUpdates()
@@ -89,9 +89,9 @@ class MarketsItemViewModel: Identifiable, ObservableObject {
 
     // MARK: - Private Implementation
 
-    private func setupPriceInfo(price: Decimal?, priceChangePercent: Decimal?) {
-        priceValue = priceFormatter.formatPrice(price)
-        priceChangeState = priceChangeUtility.convertToPriceChangeState(changePercent: priceChangePercent)
+    private func setupPriceInfo(input: ViewUpdateInput) {
+        priceValue = input.priceValue
+        priceChangeState = input.priceChangeState
     }
 
     private func bindToIntervalUpdates() {
@@ -100,7 +100,7 @@ class MarketsItemViewModel: Identifiable, ObservableObject {
             .removeDuplicates()
             .withWeakCaptureOf(self)
             .sink { viewModel, filter in
-                viewModel.updatePrice(by: viewModel.quotesRepository.quotes[viewModel.tokenId], with: filter.interval)
+                viewModel.updatePrice(for: viewModel.quotesRepository.quotes[viewModel.tokenId], with: filter.interval)
             }
             .store(in: &bag)
     }
@@ -111,15 +111,22 @@ class MarketsItemViewModel: Identifiable, ObservableObject {
             .compactMap { viewModel, quotes in
                 quotes[viewModel.tokenId]
             }
-            .receive(on: DispatchQueue.main)
             .withPrevious()
             .withWeakCaptureOf(self)
-            .sink { elements in
-                let (viewModel, (previousValue, newQuote)) = elements
+            .map { viewModel, elements in
+                let (previousValue, newQuote) = elements
 
-                viewModel.updatePrice(by: newQuote, with: viewModel.filterProvider?.currentFilterValue.interval)
-                viewModel.priceChangeAnimation = .calculateChange(from: previousValue?.price, to: newQuote.price)
+                let input = viewModel.calculateViewUpdateInput(for: newQuote, with: viewModel.filterProvider?.currentFilterValue.interval)
+                let priceChangeAnimation: ForegroundBlinkAnimationModifier.Change = .calculateChange(from: previousValue?.price, to: newQuote.price)
+                return (input, priceChangeAnimation)
             }
+            .receive(on: DispatchQueue.main)
+            .withWeakCaptureOf(self)
+            .sink(receiveValue: { items in
+                let (viewModel, (input, priceChangeAnimation)) = items
+                viewModel.setupPriceInfo(input: input)
+                viewModel.priceChangeAnimation = priceChangeAnimation
+            })
             .store(in: &bag)
     }
 
@@ -140,12 +147,12 @@ class MarketsItemViewModel: Identifiable, ObservableObject {
         from chartsDictionary: [String: [MarketsPriceIntervalType: MarketsChartModel]],
         with interval: MarketsPriceIntervalType
     ) {
-        guard let chart = chartsDictionary.first(where: { $0.key == tokenId }) else {
+        guard let loadedChartsModels = chartsDictionary[tokenId] else {
             charts = nil
             return
         }
 
-        let model = chart.value[interval]
+        let model = loadedChartsModels[interval]
         charts = makeChartsValues(from: model)
     }
 
@@ -166,10 +173,14 @@ class MarketsItemViewModel: Identifiable, ObservableObject {
         }
     }
 
-    private func updatePrice(by newQuote: TokenQuote?, with interval: MarketsPriceIntervalType?) {
+    private func updatePrice(for newQuote: TokenQuote?, with interval: MarketsPriceIntervalType?) {
+        let input = calculateViewUpdateInput(for: newQuote, with: interval)
+        setupPriceInfo(input: input)
+    }
+
+    private func calculateViewUpdateInput(for newQuote: TokenQuote?, with interval: MarketsPriceIntervalType?) -> ViewUpdateInput {
         guard let newQuote else {
-            setupPriceInfo(price: nil, priceChangePercent: nil)
-            return
+            return formatViewUpdateInput(forPrice: nil, priceChange: nil)
         }
 
         let priceChangePercent: Decimal?
@@ -185,6 +196,16 @@ class MarketsItemViewModel: Identifiable, ObservableObject {
             priceChangePercent = nil
         }
 
-        setupPriceInfo(price: newQuote.price, priceChangePercent: priceChangePercent)
+        return formatViewUpdateInput(forPrice: newQuote.price, priceChange: priceChangePercent)
     }
+
+    private func formatViewUpdateInput(forPrice: Decimal?, priceChange: Decimal?) -> ViewUpdateInput {
+        let priceValue = priceFormatter.formatPrice(forPrice)
+        let priceChangeState = priceChangeUtility.convertToPriceChangeState(changePercent: priceChange)
+        return (priceValue, priceChangeState)
+    }
+}
+
+private extension MarketsItemViewModel {
+    typealias ViewUpdateInput = (priceValue: String, priceChangeState: TokenPriceChangeView.State)
 }

--- a/Tangem/Modules/SupportedBlockchainsPreferences/SupportedBlockchainsPreferencesViewModel.swift
+++ b/Tangem/Modules/SupportedBlockchainsPreferences/SupportedBlockchainsPreferencesViewModel.swift
@@ -11,7 +11,7 @@ import BlockchainSdk
 
 class SupportedBlockchainsPreferencesViewModel: ObservableObject {
     @Published var blockchainViewModels: [DefaultToggleRowViewModel] = []
-    private let featureStorage = FeatureStorage()
+    private let featureStorage = FeatureStorage.instance
 
     init(
         blockchainIds: Set<Item>,


### PR DESCRIPTION
* Обновил логику проверки фича стореджа, т.к. была проблема в альфа сборках, что он часто инициализировался во время построения вью графа при каждом задании шрифта. Т.к. у нас есть проверка на динамические шрифты, фича сторедж инициализировался, читал данные из `UserDefaults` и деинициализировался, а это класс и не самая простая операция, а это происходило на каждой вьюхе, которая имеет `.style(Fonts....)`, но это затрагивает только альфу и бету
* Вторая правка в `AppEnvironment` и `UserDictionaryUtils`, перенес все в одно место, добавил новые ключевики. В `AppEnvironment` один раз парсился `Info.plist` и хранился в памяти, но только для `AppEnvironment`, поэтому проверка `AppEnvironment.current.isProduction` происходила быстро, а вот дальше обращение `UserDictionaryUtils` каждый раз по новой читало этот файл и проверяло версию, что собственно бесмысленно, т.к. эта инфа не меняется во время исполнения и определяется во время компиляции. Поэтому объединил все в `UserDictionaryUtils`, перенес туда хранение словаря и через него теперь работают проверки `AppEnvironment`. Опять же при выборе шрифта была в начале проверка `.isProduction`, а потом проверка версии приложения
* Третья правка - внутри `MarketsItemViewModel`, при получении словаря с графиками был поиск в цикле по всему словарю, вместо обращения через хэш  `guard let chart = chartsDictionary.first(where: { $0.key == tokenId }) else {` -> `guard let loadedChartsModels = chartsDictionary[tokenId] else {`.
* Четвертая правка - переработка `MarketsItemViewModel`. Обновление контента происходило на основном потоке, а это форматирование цены и изменения цены, а под капотом это обращение к `MarketsTokenPriceFormatter` и `PriceChangeUtility`, которые выполняют довольно сложные операции, округление и форматирование. Теперь обработка этой инфы происходит на том потоке, на котором пришли данные - бэкгранд поток, т.к. инфа берется из репозитория квот после сетевого запроса. После формирования данных на главном потоке задаются новые строки просто

Пока что есть ещё проблемы, в частности с `Kingfisher`, в `Time Profiler` видно что много времени во время подвисаний тратится на операции либы с кэшем. Попробовал отключать `forceKingfisher`, чтобы для иконок использовался `CachedAsyncImage`, но тогда есть проблемы с прокрутной обратно, картинки не сразу берутся из кэша, а с небольшой задержкой и кажется будто они по новой грузятся. Надо, наконец, брать задачу с ресерчем либы `Nuke`, чтобы заменить `Kingfisher`, может она лучше будет работать.