### PR TITLE
IOS-8336 Add fix for solana rent exemption

### DIFF
--- a/BlockchainSdk/Blockchains/Solana/SolanaResponse.swift
+++ b/BlockchainSdk/Blockchains/Solana/SolanaResponse.swift
@@ -14,12 +14,13 @@ struct SolanaAccountInfoResponse {
     let accountExists: Bool
     let tokensByMint: [String: SolanaTokenAccountInfoResponse]
     let confirmedTransactionIDs: [String]
+    let mainAccountRentExemption: Decimal
 }
 
 struct SolanaMainAccountInfoResponse {
     let balance: Lamports
     let accountExists: Bool
-    let space: UInt64?
+    let rentExemption: Decimal
 }
 
 struct SolanaTokenAccountInfoResponse {

--- a/BlockchainSdk/Blockchains/Solana/SolanaWalletManager.swift
+++ b/BlockchainSdk/Blockchains/Solana/SolanaWalletManager.swift
@@ -104,7 +104,7 @@ extension SolanaWalletManager: TransactionSender {
                 .map { (feeForMessage: $0, feeParameters: feeParameters) }
             }
             .withWeakCaptureOf(self)
-            .tryMap { walletManager, feeInfo -> [Fee] in
+            .map { walletManager, feeInfo -> [Fee] in
                 let totalFee = feeInfo.feeForMessage + feeInfo.feeParameters.accountCreationFee
                 let amount = Amount(with: walletManager.wallet.blockchain, type: .coin, value: totalFee)
 

--- a/BlockchainSdk/Blockchains/Solana/SolanaWalletManager.swift
+++ b/BlockchainSdk/Blockchains/Solana/SolanaWalletManager.swift
@@ -105,14 +105,8 @@ extension SolanaWalletManager: TransactionSender {
             }
             .withWeakCaptureOf(self)
             .tryMap { walletManager, feeInfo -> [Fee] in
-                let totalFee = feeInfo.feeForMessage + feeInfo.feeParameters.accountCreationFee
+                let totalFee = feeInfo.feeForMessage + feeInfo.feeParameters.accountCreationFee + walletManager.minimalRentExamptionFee
                 let amount = Amount(with: walletManager.wallet.blockchain, type: .coin, value: totalFee)
-
-                // Сюда встроить проверку
-
-                guard totalFee > walletManager.minimalRentExamptionFee else {
-                    throw WalletError.failedToGetFee
-                }
 
                 return [Fee(amount, parameters: feeInfo.feeParameters)]
             }

--- a/BlockchainSdk/Blockchains/Solana/SolanaWalletManager.swift
+++ b/BlockchainSdk/Blockchains/Solana/SolanaWalletManager.swift
@@ -21,7 +21,7 @@ class SolanaWalletManager: BaseManager, WalletManager {
     var usePriorityFees = !NFCUtils.isPoorNfcQualityDevice
 
     // It is taken into account in the calculation of the account rent commission for the sender
-    var mainAccountRentExemption: Decimal = 0
+    private var mainAccountRentExemption: Decimal = 0
 
     override func update(completion: @escaping (Result<Void, Error>) -> Void) {
         let transactionIDs = wallet.pendingTransactions.map { $0.hash }
@@ -105,7 +105,7 @@ extension SolanaWalletManager: TransactionSender {
             }
             .withWeakCaptureOf(self)
             .tryMap { walletManager, feeInfo -> [Fee] in
-                let totalFee = feeInfo.feeForMessage + feeInfo.feeParameters.accountCreationFee + walletManager.mainAccountRentExemption
+                let totalFee = feeInfo.feeForMessage + feeInfo.feeParameters.accountCreationFee
                 let amount = Amount(with: walletManager.wallet.blockchain, type: .coin, value: totalFee)
 
                 return [Fee(amount, parameters: feeInfo.feeParameters)]
@@ -329,5 +329,29 @@ extension SolanaWalletManager: StakeKitTransactionSender, StakeKitTransactionSen
 
     func broadcast(transaction: StakeKitTransaction, rawTransaction: RawTransaction) async throws -> String {
         try await networkService.sendRaw(base64serializedTransaction: rawTransaction).async()
+    }
+}
+
+// MARK: - MinimumBalanceRestrictable
+
+extension SolanaWalletManager: MinimumBalanceRestrictable {
+    var minimumBalance: Amount {
+        Amount(with: wallet.blockchain, value: mainAccountRentExemption)
+    }
+
+    // Required to determine the remaining rent when sending the token
+    func validateMinimumBalance(amount: Amount, fee: Amount) throws {
+        guard case .token = amount.type else {
+            return
+        }
+
+        guard let balance = wallet.amounts[.coin] else {
+            throw ValidationError.balanceNotFound
+        }
+
+        let remainderBalance = balance - fee
+        if remainderBalance < minimumBalance {
+            throw ValidationError.minimumBalance(minimumBalance: minimumBalance)
+        }
     }
 }

--- a/BlockchainSdk/Blockchains/Solana/SolanaWalletManager.swift
+++ b/BlockchainSdk/Blockchains/Solana/SolanaWalletManager.swift
@@ -21,7 +21,7 @@ class SolanaWalletManager: BaseManager, WalletManager {
     var usePriorityFees = !NFCUtils.isPoorNfcQualityDevice
 
     // It is taken into account in the calculation of the account rent commission for the sender
-    var minimalRentExamptionFee: Decimal = 0
+    var mainAccountRentExemption: Decimal = 0
 
     override func update(completion: @escaping (Result<Void, Error>) -> Void) {
         let transactionIDs = wallet.pendingTransactions.map { $0.hash }
@@ -41,7 +41,7 @@ class SolanaWalletManager: BaseManager, WalletManager {
     }
 
     private func updateWallet(info: SolanaAccountInfoResponse) {
-        minimalRentExamptionFee = info.balance - info.mainAccountRentExemption
+        mainAccountRentExemption = info.mainAccountRentExemption
 
         wallet.add(coinValue: info.balance)
 
@@ -105,7 +105,7 @@ extension SolanaWalletManager: TransactionSender {
             }
             .withWeakCaptureOf(self)
             .tryMap { walletManager, feeInfo -> [Fee] in
-                let totalFee = feeInfo.feeForMessage + feeInfo.feeParameters.accountCreationFee + walletManager.minimalRentExamptionFee
+                let totalFee = feeInfo.feeForMessage + feeInfo.feeParameters.accountCreationFee + walletManager.mainAccountRentExemption
                 let amount = Amount(with: walletManager.wallet.blockchain, type: .coin, value: totalFee)
 
                 return [Fee(amount, parameters: feeInfo.feeParameters)]


### PR DESCRIPTION
Полное описание в таске. Если коротко фикс

_получаем space отправителья, запрашиваем ренту для отправителя с учетом space, для получателя ничего не трогаем считаем как раньше фи
потом делаем проверку
if balance - fee < полученная рента для отправителя  то ошибка о нехватке средств_