### PR TITLE
iOS-8446 [Staking] solana estimate fee error

### DIFF
--- a/Tangem/Modules/Send/Services/ManagmentModels/UnstakingModel.swift
+++ b/Tangem/Modules/Send/Services/ManagmentModels/UnstakingModel.swift
@@ -64,7 +64,6 @@ class UnstakingModel {
 
         _amount = CurrentValueSubject(SendAmount(type: .typical(crypto: action.amount, fiat: fiat)))
 
-        updateState()
         logOpenScreen()
     }
 }

--- a/Tangem/Modules/Send/Services/ManagmentModels/UnstakingModel.swift
+++ b/Tangem/Modules/Send/Services/ManagmentModels/UnstakingModel.swift
@@ -103,6 +103,8 @@ private extension UnstakingModel {
                 model.update(state: .loading)
                 let state = try await model.state(amount: amount)
                 model.update(state: state)
+            } catch _ as CancellationError {
+                // Do nothing
             } catch {
                 AppLog.shared.error(error)
                 model.update(state: .networkError(error))


### PR DESCRIPTION
Проблема была в том что если запрос на estimate fee выполнялся долго, то после ввода суммы следующий запрос отменял первый. Убрал первый запрос при входе, т.к. он по сути не нужен, после ввода все равно запросим еще раз. Также на всякий случай добавил игнор CancellationError.