### PR TITLE
IOS-8451: Fix text attributes in `AddressTextView`

### DIFF
--- a/Tangem/Modules/Send/UI/Destination/AddressView/AddressTextView.swift
+++ b/Tangem/Modules/Send/UI/Destination/AddressView/AddressTextView.swift
@@ -65,7 +65,13 @@ private struct TextViewWrapper: UIViewRepresentable {
         textView.backgroundColor = .clear
         textView.textContainer.lineFragmentPadding = 0
 
-        textView.attributedText = attributedText(text)
+        let newAttributedText = attributedText(text)
+        // UITextView instance won't use attributes from an empty NSAttributedString, so we temporarily
+        // assign a dummy non-empty attributed string to set all attributes in the UITextView instance
+        if newAttributedText.string.isEmpty {
+            textView.attributedText = attributedText(#fileID)
+        }
+        textView.attributedText = newAttributedText
 
         return textView
     }


### PR DESCRIPTION
[IOS-8451](https://tangem.atlassian.net/browse/IOS-8451)

Баг в принципе существовал с самого начала сенда

Аттрибуты не обновлялись в `updateUIView`, т.к. `updateUIView` дергается уже после того, как внутри самого UITextView обновлен текст и соответственно условие `if uiView.attributedText.string != newAttributedText.string` не выполняется. Оно вообще предназначено и будет работать при external обновлении (программно через биндинг)  текста, а не internal обновлении (при вводе в инпут)

[IOS-8451]: https://tangem.atlassian.net/browse/IOS-8451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ