### PR TITLE
IOS-8495: Misc CI/CD improvements

### DIFF
--- a/.github/workflows/build-deploy-alpha.yml
+++ b/.github/workflows/build-deploy-alpha.yml
@@ -7,9 +7,9 @@ on:
         description: >
           Optional build version override. Leave blank (default value) to use the default value derived from the branch name
         type: string
-      changelog:
+      build_description:
         description: >
-          Optional additional info about build
+          Optional additional info about the build
         type: string
       xcode_version_override:
         description: >
@@ -24,12 +24,12 @@ concurrency:
 jobs:
   prepare:
     name: Prepare information
-    runs-on: [self-hosted, active]
+    runs-on: ubuntu-latest
     outputs:
       version: '${{ steps.version.outputs.build_version }}'
-      stage: Alpha
+      stage: 'Alpha'
       build_number: '${{ github.run_number }}'
-      changelog: '${{ steps.changelog.outputs.result }}'
+      jira_summary: '${{ steps.jira.outputs.summary }}'
     steps:
       - name: Jira Login
         uses: atlassian/gajira-login@master
@@ -51,8 +51,6 @@ jobs:
           JIRA_ISSUE_KEY: '${{ steps.jira.outputs.key }}'
           BUILD_VERSION_OVERRIDE: '${{ inputs.build_version_override }}'
         run: |
-          BUILD_VERSION=""
-
           if [[ -n "${BUILD_VERSION_OVERRIDE}" ]]; then
             # Use the build version value from user input (if any)
             BUILD_VERSION="${BUILD_VERSION_OVERRIDE}"
@@ -66,51 +64,33 @@ jobs:
 
           echo "build_version=${BUILD_VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Create changelog
-        id: changelog
-        env:
-          JIRA_ISSUE_SUMMARY: '${{ steps.jira.outputs.summary }}'
-          JIRA_ISSUE_KEY: '${{ steps.jira.outputs.key }}'
-          ADDITIONAL_CHANGELOG: '${{ inputs.changelog }}'
-        run: |
-          JIRA_DESCRIPTION="Jira issue: ${JIRA_ISSUE_KEY} ${JIRA_ISSUE_SUMMARY}"
-          if [[ -n "${ADDITIONAL_CHANGELOG}" ]]; then
-            OUTPUT_VALUE="Description: ${ADDITIONAL_CHANGELOG}"$'\n'"${JIRA_DESCRIPTION}"
-          else
-            OUTPUT_VALUE="${JIRA_DESCRIPTION}"
-          fi
-
-          # Workaround for a multi-line text in GH output
-          echo 'result<<EOF' >> $GITHUB_OUTPUT
-          echo "${OUTPUT_VALUE}" >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
-
   build:
     name: Tangem Alpha
     needs: prepare
-    uses: tangem/actions/.github/workflows/build.yml@feature/IOS-8112_ci_cd_alpha_builds_workflow
+    uses: tangem/actions/.github/workflows/build.yml@feature/IOS-8495_misc_cicd_improvements
     with:
       stage: '${{ needs.prepare.outputs.stage }}'
       version: '${{ needs.prepare.outputs.version }}'
       build_number: '${{ needs.prepare.outputs.build_number }}'
-      path: fastlane/builds/
-      filename: Tangem-${{ needs.prepare.outputs.stage }}-${{ needs.prepare.outputs.version }}(${{ needs.prepare.outputs.build_number }}).ipa
+      path: 'fastlane/builds/'
+      filename: 'Tangem-${{ needs.prepare.outputs.stage }}-${{ needs.prepare.outputs.version }}(${{ needs.prepare.outputs.build_number }}).ipa'
       xcode_version_override: '${{ inputs.xcode_version_override }}'
     secrets:
       GH_MOBILE_PAT: '${{ secrets.GH_MOBILE_PAT }}'
 
   deploy:
     name: Google Distribution
+    uses: tangem/actions/.github/workflows/deploy-firebase.yml@feature/IOS-8495_misc_cicd_improvements
     needs:
       - prepare
       - build
-    uses: tangem/actions/.github/workflows/deploy-firebase.yml@feature/IOS-8112_ci_cd_alpha_builds_workflow
     with:
       stage: '${{ needs.prepare.outputs.stage }}'
       version: '${{ needs.prepare.outputs.version }}'
       build_number: '${{ needs.prepare.outputs.build_number }}'
-      changelog: '${{ needs.prepare.outputs.changelog }}'
-      filename: Tangem-${{ needs.prepare.outputs.stage }}-${{ needs.prepare.outputs.version }}(${{ needs.prepare.outputs.build_number }}).ipa
+      changelog: '${{ needs.prepare.outputs.jira_summary }}'
+      build_description: '${{ inputs.build_description }}'
+      filename: 'Tangem-${{ needs.prepare.outputs.stage }}-${{ needs.prepare.outputs.version }}(${{ needs.prepare.outputs.build_number }}).ipa'
     secrets:
       FIREBASE_APP_ID: '${{ secrets.FIREBASE_APP_ID }}'
       FIREBASE_CLI_TOKEN: '${{ secrets.FIREBASE_CLI_TOKEN }}'
@@ -118,37 +98,39 @@ jobs:
 
   notification:
     name: Deploy Notification
+    uses: tangem/actions/.github/workflows/notification.yml@feature/IOS-8495_misc_cicd_improvements
     needs:
       - prepare
       - build
       - deploy
-    uses: tangem/actions/.github/workflows/notification.yml@feature/IOS-8112_ci_cd_alpha_builds_workflow
     with:
       channel: '${{ vars.SLACK_CHANNEL_DEPLOYMENTS_IOS }}'
-      status: success
+      status: 'success'
       app_name: '${{ vars.APP_ALPHA }}'
       deploy_to: '${{ vars.DEPLOYMENT_GOOGLE_DISTRIBUTION }}'
       version: '${{ needs.prepare.outputs.version }}'
       build_number: '${{ needs.prepare.outputs.build_number }}'
-      changelog: '${{ needs.prepare.outputs.changelog }}'
+      changelog: '${{ needs.prepare.outputs.jira_summary }}'
+      build_description: '${{ inputs.build_description }}'
+      encoded_release_url: '${{ needs.deploy.outputs.encoded_release_url }}'
     secrets:
       SLACK_BOT_TOKEN: '${{ secrets.SLACK_BOT_TOKEN }}'
 
   error_notification:
     name: Error Notification
     if: failure()
+    uses: tangem/actions/.github/workflows/notification.yml@feature/IOS-8495_misc_cicd_improvements
     needs:
       - prepare
       - build
-      - deploy
-    uses: tangem/actions/.github/workflows/notification.yml@feature/IOS-8112_ci_cd_alpha_builds_workflow
     with:
       channel: '${{ vars.SLACK_CHANNEL_DEPLOYMENTS_IOS }}'
-      status: error
+      status: 'error'
       app_name: '${{ vars.APP_ALPHA }}'
       deploy_to: '${{ vars.DEPLOYMENT_GOOGLE_DISTRIBUTION }}'
       version: '${{ needs.prepare.outputs.version }}'
       build_number: '${{ needs.prepare.outputs.build_number }}'
-      changelog: '${{ needs.prepare.outputs.changelog }}'
+      changelog: '${{ needs.prepare.outputs.jira_summary }}'
+      build_description: '${{ inputs.build_description }}'
     secrets:
       SLACK_BOT_TOKEN: '${{ secrets.SLACK_BOT_TOKEN }}'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
 
   test:
     name: Run unit tests
-    runs-on: macos-14
+    runs-on: macos-15
     needs: check_if_pr_has_always_run_tests_label
     if: github.event.pull_request.draft == false || needs.check_if_pr_has_always_run_tests_label.outputs.has_always_run_tests_label == 'true'
     steps:

--- a/.github/workflows/update-localizations.yml
+++ b/.github/workflows/update-localizations.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   update-localizations:
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       APP_LOCALIZATIONS_DESTINATION: "Tangem/Resources/Localizations"
       BSDK_LOCALIZATIONS_DESTINATION: "BlockchainSdk/Resources/Localizations"

--- a/.github/workflows/update-localizations.yml
+++ b/.github/workflows/update-localizations.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Push changes and open a pull-request
         env:
           GH_TOKEN: ${{ github.token }}
-          SOURCE_BRANCH: lokalise-translations-sync
+          SOURCE_BRANCH: 'lokalise/${{ github.ref_name }}'
           TARGET_BRANCH: ${{ github.ref_name }}
           LANGUAGES: ${{ github.event.inputs.langs }}
           GH_RUN_ID: ${{ github.run_id }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,6 +21,10 @@ before_all do |lane, options|
     next
   end
 
+  Dir.chdir("..") do
+    sh("./bootstrap.sh")
+  end
+
   # Xcode version overrides available only on CI
   if ENV["CI"]&.downcase == "true"
     if options[:xcode_version_override]&.empty?
@@ -34,10 +38,6 @@ before_all do |lane, options|
         select_for_current_build_only: true
       )
     end
-  end
-
-  Dir.chdir("..") do
-    sh("./bootstrap.sh")
   end
 
   ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,3 +1,5 @@
+require 'base64'
+
 default_platform(:ios)
 
 BUILD_PATH = "./fastlane/builds/"
@@ -238,13 +240,19 @@ Options:
 lane :deploy_firebase do |options|
   path = options[:path]
   release_notes = "#{options[:changelog]}\nGitHash: #{last_git_commit[:commit_hash]}"
-  firebase_app_distribution(
+  uploaded_release = firebase_app_distribution(
     app: options[:app_id],
     ipa_path: path,
     groups: FIREBASE_TESTERS_GROUP,
     firebase_cli_token: options[:firebase_token],
     release_notes: release_notes
   )
+  release_url = uploaded_release[:testingUri]
+
+  # Applying base64 encoding twice to prevent GA bug "Skip output 'output' since it may contain secret."
+  # See https://github.com/orgs/community/discussions/13082#discussioncomment-6776428 for details
+  encoded_release_url = Base64.strict_encode64(Base64.strict_encode64(release_url))
+  sh("echo 'encoded_release_url=#{encoded_release_url}' >> $GITHUB_ENV")
 end
 
 private_lane :build do |options|


### PR DESCRIPTION
[IOS-8495](https://tangem.atlassian.net/browse/IOS-8495)

- Сихра локализаций происходит из индивидуальных веток для каждой target ветки, это позволяет одновременно открыть несколько пулов в разные таргеты (как предложил @Balashov152 )
- Поправил форматирование уведомлений в слаке, отдельные секции с **Changelog** и **Additional description**
- В уведомление в слаке добавлен урл на установку релиза
- Переход на macos-15 runner из-за https://github.com/actions/runner-images/issues/10703

<img width="469" alt="Screenshot 2024-11-13 at 14 55 26" src="https://github.com/user-attachments/assets/a4debb13-52f9-4369-83fc-de5c057d8886">



[IOS-8495]: https://tangem.atlassian.net/browse/IOS-8495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ