### PR TITLE
IOS-8467: [Visa] Access token refresh handler

### DIFF
--- a/Modules/TangemFoundation/Extensions/SwiftConcurrency/AsyncTaskScheduler.swift
+++ b/Modules/TangemFoundation/Extensions/SwiftConcurrency/AsyncTaskScheduler.swift
@@ -1,21 +1,23 @@
 //
 //  AsyncTaskScheduler.swift
-//  Tangem
+//  TangemModules
 //
-//  Created by Andrew Son on 17/07/24.
+//  Created by Andrew Son on 14.11.24.
 //  Copyright © 2024 Tangem AG. All rights reserved.
 //
 
 import Foundation
 
-class AsyncTaskScheduler {
+public class AsyncTaskScheduler {
     private var task: Task<Void, Error>?
 
-    var isScheduled: Bool {
+    public var isScheduled: Bool {
         !(task?.isCancelled ?? true)
     }
 
-    func scheduleJob(interval: TimeInterval, repeats: Bool, action: @escaping () async throws -> Void) {
+    public init() {}
+
+    public func scheduleJob(interval: TimeInterval, repeats: Bool, action: @escaping () async throws -> Void) {
         task?.cancel()
         task = Task {
             repeat {
@@ -26,7 +28,7 @@ class AsyncTaskScheduler {
         }
     }
 
-    func cancel() {
+    public func cancel() {
         task?.cancel()
         task = nil
     }

--- a/Tangem/Common/Extensions/SwiftConcurrency+.swift
+++ b/Tangem/Common/Extensions/SwiftConcurrency+.swift
@@ -161,19 +161,3 @@ extension Task {
         return AnyCancellable(cancel)
     }
 }
-
-extension Task where Failure == Error {
-    static func delayed(
-        withDelay delaySeconds: TimeInterval,
-        priority: TaskPriority? = nil,
-        operation: @escaping @Sendable () async throws -> Success
-    ) -> Task {
-        Task(priority: priority) {
-            if delaySeconds > 0 {
-                try await Task<Never, Never>.sleep(seconds: delaySeconds)
-            }
-            try Task<Never, Never>.checkCancellation()
-            return try await operation()
-        }
-    }
-}

--- a/Tangem/Modules/Onboarding/OnboardingCoordinator.swift
+++ b/Tangem/Modules/Onboarding/OnboardingCoordinator.swift
@@ -72,7 +72,10 @@ class OnboardingCoordinator: CoordinatorObject {
         case .visa:
             let model = VisaOnboardingViewModel(
                 input: input,
-                visaActivationManager: VisaActivationManagerFactory().make(),
+                visaActivationManager: VisaActivationManagerFactory().make(
+                    urlSessionConfiguration: .default,
+                    logger: AppLog.shared
+                ),
                 coordinator: self
             )
             onDismissalAttempt = model.backButtonAction

--- a/Tangem/Modules/Onboarding/Visa/VisaOnboardingViewModel.swift
+++ b/Tangem/Modules/Onboarding/Visa/VisaOnboardingViewModel.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 import Combine
 import TangemSdk
+import TangemFoundation
 import TangemVisa
 
 protocol VisaOnboardingRoutable: AnyObject {
@@ -69,6 +70,8 @@ class VisaOnboardingViewModel: ObservableObject {
     private var userWalletModel: UserWalletModel?
     private weak var coordinator: VisaOnboardingRoutable?
 
+    private var activationManagerTask: AnyCancellable?
+
     init(
         input: OnboardingInput,
         visaActivationManager: VisaActivationManager,
@@ -114,7 +117,16 @@ class VisaOnboardingViewModel: ObservableObject {
 }
 
 private extension VisaOnboardingViewModel {
-    func goToNextStep() {}
+    func goToNextStep() {
+        switch currentStep {
+        case .welcome:
+            startActivation()
+        case .saveUserWallet, .pushNotifications:
+            break
+        case .success:
+            closeOnboarding()
+        }
+    }
 
     func goToStep(_ step: VisaOnboardingStep) {
         guard steps.contains(step) else {
@@ -132,6 +144,28 @@ private extension VisaOnboardingViewModel {
     func closeOnboarding() {
         userWalletRepository.updateSelection()
         coordinator?.closeOnboarding()
+    }
+
+    // This function will be updated in IOS-8509. Requirements for activation flow was reworked,
+    // so for now this function is for testing purposes
+    func startActivation() {
+        guard activationManagerTask == nil else {
+            print("Activation task already exists, skipping")
+            return
+        }
+
+        guard
+            case .cardInfo(let cardInfo) = input.cardInput,
+            case .visa(let accessToken, let refreshToken) = cardInfo.walletData
+        else {
+            print("Wrong onboarding input")
+            return
+        }
+
+        let authorizationTokens = VisaAuthorizationTokens(accessToken: accessToken, refreshToken: refreshToken)
+        activationManagerTask = runTask(in: self, isDetached: false) { viewModel in
+            try await viewModel.visaActivationManager.startActivation(authorizationTokens)
+        }.eraseToAnyCancellable()
     }
 }
 
@@ -174,7 +208,10 @@ extension VisaOnboardingViewModel: PushNotificationsPermissionRequestDelegate {
     }
 }
 
+#if DEBUG
 extension VisaOnboardingViewModel {
+    static let coordinator = OnboardingCoordinator()
+
     static var mock: VisaOnboardingViewModel {
         let cardMock = CardMock.visa
         let visaUserWalletModelMock = CommonUserWalletModel.visaMock
@@ -189,8 +226,12 @@ extension VisaOnboardingViewModel {
 
         return .init(
             input: inputFactory.makeOnboardingInput()!,
-            visaActivationManager: VisaActivationManagerFactory().make(),
-            coordinator: OnboardingCoordinator()
+            visaActivationManager: VisaActivationManagerFactory().make(
+                urlSessionConfiguration: .default,
+                logger: AppLog.shared
+            ),
+            coordinator: coordinator
         )
     }
 }
+#endif

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -431,7 +431,6 @@
 		B05E36D52CDA418800CE44F2 /* JSONDecoderFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05E36D42CDA418800CE44F2 /* JSONDecoderFactory.swift */; };
 		B05F19552BF3589C007E5552 /* GetTokenInfoMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05F19542BF3589C007E5552 /* GetTokenInfoMethod.swift */; };
 		B05F1E66299CB81D00E27E32 /* TransactionViewPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05F1E65299CB81D00E27E32 /* TransactionViewPlaceholder.swift */; };
-		B05FADF02C4810BB00ED96E5 /* AsyncTaskScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05FADEF2C4810BB00ED96E5 /* AsyncTaskScheduler.swift */; };
 		B06015E529730C3D00D0F809 /* WalletConnectUIDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06015E429730C3D00D0F809 /* WalletConnectUIDelegate.swift */; };
 		B0606E122684A946004004ED /* BlinkingModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0606E112684A946004004ED /* BlinkingModifier.swift */; };
 		B06243082AA9B77C00F7B9B2 /* SingleTokenRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06243072AA9B77C00F7B9B2 /* SingleTokenRouter.swift */; };
@@ -467,6 +466,7 @@
 		B06C3A252BFE316A005E6D40 /* ManageTokensListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06C3A242BFE316A005E6D40 /* ManageTokensListView.swift */; };
 		B06C3A272BFE31BB005E6D40 /* ManageTokensListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06C3A262BFE31BB005E6D40 /* ManageTokensListViewModel.swift */; };
 		B06C3A292BFE31E3005E6D40 /* ManageTokensListLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06C3A282BFE31E3005E6D40 /* ManageTokensListLoader.swift */; };
+		B06C6D2A2CE48A1900B30325 /* AuthorizationTokensHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06C6D292CE48A1900B30325 /* AuthorizationTokensHandler.swift */; };
 		B06C94C92A3B555000D17E85 /* TokenActionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06C94C82A3B555000D17E85 /* TokenActionType.swift */; };
 		B06C94CC2A3B70E000D17E85 /* TokenActionListBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06C94CB2A3B70E000D17E85 /* TokenActionListBuilder.swift */; };
 		B06C9B862A3AE65A00875852 /* ExchangeCryptoUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06C9B852A3AE65A00875852 /* ExchangeCryptoUtility.swift */; };
@@ -553,6 +553,10 @@
 		B0A1BC172C296B7800DECCFD /* MarketsTokenDetailsCoordinatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A1BC162C296B7800DECCFD /* MarketsTokenDetailsCoordinatorView.swift */; };
 		B0A1BC192C296B9F00DECCFD /* MarketsTokenDetailsRoutable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A1BC182C296B9F00DECCFD /* MarketsTokenDetailsRoutable.swift */; };
 		B0A2B3E925D6B5BD0001EEB4 /* TokenBalanceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A2B3E825D6B5BD0001EEB4 /* TokenBalanceViewModel.swift */; };
+		B0A359AA2CE6FCA10001499E /* VisaAccessTokenHandlerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A359A92CE6FCA10001499E /* VisaAccessTokenHandlerError.swift */; };
+		B0A359AC2CE6FD7B0001499E /* AuthorizationServiceBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A359AB2CE6FD7B0001499E /* AuthorizationServiceBuilder.swift */; };
+		B0A359AE2CE7021B0001499E /* AccessTokenHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A359AD2CE7021B0001499E /* AccessTokenHolder.swift */; };
+		B0A359B02CE7030C0001499E /* AuthorizationTokensDecoderUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A359AF2CE7030C0001499E /* AuthorizationTokensDecoderUtility.swift */; };
 		B0A37B702C2D9A9F005397FA /* MarketsTokenDetailsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A37B6F2C2D9A9F005397FA /* MarketsTokenDetailsModel.swift */; };
 		B0A4C4A02A270F5B0060E039 /* BalanceWithButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A4C49F2A270F5B0060E039 /* BalanceWithButtonsView.swift */; };
 		B0A4C4A22A271CD20060E039 /* BalanceWithButtonsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A4C4A12A271CD20060E039 /* BalanceWithButtonsViewModel.swift */; };
@@ -652,6 +656,7 @@
 		B0D51C872C2400810043D792 /* visa.json in Resources */ = {isa = PBXBuildFile; fileRef = B0D51C852C2400810043D792 /* visa.json */; };
 		B0D622FE2A9E33E5001FA044 /* SingleTokenNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D622FD2A9E33E5001FA044 /* SingleTokenNotificationManager.swift */; };
 		B0D6B2542CB52B090068D310 /* NavigationBarHidingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D6B2532CB52B090068D310 /* NavigationBarHidingView.swift */; };
+		B0D70D482CE5FB6800A8A0F1 /* JWTDecode in Frameworks */ = {isa = PBXBuildFile; productRef = B0D70D472CE5FB6800A8A0F1 /* JWTDecode */; };
 		B0D7F896295EDCBE00497139 /* ReferralErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D7F895295EDCBE00497139 /* ReferralErrors.swift */; };
 		B0D9FDCA2A9336920047A1C0 /* IconViewSizeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D9FDC92A9336920047A1C0 /* IconViewSizeSettings.swift */; };
 		B0DB73FC2A8CA28800F6376E /* UnlockUserWalletBottomSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0DB73FB2A8CA28800F6376E /* UnlockUserWalletBottomSheetViewModel.swift */; };
@@ -2800,9 +2805,6 @@
 		EFC990032CD3A6890098B7C8 /* OnrampPaymentMethodsBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC990022CD3A6890098B7C8 /* OnrampPaymentMethodsBuilder.swift */; };
 		EFC990082CD3A6D90098B7C8 /* OnrampPaymentMethodsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC990072CD3A6D90098B7C8 /* OnrampPaymentMethodsInteractor.swift */; };
 		EFC9900C2CD3A70C0098B7C8 /* OnrampPaymentMethodsInputOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC9900B2CD3A70C0098B7C8 /* OnrampPaymentMethodsInputOutput.swift */; };
-		EFC990102CD3A74A0098B7C8 /* OnrampProvidersInputOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC9900F2CD3A74A0098B7C8 /* OnrampProvidersInputOutput.swift */; };
-		EFC990132CD3BAFF0098B7C8 /* OnrampProvidersCompactProviderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC990122CD3BAFF0098B7C8 /* OnrampProvidersCompactProviderView.swift */; };
-		EFC990152CD3BB130098B7C8 /* OnrampProvidersCompactProviderViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC990142CD3BB130098B7C8 /* OnrampProvidersCompactProviderViewData.swift */; };
 		EFC990172CD3CC9C0098B7C8 /* ExpressBranch.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC990162CD3CC9C0098B7C8 /* ExpressBranch.swift */; };
 		EFC9901A2CD4F0A90098B7C8 /* CommonOnrampProviderManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC990192CD4F0A90098B7C8 /* CommonOnrampProviderManager.swift */; };
 		EFD0A14B2C9985CF0010E642 /* SendAmountModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD0A14A2C9985CD0010E642 /* SendAmountModifier.swift */; };
@@ -3540,7 +3542,6 @@
 		B05E36D42CDA418800CE44F2 /* JSONDecoderFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecoderFactory.swift; sourceTree = "<group>"; };
 		B05F19542BF3589C007E5552 /* GetTokenInfoMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTokenInfoMethod.swift; sourceTree = "<group>"; };
 		B05F1E65299CB81D00E27E32 /* TransactionViewPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionViewPlaceholder.swift; sourceTree = "<group>"; };
-		B05FADEF2C4810BB00ED96E5 /* AsyncTaskScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTaskScheduler.swift; sourceTree = "<group>"; };
 		B06015E429730C3D00D0F809 /* WalletConnectUIDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletConnectUIDelegate.swift; sourceTree = "<group>"; };
 		B0606E112684A946004004ED /* BlinkingModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlinkingModifier.swift; sourceTree = "<group>"; };
 		B06243072AA9B77C00F7B9B2 /* SingleTokenRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleTokenRouter.swift; sourceTree = "<group>"; };
@@ -3578,6 +3579,7 @@
 		B06C3A242BFE316A005E6D40 /* ManageTokensListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageTokensListView.swift; sourceTree = "<group>"; };
 		B06C3A262BFE31BB005E6D40 /* ManageTokensListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageTokensListViewModel.swift; sourceTree = "<group>"; };
 		B06C3A282BFE31E3005E6D40 /* ManageTokensListLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageTokensListLoader.swift; sourceTree = "<group>"; };
+		B06C6D292CE48A1900B30325 /* AuthorizationTokensHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationTokensHandler.swift; sourceTree = "<group>"; };
 		B06C94C82A3B555000D17E85 /* TokenActionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenActionType.swift; sourceTree = "<group>"; };
 		B06C94CB2A3B70E000D17E85 /* TokenActionListBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenActionListBuilder.swift; sourceTree = "<group>"; };
 		B06C9B852A3AE65A00875852 /* ExchangeCryptoUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeCryptoUtility.swift; sourceTree = "<group>"; };
@@ -3660,6 +3662,10 @@
 		B0A1BC162C296B7800DECCFD /* MarketsTokenDetailsCoordinatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketsTokenDetailsCoordinatorView.swift; sourceTree = "<group>"; };
 		B0A1BC182C296B9F00DECCFD /* MarketsTokenDetailsRoutable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketsTokenDetailsRoutable.swift; sourceTree = "<group>"; };
 		B0A2B3E825D6B5BD0001EEB4 /* TokenBalanceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenBalanceViewModel.swift; sourceTree = "<group>"; };
+		B0A359A92CE6FCA10001499E /* VisaAccessTokenHandlerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisaAccessTokenHandlerError.swift; sourceTree = "<group>"; };
+		B0A359AB2CE6FD7B0001499E /* AuthorizationServiceBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationServiceBuilder.swift; sourceTree = "<group>"; };
+		B0A359AD2CE7021B0001499E /* AccessTokenHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenHolder.swift; sourceTree = "<group>"; };
+		B0A359AF2CE7030C0001499E /* AuthorizationTokensDecoderUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationTokensDecoderUtility.swift; sourceTree = "<group>"; };
 		B0A37B6F2C2D9A9F005397FA /* MarketsTokenDetailsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketsTokenDetailsModel.swift; sourceTree = "<group>"; };
 		B0A4C49F2A270F5B0060E039 /* BalanceWithButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceWithButtonsView.swift; sourceTree = "<group>"; };
 		B0A4C4A12A271CD20060E039 /* BalanceWithButtonsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceWithButtonsViewModel.swift; sourceTree = "<group>"; };
@@ -5912,9 +5918,6 @@
 		EFC990022CD3A6890098B7C8 /* OnrampPaymentMethodsBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampPaymentMethodsBuilder.swift; sourceTree = "<group>"; };
 		EFC990072CD3A6D90098B7C8 /* OnrampPaymentMethodsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampPaymentMethodsInteractor.swift; sourceTree = "<group>"; };
 		EFC9900B2CD3A70C0098B7C8 /* OnrampPaymentMethodsInputOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampPaymentMethodsInputOutput.swift; sourceTree = "<group>"; };
-		EFC9900F2CD3A74A0098B7C8 /* OnrampProvidersInputOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampProvidersInputOutput.swift; sourceTree = "<group>"; };
-		EFC990122CD3BAFF0098B7C8 /* OnrampProvidersCompactProviderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampProvidersCompactProviderView.swift; sourceTree = "<group>"; };
-		EFC990142CD3BB130098B7C8 /* OnrampProvidersCompactProviderViewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampProvidersCompactProviderViewData.swift; sourceTree = "<group>"; };
 		EFC990162CD3CC9C0098B7C8 /* ExpressBranch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressBranch.swift; sourceTree = "<group>"; };
 		EFC990192CD4F0A90098B7C8 /* CommonOnrampProviderManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonOnrampProviderManager.swift; sourceTree = "<group>"; };
 		EFCC66E028AA6FC500EC7757 /* UserTokenList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTokenList.swift; sourceTree = "<group>"; };
@@ -6055,6 +6058,7 @@
 			files = (
 				B62C16792CBE095A00522683 /* Alamofire in Frameworks */,
 				B62D34102CBC4C5800C2460E /* BlockchainSdk.framework in Frameworks */,
+				B0D70D482CE5FB6800A8A0F1 /* JWTDecode in Frameworks */,
 				B67E38BB2CC7179000D660EB /* TangemSdk in Frameworks */,
 				B6C0D3FF2CBDC73E001113ED /* TangemModules in Frameworks */,
 				B6C0D3FB2CBDC6DD001113ED /* Moya in Frameworks */,
@@ -7733,7 +7737,6 @@
 				B64781E12C22F74300B0E882 /* CustomTokenContractAddressConverter.swift */,
 				DA19EF602B8CBDE200F7BDFD /* TangemBlogUrlBuilder.swift */,
 				B041C9662C3FF5BB00CE027A /* Math.swift */,
-				B05FADEF2C4810BB00ED96E5 /* AsyncTaskScheduler.swift */,
 				DAE4BB152CD7A0D30020CE3F /* SearchUtil.swift */,
 			);
 			path = Utilities;
@@ -7832,6 +7835,17 @@
 				DAC4F9EF2AC314E100BEBCF8 /* SingleWalletMainContentDelegate.swift */,
 			);
 			path = SingleWalletMainContent;
+			sourceTree = "<group>";
+		};
+		B06C6D282CE48A0100B30325 /* AccessTokenHandler */ = {
+			isa = PBXGroup;
+			children = (
+				B0A359AF2CE7030C0001499E /* AuthorizationTokensDecoderUtility.swift */,
+				B0A359AD2CE7021B0001499E /* AccessTokenHolder.swift */,
+				B06C6D292CE48A1900B30325 /* AuthorizationTokensHandler.swift */,
+				B0A359A92CE6FCA10001499E /* VisaAccessTokenHandlerError.swift */,
+			);
+			path = AccessTokenHandler;
 			sourceTree = "<group>";
 		};
 		B06C94CA2A3B70C200D17E85 /* TokenActions */ = {
@@ -8120,6 +8134,7 @@
 		B09933782B5517E500240CDB /* TangemVisa */ = {
 			isa = PBXGroup;
 			children = (
+				B06C6D282CE48A0100B30325 /* AccessTokenHandler */,
 				B07D96762CD4CCD400A3BAF2 /* Activation */,
 				B08D3C122BF6267E00C83299 /* Config */,
 				B050F4F22B5FB02B00B2E53C /* APIService */,
@@ -8634,6 +8649,7 @@
 		B0DE6EE32CDCF56000254675 /* AuthorizationService */ = {
 			isa = PBXGroup;
 			children = (
+				B0A359AB2CE6FD7B0001499E /* AuthorizationServiceBuilder.swift */,
 				B05E36912CDA0F2C00CE44F2 /* VisaAuthorizationService.swift */,
 				B0DE6EE42CDCF5A200254675 /* AuthorizationAPITarget.swift */,
 				B0DE6EE62CDCFC7700254675 /* VisaAuthorizationAPIError.swift */,
@@ -15544,6 +15560,7 @@
 				B6C0D3FE2CBDC73E001113ED /* TangemModules */,
 				B62C16782CBE095A00522683 /* Alamofire */,
 				B67E38BA2CC7179000D660EB /* TangemSdk */,
+				B0D70D472CE5FB6800A8A0F1 /* JWTDecode */,
 			);
 			productName = TangemVisa;
 			productReference = B09933772B5517E300240CDB /* TangemVisa.framework */;
@@ -15843,6 +15860,7 @@
 				B6CAC1C82CC3352D0001A427 /* XCRemoteSwiftPackageReference "Solana.Swift" */,
 				B6FFC31D2CC70E1D00F4400E /* XCRemoteSwiftPackageReference "bitcoincore" */,
 				B67E38B72CC7147600D660EB /* XCRemoteSwiftPackageReference "tangem-sdk-ios" */,
+				B09FF1882CE24DF5004881F6 /* XCRemoteSwiftPackageReference "JWTDecode" */,
 			);
 			productRefGroup = 5D3F77C324BF56D800E8695B /* Products */;
 			projectDirPath = "";
@@ -16688,7 +16706,6 @@
 				DCBE4CF02CC8C8F400855904 /* ActionButtonsViewModel.swift in Sources */,
 				DA5CD09A2A25F4F2008FD876 /* PromotionCoordinator.swift in Sources */,
 				B0290CDB2CAED78A008ABBD2 /* MarketsExchangeTrustScore.swift in Sources */,
-				B05FADF02C4810BB00ED96E5 /* AsyncTaskScheduler.swift in Sources */,
 				DC3DCAEA2A49B5E900F72554 /* CommonUserTokensManager.swift in Sources */,
 				B0FAD01226BAF35C00F45E88 /* FrameSizeModifier.swift in Sources */,
 				B64E38692C810BA400B0CFA0 /* PercentFormatterNumberFormatterRepository.swift in Sources */,
@@ -17863,10 +17880,13 @@
 				B05E36922CDA0F2C00CE44F2 /* VisaAuthorizationService.swift in Sources */,
 				B051450E2B59346500EDAD1E /* GetTotalBalanceMethod.swift in Sources */,
 				B05145142B5934BB00EDAD1E /* VisaSmartContractRequest.swift in Sources */,
+				B0A359AC2CE6FD7B0001499E /* AuthorizationServiceBuilder.swift in Sources */,
 				B0DE6EE72CDCFC7700254675 /* VisaAuthorizationAPIError.swift in Sources */,
 				B050F4F62B60E7F400B2E53C /* VisaTransactionRecord.swift in Sources */,
+				B0A359B02CE7030C0001499E /* AuthorizationTokensDecoderUtility.swift in Sources */,
 				B050F4F42B5FB03F00B2E53C /* VisaTransactionHistoryAPIService.swift in Sources */,
 				B050F4FC2B60F9F300B2E53C /* PayAPITarget.swift in Sources */,
+				B0A359AE2CE7021B0001499E /* AccessTokenHolder.swift in Sources */,
 				B08BC1BE2BF72C0B00041E95 /* VisaTokenInfoLoader.swift in Sources */,
 				B050F4FE2B60FA1800B2E53C /* PayAPIService.swift in Sources */,
 				B07D96782CD4CCE700A3BAF2 /* VisaActivationManager.swift in Sources */,
@@ -17879,7 +17899,9 @@
 				B05E36D22CDA3D2200CE44F2 /* APIService.swift in Sources */,
 				B099339D2B55196700240CDB /* VisaBridgeInteractor.swift in Sources */,
 				B0DE6EE52CDCF5A300254675 /* AuthorizationAPITarget.swift in Sources */,
+				B06C6D2A2CE48A1900B30325 /* AuthorizationTokensHandler.swift in Sources */,
 				B05145062B5933E000EDAD1E /* VisaUtilities.swift in Sources */,
+				B0A359AA2CE6FCA10001499E /* VisaAccessTokenHandlerError.swift in Sources */,
 				B05145122B59349100EDAD1E /* SmartContractMethodPrefixCreator.swift in Sources */,
 				B03FF8A22B5E5C4500202EC0 /* VisaLogger.swift in Sources */,
 				B05145102B59348000EDAD1E /* GetAmountMethod.swift in Sources */,
@@ -25226,6 +25248,14 @@
 				minimumVersion = 1.1.0;
 			};
 		};
+		B09FF1882CE24DF5004881F6 /* XCRemoteSwiftPackageReference "JWTDecode" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/auth0/JWTDecode.swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.2.0;
+			};
+		};
 		B0B11A062C787FE70018A2A6 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/gonzalezreal/swift-markdown-ui";
@@ -25419,6 +25449,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B0B11A062C787FE70018A2A6 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
 			productName = MarkdownUI;
+		};
+		B0D70D472CE5FB6800A8A0F1 /* JWTDecode */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B09FF1882CE24DF5004881F6 /* XCRemoteSwiftPackageReference "JWTDecode" */;
+			productName = JWTDecode;
 		};
 		B620FC9F2C5D326D00AD0FD1 /* DGCharts */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/TangemApp.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TangemApp.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "584ca60af0fbbc527d504d4d480a556058e05f97a79e92bf44c594618d31cc9a",
+  "originHash" : "6b035953f736066530f0d187d9ba246ef7feaaf3f9e8bf5106f9f10b0ba6d560",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -107,6 +107,15 @@
       "state" : {
         "revision" : "48d906f7a3eca66dd4cbc239f21fd829dfc9decf",
         "version" : "0.1.2-tangem4"
+      }
+    },
+    {
+      "identity" : "jwtdecode.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/auth0/JWTDecode.swift",
+      "state" : {
+        "revision" : "1e153ef009969543191970c66b7c60163c0b4a65",
+        "version" : "3.2.0"
       }
     },
     {

--- a/TangemVisa/APIService/AuthorizationService/AuthorizationAPITarget.swift
+++ b/TangemVisa/APIService/AuthorizationService/AuthorizationAPITarget.swift
@@ -46,10 +46,10 @@ struct AuthorizationAPITarget: TargetType {
             params[.sessionId] = sessionId
             params[.signature] = signature
             params[.salt] = salt
-            params[.grantType] = GrantType.password
+            params[.grantType] = GrantType.password.rawValue
         case .refreshAccessToken(let refreshToken):
             params[.clientId] = clientId
-            params[.grantType] = GrantType.refreshToken
+            params[.grantType] = GrantType.refreshToken.rawValue
             params[.refreshToken] = refreshToken
         }
 

--- a/TangemVisa/APIService/AuthorizationService/AuthorizationServiceBuilder.swift
+++ b/TangemVisa/APIService/AuthorizationService/AuthorizationServiceBuilder.swift
@@ -1,0 +1,21 @@
+//
+//  AuthorizationServiceBuilder.swift
+//  TangemApp
+//
+//  Created by Andrew Son on 15.11.24.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Moya
+
+struct AuthorizationServiceBuilder {
+    func build(urlSessionConfiguration: URLSessionConfiguration, logger: VisaLogger) -> CommonVisaAuthorizationService {
+        let logger = InternalLogger(logger: logger)
+        let provider = MoyaProvider<AuthorizationAPITarget>(session: Session(configuration: urlSessionConfiguration))
+
+        return CommonVisaAuthorizationService(
+            provider: provider,
+            logger: logger
+        )
+    }
+}

--- a/TangemVisa/APIService/AuthorizationService/VisaAuthorizationModels.swift
+++ b/TangemVisa/APIService/AuthorizationService/VisaAuthorizationModels.swift
@@ -13,7 +13,13 @@ public struct VisaAuthChallengeResponse: Decodable {
     public let sessionId: String
 }
 
-public struct VisaAccessToken: Decodable {
+public struct VisaAuthorizationTokens: Decodable {
     public let accessToken: String
     public let refreshToken: String
+
+    // Will be updated in IOS-8509. Requirements for activation flow was reworked, so for now this function is for testing purposes
+    public init(accessToken: String, refreshToken: String) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+    }
 }

--- a/TangemVisa/APIService/AuthorizationService/VisaAuthorizationService.swift
+++ b/TangemVisa/APIService/AuthorizationService/VisaAuthorizationService.swift
@@ -11,7 +11,11 @@ import Moya
 
 public protocol VisaAuthorizationService {
     func getAuthorizationChallenge(cardId: String, cardPublicKey: String) async throws -> VisaAuthChallengeResponse
-    func getAccessTokens(signedChallenge: String, salt: String, sessionId: String) async throws -> VisaAccessToken
+    func getAccessTokens(signedChallenge: String, salt: String, sessionId: String) async throws -> VisaAuthorizationTokens
+}
+
+protocol AccessTokenRefreshService {
+    func refreshAccessToken(refreshToken: String) async throws -> VisaAuthorizationTokens
 }
 
 class CommonVisaAuthorizationService {
@@ -36,9 +40,17 @@ extension CommonVisaAuthorizationService: VisaAuthorizationService {
         ))
     }
 
-    func getAccessTokens(signedChallenge: String, salt: String, sessionId: String) async throws -> VisaAccessToken {
+    func getAccessTokens(signedChallenge: String, salt: String, sessionId: String) async throws -> VisaAuthorizationTokens {
         try await apiService.request(.init(
             target: .getAccessToken(signature: signedChallenge, salt: salt, sessionId: sessionId)
+        ))
+    }
+}
+
+extension CommonVisaAuthorizationService: AccessTokenRefreshService {
+    func refreshAccessToken(refreshToken: String) async throws -> VisaAuthorizationTokens {
+        try await apiService.request(.init(
+            target: .refreshAccessToken(refreshToken: refreshToken)
         ))
     }
 }

--- a/TangemVisa/APIService/VisaAPIServiceBuilder.swift
+++ b/TangemVisa/APIService/VisaAPIServiceBuilder.swift
@@ -20,13 +20,8 @@ public struct VisaAPIServiceBuilder {
         return PayAPIService(isTestnet: isTestnet, additionalAPIHeaders: additionalAPIHeaders, provider: provider, logger: logger)
     }
 
+    // Requirements are changed so this function will be also changed, but for now it is used for testing purposes
     public func buildAuthorizationService(urlSessionConfiguration: URLSessionConfiguration, logger: VisaLogger) -> VisaAuthorizationService {
-        let logger = InternalLogger(logger: logger)
-        let provider = MoyaProvider<AuthorizationAPITarget>(session: Session(configuration: urlSessionConfiguration))
-
-        return CommonVisaAuthorizationService(
-            provider: provider,
-            logger: logger
-        )
+        return AuthorizationServiceBuilder().build(urlSessionConfiguration: urlSessionConfiguration, logger: logger)
     }
 }

--- a/TangemVisa/AccessTokenHandler/AccessTokenHolder.swift
+++ b/TangemVisa/AccessTokenHandler/AccessTokenHolder.swift
@@ -1,0 +1,25 @@
+//
+//  AccessTokenHolder.swift
+//  TangemApp
+//
+//  Created by Andrew Son on 15.11.24.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+actor AccessTokenHolder {
+    private var jwtTokens: DecodedAuthorizationJWTTokens?
+
+    func setTokens(_ tokens: DecodedAuthorizationJWTTokens) async {
+        jwtTokens = tokens
+    }
+
+    func setTokens(authorizationTokens: VisaAuthorizationTokens) async throws {
+        jwtTokens = try AuthorizationTokensDecoderUtility().decodeAuthTokens(authorizationTokens)
+    }
+
+    func getTokens() async -> DecodedAuthorizationJWTTokens? {
+        jwtTokens
+    }
+}

--- a/TangemVisa/AccessTokenHandler/AuthorizationTokensDecoderUtility.swift
+++ b/TangemVisa/AccessTokenHandler/AuthorizationTokensDecoderUtility.swift
@@ -1,0 +1,23 @@
+//
+//  AuthorizationTokensDecoderUtility.swift
+//  TangemApp
+//
+//  Created by Andrew Son on 15.11.24.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import JWTDecode
+
+struct AuthorizationTokensDecoderUtility {
+    func decodeAuthTokens(_ tokens: VisaAuthorizationTokens) throws -> DecodedAuthorizationJWTTokens {
+        let accessToken = try decode(jwt: tokens.accessToken)
+        let refreshToken = try decode(jwt: tokens.refreshToken)
+        return .init(accessToken: accessToken, refreshToken: refreshToken)
+    }
+}
+
+struct DecodedAuthorizationJWTTokens {
+    var accessToken: JWT
+    var refreshToken: JWT
+}

--- a/TangemVisa/AccessTokenHandler/AuthorizationTokensHandler.swift
+++ b/TangemVisa/AccessTokenHandler/AuthorizationTokensHandler.swift
@@ -1,0 +1,180 @@
+//
+//  AuthorizationTokensHandler.swift
+//  TangemVisa
+//
+//  Created by Andrew Son on 13.11.24.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import Combine
+import TangemFoundation
+import JWTDecode
+
+public protocol VisaRefreshTokenSaver: AnyObject {
+    func saveRefreshTokenToStorage(refreshToken: String) async throws
+}
+
+protocol AuthorizationTokenHandler {
+    func setupTokens(_ tokens: VisaAuthorizationTokens) async throws
+    func authorizationHeader() async throws -> String
+    func setupRefreshTokenSaver(_ refreshTokenSaver: VisaRefreshTokenSaver)
+}
+
+class CommonVisaAccessTokenHandler {
+    private let tokenRefreshService: AccessTokenRefreshService
+    private weak var refreshTokenSaver: VisaRefreshTokenSaver?
+
+    private let scheduler: AsyncTaskScheduler = .init()
+    private let logger: InternalLogger
+
+    private let accessTokenHolder: AccessTokenHolder = .init()
+    private var refresherTask: AnyCancellable?
+
+    private let minSecondsBeforeExpiration: TimeInterval = 60.0
+
+    init(
+        tokenRefreshService: AccessTokenRefreshService,
+        logger: InternalLogger,
+        refreshTokenSaver: VisaRefreshTokenSaver?
+    ) {
+        self.tokenRefreshService = tokenRefreshService
+        self.refreshTokenSaver = refreshTokenSaver
+        self.logger = logger
+    }
+
+    init(
+        authorizationTokens: VisaAuthorizationTokens,
+        tokenRefreshService: AccessTokenRefreshService,
+        logger: InternalLogger,
+        refreshTokenSaver: VisaRefreshTokenSaver?
+    ) async throws {
+        self.tokenRefreshService = tokenRefreshService
+        self.refreshTokenSaver = refreshTokenSaver
+        self.logger = logger
+        try await accessTokenHolder.setTokens(authorizationTokens: authorizationTokens)
+
+        setupRefresherTask()
+    }
+
+    private func log(_ message: @autoclosure () -> String) {
+        logger.debug(subsystem: .authorizationTokenHandler, message())
+    }
+
+    private func setupRefresherTask() {
+        log("Setup refresher task. Current refresher task is nil: \(refresherTask == nil)")
+        refresherTask?.cancel()
+        refresherTask = Task { [weak self] in
+            do {
+                try await self?.setupAccessTokenRefresher()
+            } catch {
+                if error is CancellationError {
+                    self?.log("Refresher task was cancelled")
+                    return
+                }
+                self?.log("Failed to update access token. Reason: \(error)")
+            }
+        }.eraseToAnyCancellable()
+    }
+
+    private func setupAccessTokenRefresher() async throws {
+        log("Attempting to setup token refresher")
+        guard let jwtTokens = await accessTokenHolder.getTokens() else {
+            throw VisaAccessTokenHandlerError.authorizationTokensNotFound
+        }
+
+        log("JWT tokens found. Checking expiration date.")
+        guard
+            let expirationDate = jwtTokens.accessToken.expiresAt,
+            let issuedAtDate = jwtTokens.accessToken.issuedAt
+        else {
+            throw VisaAccessTokenHandlerError.missingMandatoryInfoInAccessToken
+        }
+
+        let now = Date()
+        let timeBeforeExpiration = expirationDate.timeIntervalSince(now)
+        let shouldRefreshToken = timeBeforeExpiration < minSecondsBeforeExpiration || jwtTokens.accessToken.expired
+
+        // We need to refresh token before setup token update with fixed interval
+        if shouldRefreshToken {
+            log("Access token needs to be refreshed.")
+            // Token already expired or will expire very soon. Refreshing
+            try await refreshAccessToken(refreshJWTToken: jwtTokens.refreshToken)
+        } else {
+            log("Access token is not expired. Waiting until it will expire.")
+            let maxDateBeforeUpdate = Calendar.current.date(
+                byAdding: .second,
+                value: -Int(minSecondsBeforeExpiration),
+                to: expirationDate
+            ) ?? now
+            let refreshDelay = maxDateBeforeUpdate.timeIntervalSince(now)
+            log("Access token will expire in \(expirationDate.timeIntervalSince(Date()))")
+            log("Access token will be refreshed in \(refreshDelay) seconds.")
+
+            // Wait until token will need to refresh and update it one time
+            try await Task.sleep(seconds: refreshDelay)
+            try await refreshAccessToken(refreshJWTToken: jwtTokens.refreshToken)
+        }
+
+        try Task.checkCancellation()
+        log("Scheduling token update")
+        // Setup recurring token update with fixed interval
+        let tokenLifeTime = expirationDate.timeIntervalSince(issuedAtDate)
+        let tokenRefreshTimeInterval = tokenLifeTime - minSecondsBeforeExpiration
+        log("Scheduling token refresh job with interval: \(tokenRefreshTimeInterval)")
+        scheduler.scheduleJob(interval: tokenRefreshTimeInterval, repeats: true) { [weak self] in
+            self?.log("Access token is about to expire. Refreshing...")
+            guard let jwtTokens = await self?.accessTokenHolder.getTokens() else {
+                self?.log("Failed to find access token. Canceling scheduled job.")
+                self?.scheduler.cancel()
+                return
+            }
+
+            self?.log("Scheduled token update")
+            do {
+                try await self?.refreshAccessToken(refreshJWTToken: jwtTokens.refreshToken)
+            } catch {
+                self?.log("Failed to refresh access token. Reason: \(error)")
+            }
+        }
+    }
+
+    private func refreshAccessToken(refreshJWTToken: JWT) async throws {
+        log("Refreshing access token")
+        if refreshJWTToken.expired {
+            log("Refresh token expired, cant refresh")
+            throw VisaAccessTokenHandlerError.refreshTokenExpired
+        }
+
+        let visaTokens = try await tokenRefreshService.refreshAccessToken(refreshToken: refreshJWTToken.string)
+        let newJWTTokens = try AuthorizationTokensDecoderUtility().decodeAuthTokens(visaTokens)
+
+        if newJWTTokens.accessToken.expired {
+            throw VisaAccessTokenHandlerError.failedToUpdateAccessToken
+        }
+
+        await accessTokenHolder.setTokens(newJWTTokens)
+        try await refreshTokenSaver?.saveRefreshTokenToStorage(refreshToken: newJWTTokens.refreshToken.string)
+    }
+}
+
+extension CommonVisaAccessTokenHandler: AuthorizationTokenHandler {
+    func setupTokens(_ tokens: VisaAuthorizationTokens) async throws {
+        log("Setup new authorization tokens in token handler")
+        try await accessTokenHolder.setTokens(authorizationTokens: tokens)
+        /// We need to use `setupRefresherTask` to prevent blocking current task
+        setupRefresherTask()
+    }
+
+    func authorizationHeader() async throws -> String {
+        guard let jwtTokens = await accessTokenHolder.getTokens() else {
+            throw VisaAccessTokenHandlerError.missingAccessToken
+        }
+
+        return "Bearer \(jwtTokens.accessToken.string)"
+    }
+
+    func setupRefreshTokenSaver(_ refreshTokenSaver: any VisaRefreshTokenSaver) {
+        self.refreshTokenSaver = refreshTokenSaver
+    }
+}

--- a/TangemVisa/AccessTokenHandler/VisaAccessTokenHandlerError.swift
+++ b/TangemVisa/AccessTokenHandler/VisaAccessTokenHandlerError.swift
@@ -1,0 +1,19 @@
+//
+//  VisaAccessTokenHandlerError.swift
+//  TangemVisa
+//
+//  Created by Andrew Son on 15.11.24.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+public enum VisaAccessTokenHandlerError: String, LocalizedError {
+    case authorizationTokensNotFound
+    case refreshTokenExpired
+    case missingMandatoryInfoInAccessToken
+    case missingAccessToken
+    case missingRefreshToken
+    case accessTokenExpired
+    case failedToUpdateAccessToken
+}

--- a/TangemVisa/Activation/VisaActivationManager.swift
+++ b/TangemVisa/Activation/VisaActivationManager.swift
@@ -11,10 +11,19 @@ import Foundation
 public protocol VisaActivationManager {
     func saveAccessCode(_ accessCode: String) throws
     func resetAccessCode()
+    func setupRefreshTokenSaver(_ refreshTokenSaver: VisaRefreshTokenSaver)
+
+    // Will be updated in IOS-8509. Requirements for activation flow was reworked, so for now this function is for testing purposes
+    func startActivation(_ tokens: VisaAuthorizationTokens) async throws
 }
 
 class CommonVisaActivationManager {
     private var selectedAccessCode: String?
+    private let authorizationTokenHandler: AuthorizationTokenHandler
+
+    init(authorizationTokenHandler: AuthorizationTokenHandler) {
+        self.authorizationTokenHandler = authorizationTokenHandler
+    }
 }
 
 extension CommonVisaActivationManager: VisaActivationManager {
@@ -29,13 +38,28 @@ extension CommonVisaActivationManager: VisaActivationManager {
     func resetAccessCode() {
         selectedAccessCode = nil
     }
+
+    func setupRefreshTokenSaver(_ refreshTokenSaver: VisaRefreshTokenSaver) {
+        authorizationTokenHandler.setupRefreshTokenSaver(refreshTokenSaver)
+    }
+
+    func startActivation(_ tokens: VisaAuthorizationTokens) async throws {
+        try await authorizationTokenHandler.setupTokens(tokens)
+    }
 }
 
 public struct VisaActivationManagerFactory {
     public init() {}
 
-    public func make() -> VisaActivationManager {
-        CommonVisaActivationManager()
+    public func make(urlSessionConfiguration: URLSessionConfiguration, logger: VisaLogger) -> VisaActivationManager {
+        let internalLogger = InternalLogger(logger: logger)
+        let tokenRefreshService = AuthorizationServiceBuilder().build(urlSessionConfiguration: urlSessionConfiguration, logger: logger)
+        let tokenHandler = CommonVisaAccessTokenHandler(
+            tokenRefreshService: tokenRefreshService,
+            logger: internalLogger,
+            refreshTokenSaver: nil
+        )
+        return CommonVisaActivationManager(authorizationTokenHandler: tokenHandler)
     }
 }
 

--- a/TangemVisa/Utilities/VisaLogger.swift
+++ b/TangemVisa/Utilities/VisaLogger.swift
@@ -35,5 +35,6 @@ extension InternalLogger {
         case bridgeInteractor = "[Visa] [Bridge Interactor]:\n"
         case apiService = "[Visa] [API Service]\n"
         case tokenInfoLoader = "[Visa] [TokenInfoLoader]:\n"
+        case authorizationTokenHandler = "[Visa] [AuthorizationTokenHandler]: "
     }
 }


### PR DESCRIPTION
* Токен теперь обновляется каждые = **(продолжительность жизни токена - 1 минута)**, чтобы не было задержек при запросах.
* впереди предстоит переработка `VisaCardScanHandler`, потому что карточка теперь будет авторизоваться только если кошельки на ней уже созданы, а во время онбординга авторизация будет не при первом сканировании а позже, поэтому часть функционала будет меняться, но уже в другой задаче.
* Перенес `AsyncTaskScheduler` в `TangemFoundation`, т.к. используется и в приложении и в визе
* Логов пока что много, чтобы трекать что все нормально работает, в общем-то на приложении никак не скажется, т.к. это работает только для определенных карточек