### PR TITLE
IOS-8398 [Onramp] Fully separate from `SendAmountStep`

### DIFF
--- a/Tangem/App/Services/TokenQuotesRepository/CommonTokenQuotesRepository.swift
+++ b/Tangem/App/Services/TokenQuotesRepository/CommonTokenQuotesRepository.swift
@@ -48,9 +48,7 @@ extension CommonTokenQuotesRepository: TokenQuotesRepository {
 
         return quote
     }
-}
 
-extension CommonTokenQuotesRepository: TokenQuotesRepositoryUpdater {
     func loadQuotes(currencyIds: [String]) -> AnyPublisher<[String: Decimal], Never> {
         log("Request loading quotes for ids: \(currencyIds)")
 
@@ -62,6 +60,21 @@ extension CommonTokenQuotesRepository: TokenQuotesRepositoryUpdater {
         return outputPublisher.eraseToAnyPublisher()
     }
 
+    func loadPrice(currencyCode: String, currencyId: String) -> AnyPublisher<Decimal, any Error> {
+        let request = QuotesDTO.Request(coinIds: [currencyId], currencyId: currencyCode, fields: [.price])
+
+        return tangemApiService
+            .loadQuotes(requestModel: request)
+            .compactMap { quotes in
+                quotes.first(where: { $0.id == currencyId })?.price
+            }
+            .eraseToAnyPublisher()
+    }
+}
+
+// MARK: - TokenQuotesRepositoryUpdater
+
+extension CommonTokenQuotesRepository: TokenQuotesRepositoryUpdater {
     func saveQuotes(_ quotes: [TokenQuote]) {
         var current = _quotes.value
 

--- a/Tangem/App/Services/TokenQuotesRepository/TokenQuotesRepository.swift
+++ b/Tangem/App/Services/TokenQuotesRepository/TokenQuotesRepository.swift
@@ -20,6 +20,8 @@ protocol TokenQuotesRepository: AnyObject {
     /// Use it just for load and save quotes in the cache
     /// For get updates make a subscribe to quotesPublisher
     func loadQuotes(currencyIds: [String]) -> AnyPublisher<[String: Decimal], Never>
+
+    func loadPrice(currencyCode: String, currencyId: String) -> AnyPublisher<Decimal, Error>
 }
 
 extension TokenQuotesRepository {
@@ -37,6 +39,10 @@ extension TokenQuotesRepository {
 
     func loadQuotes(currencyIds: [String]) async {
         _ = try? await loadQuotes(currencyIds: currencyIds).async()
+    }
+
+    func loadPrice(currencyCode: String, currencyId: String) async -> Decimal? {
+        try? await loadPrice(currencyCode: currencyCode, currencyId: currencyId).async()
     }
 }
 

--- a/Tangem/Modules/Send/Factories/FlowBuilders/OnrampFlowBaseBuilder.swift
+++ b/Tangem/Modules/Send/Factories/FlowBuilders/OnrampFlowBaseBuilder.swift
@@ -13,6 +13,7 @@ struct OnrampFlowBaseBuilder {
     let userWalletModel: UserWalletModel
     let walletModel: WalletModel
     let sendAmountStepBuilder: SendAmountStepBuilder
+    let onrampAmountBuilder: OnrampAmountBuilder
     let onrampStepBuilder: OnrampStepBuilder
     let sendFinishStepBuilder: SendFinishStepBuilder
     let builder: SendDependenciesBuilder
@@ -23,9 +24,8 @@ struct OnrampFlowBaseBuilder {
 
         let onrampModel = builder.makeOnrampModel(onrampManager: onrampManager, onrampRepository: onrampRepository)
 
-        let onrampAmountViewModel = sendAmountStepBuilder.makeOnrampAmountViewModel(
-            io: (input: onrampModel, output: onrampModel),
-            sendAmountValidator: builder.makeOnrampAmountValidator()
+        let (onrampAmountViewModel, _) = onrampAmountBuilder.makeOnrampAmountViewModel(
+            io: (input: onrampModel, output: onrampModel)
         )
 
         let sendAmountCompactViewModel = sendAmountStepBuilder.makeSendAmountCompactViewModel(

--- a/Tangem/Modules/Send/Factories/SendFlowFactory.swift
+++ b/Tangem/Modules/Send/Factories/SendFlowFactory.swift
@@ -150,12 +150,14 @@ struct SendFlowFactory {
         let builder = SendDependenciesBuilder(userWalletModel: userWalletModel, walletModel: walletModel)
         let sendAmountStepBuilder = SendAmountStepBuilder(walletModel: walletModel, builder: builder)
         let onrampStepBuilder = OnrampStepBuilder(walletModel: walletModel)
+        let onrampAmountBuilder = OnrampAmountBuilder(walletModel: walletModel, builder: builder)
         let sendFinishStepBuilder = SendFinishStepBuilder(walletModel: walletModel)
 
         let baseBuilder = OnrampFlowBaseBuilder(
             userWalletModel: userWalletModel,
             walletModel: walletModel,
             sendAmountStepBuilder: sendAmountStepBuilder,
+            onrampAmountBuilder: onrampAmountBuilder,
             onrampStepBuilder: onrampStepBuilder,
             sendFinishStepBuilder: sendFinishStepBuilder,
             builder: builder

--- a/Tangem/Modules/Send/Factories/StepBuilders/OnrampAmountBuilder.swift
+++ b/Tangem/Modules/Send/Factories/StepBuilders/OnrampAmountBuilder.swift
@@ -1,0 +1,43 @@
+//
+//  OnrampAmountBuilder.swift
+//  TangemApp
+//
+//  Created by Sergey Balashov on 30.10.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import TangemExpress
+
+struct OnrampAmountBuilder {
+    typealias IO = (input: OnrampAmountInput, output: OnrampAmountOutput)
+    typealias ReturnValue = (viewModel: OnrampAmountViewModel, interactor: OnrampAmountInteractor)
+
+    private let walletModel: WalletModel
+    private let builder: SendDependenciesBuilder
+
+    init(walletModel: WalletModel, builder: SendDependenciesBuilder) {
+        self.walletModel = walletModel
+        self.builder = builder
+    }
+
+    func makeOnrampAmountViewModel(io: IO) -> ReturnValue {
+        let interactor = makeOnrampAmountInteractor(io: io)
+        let viewModel = OnrampAmountViewModel(tokenItem: walletModel.tokenItem, interactor: interactor)
+
+        return (viewModel: viewModel, interactor: interactor)
+    }
+}
+
+// MARK: - Private
+
+private extension OnrampAmountBuilder {
+    func makeOnrampAmountInteractor(io: IO) -> OnrampAmountInteractor {
+        CommonOnrampAmountInteractor(
+            input: io.input,
+            output: io.output,
+            tokenItem: walletModel.tokenItem,
+            validator: builder.makeOnrampAmountValidator()
+        )
+    }
+}

--- a/Tangem/Modules/Send/Factories/StepBuilders/SendAmountStepBuilder.swift
+++ b/Tangem/Modules/Send/Factories/StepBuilders/SendAmountStepBuilder.swift
@@ -55,20 +55,6 @@ struct SendAmountStepBuilder {
             tokenItem: walletModel.tokenItem
         )
     }
-
-    func makeOnrampAmountViewModel(
-        io: IO,
-        sendAmountValidator: SendAmountValidator
-    ) -> OnrampAmountViewModel {
-        let interactor = makeSendAmountInteractor(
-            io: io,
-            sendAmountValidator: sendAmountValidator,
-            amountModifier: nil,
-            type: .fiat
-        )
-
-        return OnrampAmountViewModel(tokenItem: walletModel.tokenItem, interactor: interactor)
-    }
 }
 
 // MARK: - Private

--- a/Tangem/Modules/Send/Services/ManagmentModels/OnrampModel.swift
+++ b/Tangem/Modules/Send/Services/ManagmentModels/OnrampModel.swift
@@ -22,7 +22,6 @@ class OnrampModel {
     private let _amount: CurrentValueSubject<SendAmount?, Never> = .init(.none)
     private let _selectedQuote: CurrentValueSubject<LoadingValue<OnrampQuote>?, Never> = .init(.none)
     private let _transactionTime = PassthroughSubject<Date?, Never>()
-    private let _state = CurrentValueSubject<State?, Never>(nil)
     private let _isLoading = CurrentValueSubject<Bool, Never>(false)
 
     // MARK: - Dependencies
@@ -167,7 +166,7 @@ extension OnrampModel: OnrampAmountInput {
         _currency.value
     }
 
-    var currencyPublisher: AnyPublisher<LoadingValue<TangemExpress.OnrampFiatCurrency>, Never> {
+    var fiatCurrencyPublisher: AnyPublisher<LoadingValue<OnrampFiatCurrency>, Never> {
         _currency.eraseToAnyPublisher()
     }
 }
@@ -210,12 +209,7 @@ extension OnrampModel: SendFinishInput {
 
 extension OnrampModel: SendBaseInput {
     var actionInProcessing: AnyPublisher<Bool, Never> {
-        _state.map { state in
-            switch state {
-            case .loading: true
-            default: false
-            }
-        }.eraseToAnyPublisher()
+        _isLoading.eraseToAnyPublisher()
     }
 }
 
@@ -233,14 +227,6 @@ extension OnrampModel: SendBaseOutput {
 // MARK: - OnrampBaseDataBuilderInput
 
 extension OnrampModel: OnrampBaseDataBuilderInput {}
-
-extension OnrampModel {
-    enum State {
-        case loading
-        case error(String)
-        case loaded
-    }
-}
 
 enum OnrampModelError: String, LocalizedError {
     case countryNotFound

--- a/Tangem/Modules/Send/Services/SendStepsManager/Flows/CommonOnrampStepsManager.swift
+++ b/Tangem/Modules/Send/Services/SendStepsManager/Flows/CommonOnrampStepsManager.swift
@@ -58,7 +58,7 @@ extension CommonOnrampStepsManager: SendStepsManager {
     }
 
     var shouldShowDismissAlert: Bool {
-        return false
+        return true
     }
 
     func set(output: SendStepsManagerOutput) {

--- a/Tangem/Modules/Send/UI/Amount/Interactor/SendAmount.swift
+++ b/Tangem/Modules/Send/UI/Amount/Interactor/SendAmount.swift
@@ -27,6 +27,7 @@ struct SendAmount: Hashable {
     func formatAlternative(
         currencySymbol: String,
         balanceFormatter: BalanceFormatter = .init(),
+        trimFractions: Bool = true,
         decimalCount: Int
     ) -> String? {
         switch type {
@@ -40,7 +41,7 @@ struct SendAmount: Hashable {
             let formatter = SendCryptoValueFormatter(
                 decimals: decimalCount,
                 currencySymbol: currencySymbol,
-                trimFractions: true
+                trimFractions: trimFractions
             )
 
             return formatter.string(from: crypto)

--- a/Tangem/Modules/Send/UI/OnrampAmount/Interactor/OnrampAmountInputOutput.swift
+++ b/Tangem/Modules/Send/UI/OnrampAmount/Interactor/OnrampAmountInputOutput.swift
@@ -1,0 +1,19 @@
+//
+//  OnrampAmountInputOutput.swift
+//  TangemApp
+//
+//  Created by Sergey Balashov on 30.10.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Combine
+import TangemExpress
+
+protocol OnrampAmountInput: AnyObject {
+    var fiatCurrency: LoadingValue<OnrampFiatCurrency> { get }
+    var currencyPublisher: AnyPublisher<LoadingValue<OnrampFiatCurrency>, Never> { get }
+}
+
+protocol OnrampAmountOutput: AnyObject {
+    func amountDidChanged(amount: SendAmount?)
+}

--- a/Tangem/Modules/Send/UI/OnrampAmount/Interactor/OnrampAmountInputOutput.swift
+++ b/Tangem/Modules/Send/UI/OnrampAmount/Interactor/OnrampAmountInputOutput.swift
@@ -11,7 +11,7 @@ import TangemExpress
 
 protocol OnrampAmountInput: AnyObject {
     var fiatCurrency: LoadingValue<OnrampFiatCurrency> { get }
-    var currencyPublisher: AnyPublisher<LoadingValue<OnrampFiatCurrency>, Never> { get }
+    var fiatCurrencyPublisher: AnyPublisher<LoadingValue<OnrampFiatCurrency>, Never> { get }
 }
 
 protocol OnrampAmountOutput: AnyObject {

--- a/Tangem/Modules/Send/UI/OnrampAmount/Interactor/OnrampAmountInteractor.swift
+++ b/Tangem/Modules/Send/UI/OnrampAmount/Interactor/OnrampAmountInteractor.swift
@@ -10,7 +10,7 @@ import Combine
 import TangemExpress
 
 protocol OnrampAmountInteractor {
-    var currencyPublisher: AnyPublisher<LoadingValue<OnrampFiatCurrency>, Never> { get }
+    var currencyPublisher: AnyPublisher<OnrampFiatCurrency?, Never> { get }
     var errorPublisher: AnyPublisher<String?, Never> { get }
 
     func update(amount: Decimal?) async -> SendAmount?
@@ -80,13 +80,13 @@ private extension CommonOnrampAmountInteractor {
 // MARK: - OnrampAmountInteractor
 
 extension CommonOnrampAmountInteractor: OnrampAmountInteractor {
-    var currencyPublisher: AnyPublisher<LoadingValue<OnrampFiatCurrency>, Never> {
+    var currencyPublisher: AnyPublisher<OnrampFiatCurrency?, Never> {
         guard let input else {
             assertionFailure("OnrampAmountInput not found")
             return Empty().eraseToAnyPublisher()
         }
 
-        return input.currencyPublisher.eraseToAnyPublisher()
+        return input.fiatCurrencyPublisher.map { $0.value }.eraseToAnyPublisher()
     }
 
     var errorPublisher: AnyPublisher<String?, Never> {

--- a/Tangem/Modules/Send/UI/OnrampAmount/Interactor/OnrampAmountInteractor.swift
+++ b/Tangem/Modules/Send/UI/OnrampAmount/Interactor/OnrampAmountInteractor.swift
@@ -1,0 +1,105 @@
+//
+//  OnrampAmountInteractor.swift
+//  TangemApp
+//
+//  Created by Sergey Balashov on 30.10.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Combine
+import TangemExpress
+
+protocol OnrampAmountInteractor {
+    var currencyPublisher: AnyPublisher<LoadingValue<OnrampFiatCurrency>, Never> { get }
+    var errorPublisher: AnyPublisher<String?, Never> { get }
+
+    func update(amount: Decimal?) async -> SendAmount?
+}
+
+class CommonOnrampAmountInteractor {
+    @Injected(\.quotesRepository) private var quotesRepository: TokenQuotesRepository
+
+    private weak var input: OnrampAmountInput?
+    private weak var output: OnrampAmountOutput?
+    private let tokenItem: TokenItem
+    private let validator: SendAmountValidator
+
+    private var _error: CurrentValueSubject<String?, Never> = .init(nil)
+    private var _isValid: CurrentValueSubject<Bool, Never> = .init(false)
+
+    init(
+        input: OnrampAmountInput,
+        output: OnrampAmountOutput,
+        tokenItem: TokenItem,
+        validator: SendAmountValidator
+    ) {
+        self.input = input
+        self.output = output
+        self.tokenItem = tokenItem
+        self.validator = validator
+    }
+}
+
+// MARK: - Private
+
+private extension CommonOnrampAmountInteractor {
+    func makeSendAmount(fiat: Decimal) async -> SendAmount {
+        guard let currency = input?.fiatCurrency.value,
+              let currencyId = tokenItem.currencyId else {
+            return .init(type: .alternative(fiat: fiat, crypto: nil))
+        }
+
+        let price = await quotesRepository.loadPrice(currencyCode: currency.identity.code, currencyId: currencyId)
+        let crypto = price.map { fiat * $0 }
+
+        return .init(type: .alternative(fiat: fiat, crypto: crypto))
+    }
+
+    private func validateAndUpdate(amount: SendAmount?) {
+        do {
+            guard let crypto = amount?.crypto, crypto > 0 else {
+                // Field is empty or zero
+                update(amount: .none, isValid: false, error: .none)
+                return
+            }
+
+            try validator.validate(amount: crypto)
+            update(amount: amount, isValid: true, error: .none)
+        } catch {
+            update(amount: .none, isValid: false, error: error)
+        }
+    }
+
+    private func update(amount: SendAmount?, isValid: Bool, error: Error?) {
+        _error.send(error?.localizedDescription)
+        _isValid.send(isValid)
+        output?.amountDidChanged(amount: amount)
+    }
+}
+
+// MARK: - OnrampAmountInteractor
+
+extension CommonOnrampAmountInteractor: OnrampAmountInteractor {
+    var currencyPublisher: AnyPublisher<LoadingValue<OnrampFiatCurrency>, Never> {
+        guard let input else {
+            assertionFailure("OnrampAmountInput not found")
+            return Empty().eraseToAnyPublisher()
+        }
+
+        return input.currencyPublisher.eraseToAnyPublisher()
+    }
+
+    var errorPublisher: AnyPublisher<String?, Never> {
+        _error.eraseToAnyPublisher()
+    }
+
+    func update(amount: Decimal?) async -> SendAmount? {
+        guard let amount else {
+            validateAndUpdate(amount: nil)
+            return nil
+        }
+
+        let sendAmount = await makeSendAmount(fiat: amount)
+        return sendAmount
+    }
+}

--- a/Tangem/Modules/Send/UI/OnrampAmount/OnrampAmountView/OnrampAmountView.swift
+++ b/Tangem/Modules/Send/UI/OnrampAmount/OnrampAmountView/OnrampAmountView.swift
@@ -34,12 +34,7 @@ struct OnrampAmountView: View {
             .matchedGeometryEffect(id: namespace.names.tokenIcon, in: namespace.id)
 
             VStack(spacing: 6) {
-                SendDecimalNumberTextField(viewModel: viewModel.decimalNumberTextFieldViewModel)
-                    .initialFocusBehavior(.noFocus)
-                    .alignment(.center)
-                    .prefixSuffixOptions(viewModel.currentFieldOptions)
-                    .minTextScale(SendAmountStep.Constants.amountMinTextScale)
-                    .matchedGeometryEffect(id: namespace.names.amountCryptoText, in: namespace.id)
+                textField
 
                 // Keep empty text so that the view maintains its place in the layout
                 Text(viewModel.alternativeAmount ?? " ")
@@ -50,6 +45,16 @@ struct OnrampAmountView: View {
                 bottomInfoText
             }
         }
+    }
+
+    private var textField: some View {
+        SendDecimalNumberTextField(viewModel: viewModel.decimalNumberTextFieldViewModel)
+            .initialFocusBehavior(.noFocus)
+            .alignment(.center)
+            .prefixSuffixOptions(viewModel.currentFieldOptions)
+            .minTextScale(SendAmountStep.Constants.amountMinTextScale)
+            .matchedGeometryEffect(id: namespace.names.amountCryptoText, in: namespace.id)
+            .skeletonable(isShown: viewModel.isLoading)
     }
 
     private var bottomInfoText: some View {

--- a/Tangem/Modules/Send/UI/OnrampAmount/OnrampAmountView/OnrampAmountView.swift
+++ b/Tangem/Modules/Send/UI/OnrampAmount/OnrampAmountView/OnrampAmountView.swift
@@ -34,7 +34,13 @@ struct OnrampAmountView: View {
             .matchedGeometryEffect(id: namespace.names.tokenIcon, in: namespace.id)
 
             VStack(spacing: 6) {
-                textField
+                SendDecimalNumberTextField(viewModel: viewModel.decimalNumberTextFieldViewModel)
+                    .initialFocusBehavior(.noFocus)
+                    .alignment(.center)
+                    .prefixSuffixOptions(viewModel.currentFieldOptions)
+                    .minTextScale(SendAmountStep.Constants.amountMinTextScale)
+                    .matchedGeometryEffect(id: namespace.names.amountCryptoText, in: namespace.id)
+                    .skeletonable(isShown: viewModel.isLoading)
 
                 // Keep empty text so that the view maintains its place in the layout
                 Text(viewModel.alternativeAmount ?? " ")
@@ -45,16 +51,6 @@ struct OnrampAmountView: View {
                 bottomInfoText
             }
         }
-    }
-
-    private var textField: some View {
-        SendDecimalNumberTextField(viewModel: viewModel.decimalNumberTextFieldViewModel)
-            .initialFocusBehavior(.noFocus)
-            .alignment(.center)
-            .prefixSuffixOptions(viewModel.currentFieldOptions)
-            .minTextScale(SendAmountStep.Constants.amountMinTextScale)
-            .matchedGeometryEffect(id: namespace.names.amountCryptoText, in: namespace.id)
-            .skeletonable(isShown: viewModel.isLoading)
     }
 
     private var bottomInfoText: some View {

--- a/Tangem/Modules/Send/UI/OnrampAmount/OnrampAmountView/OnrampAmountViewModel.swift
+++ b/Tangem/Modules/Send/UI/OnrampAmount/OnrampAmountView/OnrampAmountViewModel.swift
@@ -71,22 +71,20 @@ private extension OnrampAmountViewModel {
             .store(in: &bag)
     }
 
-    func update(currency: LoadingValue<OnrampFiatCurrency>) {
+    func update(currency: OnrampFiatCurrency?) {
         switch currency {
-        case .loading:
+        case .none:
             // Equal to loading state
             fiatIconURL = nil
             isLoading = true
 
-        case .loaded(let currency):
+        case .some(let currency):
             fiatIconURL = currency.identity.image
             decimalNumberTextFieldViewModel.update(maximumFractionDigits: currency.precision)
             currentFieldOptions = prefixSuffixOptionsFactory.makeFiatOptions(
                 fiatCurrencyCode: currency.identity.code
             )
             isLoading = false
-        case .failedToLoad(let error):
-            break
         }
     }
 

--- a/Tangem/Modules/Send/UI/OnrampAmount/OnrampAmountView/OnrampAmountViewModel.swift
+++ b/Tangem/Modules/Send/UI/OnrampAmount/OnrampAmountView/OnrampAmountViewModel.swift
@@ -56,6 +56,7 @@ private extension OnrampAmountViewModel {
 
         decimalNumberTextFieldViewModel
             .valuePublisher
+            .debounce(for: 1, scheduler: DispatchQueue.main)
             .withWeakCaptureOf(self)
             .receive(on: DispatchQueue.main)
             .sink { viewModel, value in

--- a/Tangem/Modules/Send/UI/OnrampAmount/OnrampAmountView/OnrampAmountViewModel.swift
+++ b/Tangem/Modules/Send/UI/OnrampAmount/OnrampAmountView/OnrampAmountViewModel.swift
@@ -84,6 +84,7 @@ private extension OnrampAmountViewModel {
             currentFieldOptions = prefixSuffixOptionsFactory.makeFiatOptions(
                 fiatCurrencyCode: currency.identity.code
             )
+            updateAlternativeAmount(amount: .none)
             isLoading = false
         }
     }
@@ -94,11 +95,17 @@ private extension OnrampAmountViewModel {
             let amount = await viewModel.interactor.update(amount: amount)
 
             await runOnMain {
-                viewModel.alternativeAmount = amount?.formatAlternative(
-                    currencySymbol: viewModel.tokenItem.currencySymbol,
-                    decimalCount: viewModel.tokenItem.decimalCount
-                )
+                viewModel.updateAlternativeAmount(amount: amount)
             }
         }
+    }
+
+    func updateAlternativeAmount(amount: SendAmount?) {
+        let amount = amount ?? SendAmount(type: .alternative(fiat: nil, crypto: 0))
+        alternativeAmount = amount.formatAlternative(
+            currencySymbol: tokenItem.currencySymbol,
+            trimFractions: false,
+            decimalCount: tokenItem.decimalCount
+        )
     }
 }

--- a/Tangem/Preview Content/Fakes/FakeTokenQuotesRepository.swift
+++ b/Tangem/Preview Content/Fakes/FakeTokenQuotesRepository.swift
@@ -71,6 +71,10 @@ class FakeTokenQuotesRepository: TokenQuotesRepository, TokenQuotesRepositoryUpd
         Just([:]).eraseToAnyPublisher()
     }
 
+    func loadPrice(currencyCode: String, currencyId: String) -> AnyPublisher<Decimal, any Error> {
+        Just(1.2345).setFailureType(to: Error.self).eraseToAnyPublisher()
+    }
+
     func saveQuotes(_ quotes: [TokenQuote]) {
         var current = currentQuotes.value
 

--- a/Tangem/Preview Content/Mocks/TokenQuotesRepositoryMock.swift
+++ b/Tangem/Preview Content/Mocks/TokenQuotesRepositoryMock.swift
@@ -27,6 +27,10 @@ class TokenQuotesRepositoryMock: TokenQuotesRepository, TokenQuotesRepositoryUpd
 
     func quote(for item: TokenItem) -> TokenQuote? { nil }
     func loadQuotes(currencyIds: [String]) -> AnyPublisher<[String: Decimal], Never> { Just([:]).eraseToAnyPublisher() }
+    func loadPrice(currencyCode: String, currencyId: String) -> AnyPublisher<Decimal, any Error> {
+        Just(1.2345).setFailureType(to: Error.self).eraseToAnyPublisher()
+    }
+
     func saveQuotes(_ quotes: [Quote], currencyCode: String) {}
     func saveQuotes(_ quotes: [TokenQuote]) {}
 }

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -2492,6 +2492,12 @@
 		EF8BE6BD2CCA994F001FBA2B /* OnrampRedirectDataRequestItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8BE6BC2CCA9941001FBA2B /* OnrampRedirectDataRequestItem.swift */; };
 		EF8BE6C02CCA9CC3001FBA2B /* CommonOnrampDataRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8BE6BF2CCA9CC3001FBA2B /* CommonOnrampDataRepository.swift */; };
 		EF8BE6C42CCB95D7001FBA2B /* OnrampRoutable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8BE6C32CCB95D7001FBA2B /* OnrampRoutable.swift */; };
+		EF8BE6B02CCA71E3001FBA2B /* CommonOnrampProviderManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8BE6AF2CCA71E0001FBA2B /* CommonOnrampProviderManager.swift */; };
+		EF8BE6B32CCA8800001FBA2B /* OnrampDataRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8BE6B22CCA87FE001FBA2B /* OnrampDataRepository.swift */; };
+		EF8BE6BB2CCA98CB001FBA2B /* OnrampPairRequestItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8BE6BA2CCA98CA001FBA2B /* OnrampPairRequestItem.swift */; };
+		EF8BE6BD2CCA994F001FBA2B /* OnrampRedirectDataRequestItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8BE6BC2CCA9941001FBA2B /* OnrampRedirectDataRequestItem.swift */; };
+		EF8BE6C02CCA9CC3001FBA2B /* CommonOnrampDataRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8BE6BF2CCA9CC3001FBA2B /* CommonOnrampDataRepository.swift */; };
+		EF8BE6C42CCB95D7001FBA2B /* OnrampRoutable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8BE6C32CCB95D7001FBA2B /* OnrampRoutable.swift */; };
 		EF8D780F2981458500B67418 /* UserTokenListManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8D780E2981458500B67418 /* UserTokenListManagerMock.swift */; };
 		EF8DBCDD2C060A03009072CF /* StakingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8DBCDC2C060A03009072CF /* StakingManager.swift */; };
 		EF8DBCE02C060CCE009072CF /* StakingDependenciesFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8DBCDF2C060CCE009072CF /* StakingDependenciesFactory.swift */; };
@@ -2597,6 +2603,9 @@
 		EF9F907F299CFCC7006F638F /* WebViewContainerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF9F907E299CFCC7006F638F /* WebViewContainerViewModel.swift */; };
 		EF9F9081299CFCE9006F638F /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF9F9080299CFCE9006F638F /* WebView.swift */; };
 		EF9F9090299FAE84006F638F /* SupportChatInputModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF9F908F299FAE84006F638F /* SupportChatInputModel.swift */; };
+		EFA1547E2CD24B7C00A0642C /* OnrampAmountInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA1547D2CD24B7700A0642C /* OnrampAmountInteractor.swift */; };
+		EFA154802CD24B8700A0642C /* OnrampAmountInputOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA1547F2CD24B8000A0642C /* OnrampAmountInputOutput.swift */; };
+		EFA154822CD2542700A0642C /* OnrampAmountBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA154812CD2542100A0642C /* OnrampAmountBuilder.swift */; };
 		EFA3B2212AC43C350037C48D /* MultipleAddressTransactionHistoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA3B2202AC43C350037C48D /* MultipleAddressTransactionHistoryService.swift */; };
 		EFA4E3752C3EE6ED008815AD /* StakingValidatorsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA4E3742C3EE6ED008815AD /* StakingValidatorsInteractor.swift */; };
 		EFA4E3772C3EE785008815AD /* FakeStakingValidatorsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA4E3762C3EE785008815AD /* FakeStakingValidatorsInteractor.swift */; };
@@ -5495,6 +5504,12 @@
 		EF8BE6BC2CCA9941001FBA2B /* OnrampRedirectDataRequestItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampRedirectDataRequestItem.swift; sourceTree = "<group>"; };
 		EF8BE6BF2CCA9CC3001FBA2B /* CommonOnrampDataRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonOnrampDataRepository.swift; sourceTree = "<group>"; };
 		EF8BE6C32CCB95D7001FBA2B /* OnrampRoutable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampRoutable.swift; sourceTree = "<group>"; };
+		EF8BE6AF2CCA71E0001FBA2B /* CommonOnrampProviderManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonOnrampProviderManager.swift; sourceTree = "<group>"; };
+		EF8BE6B22CCA87FE001FBA2B /* OnrampDataRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampDataRepository.swift; sourceTree = "<group>"; };
+		EF8BE6BA2CCA98CA001FBA2B /* OnrampPairRequestItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampPairRequestItem.swift; sourceTree = "<group>"; };
+		EF8BE6BC2CCA9941001FBA2B /* OnrampRedirectDataRequestItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampRedirectDataRequestItem.swift; sourceTree = "<group>"; };
+		EF8BE6BF2CCA9CC3001FBA2B /* CommonOnrampDataRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonOnrampDataRepository.swift; sourceTree = "<group>"; };
+		EF8BE6C32CCB95D7001FBA2B /* OnrampRoutable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampRoutable.swift; sourceTree = "<group>"; };
 		EF8D780E2981458500B67418 /* UserTokenListManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTokenListManagerMock.swift; sourceTree = "<group>"; };
 		EF8DBCDC2C060A03009072CF /* StakingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingManager.swift; sourceTree = "<group>"; };
 		EF8DBCDF2C060CCE009072CF /* StakingDependenciesFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingDependenciesFactory.swift; sourceTree = "<group>"; };
@@ -5598,6 +5613,9 @@
 		EF9F907E299CFCC7006F638F /* WebViewContainerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewContainerViewModel.swift; sourceTree = "<group>"; };
 		EF9F9080299CFCE9006F638F /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
 		EF9F908F299FAE84006F638F /* SupportChatInputModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportChatInputModel.swift; sourceTree = "<group>"; };
+		EFA1547D2CD24B7700A0642C /* OnrampAmountInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampAmountInteractor.swift; sourceTree = "<group>"; };
+		EFA1547F2CD24B8000A0642C /* OnrampAmountInputOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampAmountInputOutput.swift; sourceTree = "<group>"; };
+		EFA154812CD2542100A0642C /* OnrampAmountBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampAmountBuilder.swift; sourceTree = "<group>"; };
 		EFA3B2202AC43C350037C48D /* MultipleAddressTransactionHistoryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleAddressTransactionHistoryService.swift; sourceTree = "<group>"; };
 		EFA4E3742C3EE6ED008815AD /* StakingValidatorsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingValidatorsInteractor.swift; sourceTree = "<group>"; };
 		EFA4E3762C3EE785008815AD /* FakeStakingValidatorsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeStakingValidatorsInteractor.swift; sourceTree = "<group>"; };
@@ -11625,7 +11643,6 @@
 				EFC84B202C37FBB200546882 /* SendAmountStep.swift */,
 				EF665E402CBD23B600F79B87 /* SendAmountView */,
 				EF0FBB6D2C53BE300095A6BD /* SendAmountCompactView */,
-				EFB23F322CBE80BC005A6719 /* OnrampAmountView */,
 				EF031A7D2C0DD234001535C9 /* Interactor */,
 				EFAECCEF2C1B6F760051710F /* SendCurrencyPicker */,
 			);
@@ -13350,6 +13367,7 @@
 				DA559C202B0261F300F59584 /* Fee */,
 				DA559C272B0261F400F59584 /* Summary */,
 				EFB23F2E2CBE7FA4005A6719 /* Onramp */,
+				EFA1547B2CD24B5300A0642C /* OnrampAmount */,
 				DAF72F3E2B0F480A0006B44F /* Finish */,
 				EF665E462CBD24F800F79B87 /* UITypes */,
 			);
@@ -14108,6 +14126,24 @@
 			path = WebViewContainer;
 			sourceTree = "<group>";
 		};
+		EFA1547B2CD24B5300A0642C /* OnrampAmount */ = {
+			isa = PBXGroup;
+			children = (
+				EFB23F322CBE80BC005A6719 /* OnrampAmountView */,
+				EFA1547C2CD24B6A00A0642C /* Interactor */,
+			);
+			path = OnrampAmount;
+			sourceTree = "<group>";
+		};
+		EFA1547C2CD24B6A00A0642C /* Interactor */ = {
+			isa = PBXGroup;
+			children = (
+				EFA1547D2CD24B7700A0642C /* OnrampAmountInteractor.swift */,
+				EFA1547F2CD24B8000A0642C /* OnrampAmountInputOutput.swift */,
+			);
+			path = Interactor;
+			sourceTree = "<group>";
+		};
 		EFA580642893F89000110DB0 /* ResetToFactory */ = {
 			isa = PBXGroup;
 			children = (
@@ -14488,6 +14524,7 @@
 				EFC84B032C37FAB500546882 /* SendFinishStepBuilder.swift */,
 				EFA4E37A2C3EEC6D008815AD /* StakingValidatorsStepBuilder.swift */,
 				EFD68F202CC2985E00693C97 /* OnrampStepBuilder.swift */,
+				EFA154812CD2542100A0642C /* OnrampAmountBuilder.swift */,
 			);
 			path = StepBuilders;
 			sourceTree = "<group>";
@@ -16168,6 +16205,7 @@
 				B696109A2A428CA300CF88B7 /* OrganizeTokensListItemView.swift in Sources */,
 				DCF8972D28ACF8CA002A85F6 /* TangemSdkConfigFactory.swift in Sources */,
 				B0A596542991FC1200C7C512 /* UtorgService.swift in Sources */,
+				EFA154822CD2542700A0642C /* OnrampAmountBuilder.swift in Sources */,
 				B020FFB425DE7F9300EF422C /* DataCollectors.swift in Sources */,
 				B6ACD00E2AD698F6005A6CA3 /* DragAndDropGestureContextProviding.swift in Sources */,
 				EFD68F282CC2993000693C97 /* OnrampInteractor.swift in Sources */,
@@ -16582,6 +16620,7 @@
 				DCA21D942BA1C77A000A3C1A /* ValidationMode.swift in Sources */,
 				DC72548E2A02BB810003FE1B /* CardInitializerMock.swift in Sources */,
 				B0CC818325CD63FB006D49B9 /* Token+.swift in Sources */,
+				EFA1547E2CD24B7C00A0642C /* OnrampAmountInteractor.swift in Sources */,
 				DC22535B28A4FDE90094F30C /* GeneralNotificationEventsFactory.swift in Sources */,
 				B041C96E2C3FF74100CE027A /* TangemProgressViewStyle.swift in Sources */,
 				B04CD3482912AA61001EA84A /* IconWithMessagePlaceholderView.swift in Sources */,
@@ -16662,6 +16701,7 @@
 				DCF2369129924C0900FE1855 /* AnalyticsContext.swift in Sources */,
 				DAC53CFF27BE63830027147D /* FinishStoryPage.swift in Sources */,
 				DC295B482861C4BE006CB7B6 /* DetailsCoordinator.swift in Sources */,
+				EFA154802CD24B8700A0642C /* OnrampAmountInputOutput.swift in Sources */,
 				B6D274EB2C38384400FEFCDC /* PushNotificationsBottomSheetView.swift in Sources */,
 				DC7D3A0B29E07829007BCD23 /* TwinTangemSdkFactory.swift in Sources */,
 				B02275D72701D9FB004C752B /* PreparePrimaryCardTask.swift in Sources */,


### PR DESCRIPTION
Решили разделить логику ввода суммы, так как в onramp работа с фиат, нет переключателя(хотя хз почему) и нужно подгружать рейты отдельно для каждой валюты