### PR TITLE
IOS-8382: [Visa] Access code setup step

### DIFF
--- a/Tangem/Modules/Onboarding/OnboardingStepsBuilders/VisaOnboardingStepsBuilder.swift
+++ b/Tangem/Modules/Onboarding/OnboardingStepsBuilders/VisaOnboardingStepsBuilder.swift
@@ -40,6 +40,7 @@ extension VisaOnboardingStepsBuilder: OnboardingStepsBuilder {
         var steps = [VisaOnboardingStep]()
 
         steps.append(.welcome)
+        steps.append(.accessCode)
 
         steps.append(contentsOf: otherSteps)
 

--- a/Tangem/Modules/Onboarding/Views/AccessCode/OnboardingAccessCodeView.swift
+++ b/Tangem/Modules/Onboarding/Views/AccessCode/OnboardingAccessCodeView.swift
@@ -45,7 +45,7 @@ struct OnboardingAccessCodeView: View {
                 .padding(.horizontal, 16)
                 .padding(.bottom, 6)
         }
-        .onDisappear(perform: viewModel.onDissappearAction)
+        .onDisappear(perform: viewModel.onDisappearAction)
         .animation(.default, value: viewModel.error)
         .animation(.default, value: viewModel.state)
     }

--- a/Tangem/Modules/Onboarding/Views/AccessCode/OnboardingAccessCodeViewModel.swift
+++ b/Tangem/Modules/Onboarding/Views/AccessCode/OnboardingAccessCodeViewModel.swift
@@ -57,7 +57,7 @@ class OnboardingAccessCodeViewModel: ObservableObject, Identifiable {
         }
     }
 
-    func onDissappearAction() {
+    func onDisappearAction() {
         DispatchQueue.main.async {
             self.error = .none
         }

--- a/Tangem/Modules/Onboarding/Visa/Pages/AccessCode/VisaOnboardingAccessCodeSetupView.swift
+++ b/Tangem/Modules/Onboarding/Visa/Pages/AccessCode/VisaOnboardingAccessCodeSetupView.swift
@@ -1,0 +1,69 @@
+//
+//  VisaOnboardingAccessCodeSetupView.swift
+//  Tangem
+//
+//  Created by Andrew Son on 18.11.24.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import SwiftUI
+
+struct VisaOnboardingAccessCodeSetupView: View {
+    @ObservedObject var viewModel: VisaOnboardingAccessCodeSetupViewModel
+
+    private let buttonIcon: MainButton.Icon = .trailing(Assets.tangemIcon)
+
+    var body: some View {
+        VStack(spacing: 24) {
+            descriptionContent
+                .padding(.horizontal, 24)
+
+            inputContent
+
+            Spacer()
+
+            MainButton(
+                title: viewModel.viewState.buttonTitle,
+                icon: viewModel.viewState.isButtonWithLogo ? buttonIcon : nil,
+                isLoading: viewModel.isButtonBusy,
+                isDisabled: viewModel.isButtonDisabled,
+                action: viewModel.mainButtonAction
+            )
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 32)
+        .padding(.bottom, 10)
+    }
+
+    private var descriptionContent: some View {
+        VStack(spacing: 10) {
+            Text(viewModel.viewState.title)
+                .multilineTextAlignment(.center)
+                .style(Fonts.Bold.title1, color: Colors.Text.primary1)
+
+            Text(viewModel.viewState.description)
+                .multilineTextAlignment(.center)
+                .style(Fonts.Regular.callout, color: Colors.Text.secondary)
+        }
+    }
+
+    private var inputContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            CustomPasswordTextField(
+                placeholder: Localization.detailsManageSecurityAccessCode,
+                color: Colors.Text.primary1,
+                password: $viewModel.accessCode,
+                onCommit: {}
+            )
+            .frame(height: 48)
+            .disabled(viewModel.isInputDisabled)
+
+            Text(viewModel.errorMessage ?? " ")
+                .multilineTextAlignment(.leading)
+                .lineLimit(2)
+                .style(Fonts.Regular.footnote, color: Colors.Text.warning)
+                .id("error_\(viewModel.errorMessage ?? " ")")
+                .hidden(viewModel.errorMessage == nil)
+        }
+    }
+}

--- a/Tangem/Modules/Onboarding/Visa/Pages/AccessCode/VisaOnboardingAccessCodeSetupView.swift
+++ b/Tangem/Modules/Onboarding/Visa/Pages/AccessCode/VisaOnboardingAccessCodeSetupView.swift
@@ -30,21 +30,18 @@ struct VisaOnboardingAccessCodeSetupView: View {
                 action: viewModel.mainButtonAction
             )
         }
-        .padding(.horizontal, 16)
-        .padding(.top, 32)
-        .padding(.bottom, 10)
+        .padding(.init(top: 32, leading: 16, bottom: 10, trailing: 16))
     }
 
     private var descriptionContent: some View {
         VStack(spacing: 10) {
             Text(viewModel.viewState.title)
-                .multilineTextAlignment(.center)
                 .style(Fonts.Bold.title1, color: Colors.Text.primary1)
 
             Text(viewModel.viewState.description)
-                .multilineTextAlignment(.center)
                 .style(Fonts.Regular.callout, color: Colors.Text.secondary)
         }
+        .multilineTextAlignment(.center)
     }
 
     private var inputContent: some View {

--- a/Tangem/Modules/Onboarding/Visa/Pages/AccessCode/VisaOnboardingAccessCodeSetupViewModel.swift
+++ b/Tangem/Modules/Onboarding/Visa/Pages/AccessCode/VisaOnboardingAccessCodeSetupViewModel.swift
@@ -21,11 +21,11 @@ protocol VisaOnboardingAccessCodeSetupDelegate: AnyObject {
 
 class VisaOnboardingAccessCodeSetupViewModel: ObservableObject {
     @Published var accessCode: String = ""
-    @Published var viewState: State = .accessCode
-    @Published var isButtonBusy: Bool = false
-    @Published var isButtonDisabled: Bool = true
-    @Published var isInputDisabled: Bool = false
-    @Published var errorMessage: String? = nil
+    @Published private(set) var viewState: State = .accessCode
+    @Published private(set) var isButtonBusy: Bool = false
+    @Published private(set) var isButtonDisabled: Bool = true
+    @Published private(set) var isInputDisabled: Bool = false
+    @Published private(set) var errorMessage: String? = nil
 
     private var selectedAccessCode: String = ""
     private var accessCodeInputSubscription: AnyCancellable?

--- a/Tangem/Modules/Onboarding/Visa/Pages/AccessCode/VisaOnboardingAccessCodeSetupViewModel.swift
+++ b/Tangem/Modules/Onboarding/Visa/Pages/AccessCode/VisaOnboardingAccessCodeSetupViewModel.swift
@@ -1,0 +1,192 @@
+//
+//  VisaOnboardingAccessCodeSetupViewModel.swift
+//  Tangem
+//
+//  Created by Andrew Son on 19.11.24.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+import Combine
+import TangemFoundation
+
+protocol VisaOnboardingAccessCodeSetupDelegate: AnyObject {
+    /// We need to show alert in parent view, otherwise it won't be shown
+    @MainActor
+    func showAlert(_ alert: AlertBinder) async
+
+    func useSelectedCode(accessCode: String) async throws
+}
+
+class VisaOnboardingAccessCodeSetupViewModel: ObservableObject {
+    @Published var accessCode: String = ""
+    @Published var viewState: State = .accessCode
+    @Published var isButtonBusy: Bool = false
+    @Published var isButtonDisabled: Bool = true
+    @Published var isInputDisabled: Bool = false
+    @Published var errorMessage: String? = nil
+
+    private var selectedAccessCode: String = ""
+    private var accessCodeInputSubscription: AnyCancellable?
+
+    private weak var delegate: VisaOnboardingAccessCodeSetupDelegate?
+
+    init(delegate: VisaOnboardingAccessCodeSetupDelegate) {
+        self.delegate = delegate
+        bind()
+    }
+
+    func mainButtonAction() {
+        switch viewState {
+        case .accessCode:
+            selectedAccessCode = accessCode
+            withAnimation {
+                viewState = .repeatAccessCode
+                accessCode = ""
+            }
+        case .repeatAccessCode:
+            if selectedAccessCode.isEmpty {
+                log("Main button on access code setup is enabled while error is present. State: \(viewState.title)")
+                return
+            }
+
+            UIApplication.shared.endEditing()
+            isButtonBusy = true
+            // We need to disable input, because a lot of operations will be done on this page
+            // May be changed)
+            isInputDisabled = true
+            runTask(in: self, isDetached: false) { viewModel in
+                do {
+                    try await viewModel.delegate?.useSelectedCode(accessCode: viewModel.selectedAccessCode)
+                } catch {
+                    viewModel.log("Failed to use selected access code. Reason: \(error)")
+                    /// We need to show alert in parent view, otherwise it won't be shown
+                    await viewModel.delegate?.showAlert(error.alertBinder)
+                }
+
+                await runOnMain {
+                    viewModel.isInputDisabled = false
+                    viewModel.isButtonBusy = false
+                }
+            }
+        }
+    }
+
+    func canGoBack() -> Bool {
+        switch viewState {
+        case .accessCode:
+            UIApplication.shared.endEditing()
+            selectedAccessCode = ""
+            accessCode = ""
+            errorMessage = nil
+            return true
+        case .repeatAccessCode:
+            withAnimation {
+                viewState = .accessCode
+                accessCode = selectedAccessCode
+                selectedAccessCode = ""
+                errorMessage = nil
+            }
+            return false
+        }
+    }
+
+    private func bind() {
+        accessCodeInputSubscription = $accessCode
+            .handleEvents(receiveOutput: { [weak self] _ in
+                self?.errorMessage = nil
+                self?.isButtonDisabled = true
+            })
+            .debounce(for: 0.5, scheduler: DispatchQueue.main)
+            .withWeakCaptureOf(self)
+            .sink { viewModel, input in
+                viewModel.processInput(accessCodeInput: input)
+            }
+    }
+
+    private func processInput(accessCodeInput: String) {
+        if accessCodeInput.isEmpty {
+            errorMessage = nil
+            isButtonDisabled = true
+            return
+        }
+
+        do {
+            try isAccessCodeValid(accessCode: accessCodeInput)
+            errorMessage = nil
+            isButtonDisabled = false
+        } catch let validationError as ValidationError {
+            errorMessage = validationError.description
+            isButtonDisabled = true
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+            isButtonDisabled = true
+            return
+        }
+    }
+
+    private func isAccessCodeValid(accessCode: String) throws {
+        switch viewState {
+        case .accessCode:
+            if accessCode.count < 4 {
+                throw ValidationError.accessCodeTooShort
+            }
+        case .repeatAccessCode:
+            if accessCode != selectedAccessCode {
+                throw ValidationError.codesDoNotMatch
+            }
+        }
+    }
+
+    private func log<T>(_ message: @autoclosure () -> T) {
+        AppLog.shared.debug("[VisaAccessCodeViewModel] - \(message())")
+    }
+}
+
+extension VisaOnboardingAccessCodeSetupViewModel {
+    enum ValidationError: String, Error {
+        case accessCodeTooShort
+        case codesDoNotMatch
+
+        var description: String {
+            switch self {
+            case .accessCodeTooShort: return Localization.onboardingAccessCodeTooShort
+            case .codesDoNotMatch: return Localization.onboardingAccessCodesDoesntMatch
+            }
+        }
+    }
+}
+
+extension VisaOnboardingAccessCodeSetupViewModel {
+    enum State {
+        case accessCode
+        case repeatAccessCode
+
+        var title: String {
+            switch self {
+            case .accessCode: return Localization.onboardingAccessCodeIntroTitle
+            case .repeatAccessCode: return Localization.onboardingAccessCodeRepeatCodeTitle
+            }
+        }
+
+        var description: String {
+            "The access code will be used manage your payment account and protect it from unauthorized access"
+        }
+
+        var buttonTitle: String {
+            switch self {
+            case .accessCode: return Localization.commonContinue
+            case .repeatAccessCode: return "Start activation"
+            }
+        }
+
+        var isButtonWithLogo: Bool {
+            switch self {
+            case .accessCode: return false
+            case .repeatAccessCode: return true
+            }
+        }
+    }
+}

--- a/Tangem/Modules/Onboarding/Visa/VisaOnboardingStep.swift
+++ b/Tangem/Modules/Onboarding/Visa/VisaOnboardingStep.swift
@@ -8,6 +8,7 @@
 
 enum VisaOnboardingStep {
     case welcome
+    case accessCode
 
     case saveUserWallet
     case pushNotifications
@@ -18,6 +19,8 @@ enum VisaOnboardingStep {
         switch self {
         case .welcome:
             return Localization.onboardingGettingStarted
+        case .accessCode:
+            return Localization.onboardingWalletInfoTitleThird
         case .saveUserWallet:
             return Localization.onboardingNavbarSaveWallet
         case .pushNotifications:

--- a/Tangem/Modules/Onboarding/Visa/VisaOnboardingView.swift
+++ b/Tangem/Modules/Onboarding/Visa/VisaOnboardingView.swift
@@ -71,6 +71,8 @@ struct VisaOnboardingView: View {
         switch viewModel.currentStep {
         case .welcome:
             VisaOnboardingWelcomeView(viewModel: viewModel.welcomeViewModel)
+        case .accessCode:
+            VisaOnboardingAccessCodeSetupView(viewModel: viewModel.accessCodeSetupViewModel)
         case .saveUserWallet:
             UserWalletStorageAgreementView(
                 viewModel: viewModel.userWalletStorageAgreementViewModel,

--- a/Tangem/Modules/Onboarding/Visa/VisaOnboardingViewModel.swift
+++ b/Tangem/Modules/Onboarding/Visa/VisaOnboardingViewModel.swift
@@ -48,6 +48,8 @@ class VisaOnboardingViewModel: ObservableObject {
         startActivationDelegate: weakify(self, forFunction: VisaOnboardingViewModel.goToNextStep)
     )
 
+    lazy var accessCodeSetupViewModel = VisaOnboardingAccessCodeSetupViewModel(delegate: self)
+
     var navigationBarTitle: String {
         currentStep.navigationTitle
     }
@@ -80,12 +82,22 @@ class VisaOnboardingViewModel: ObservableObject {
         self.input = input
         self.visaActivationManager = visaActivationManager
         self.coordinator = coordinator
+
+        if case .visa(let visaSteps) = input.steps {
+            steps = visaSteps
+        }
     }
 
     func backButtonAction() {
         switch currentStep {
         case .welcome, .pushNotifications, .saveUserWallet:
             alert = AlertBuilder.makeExitAlert(okAction: weakify(self, forFunction: VisaOnboardingViewModel.closeOnboarding))
+        case .accessCode:
+            guard accessCodeSetupViewModel.canGoBack() else {
+                return
+            }
+
+            goToStep(.welcome)
         case .success:
             break
         }
@@ -120,7 +132,9 @@ private extension VisaOnboardingViewModel {
     func goToNextStep() {
         switch currentStep {
         case .welcome:
-            startActivation()
+            goToStep(.accessCode)
+        case .accessCode:
+            break
         case .saveUserWallet, .pushNotifications:
             break
         case .success:
@@ -205,6 +219,19 @@ extension VisaOnboardingViewModel: UserWalletStorageAgreementRoutable {
 extension VisaOnboardingViewModel: PushNotificationsPermissionRequestDelegate {
     func didFinishPushNotificationOnboarding() {
         goToNextStep()
+    }
+}
+
+extension VisaOnboardingViewModel: VisaOnboardingAccessCodeSetupDelegate {
+    /// We need to show alert in parent view, otherwise it won't be presented
+    @MainActor
+    func showAlert(_ alert: AlertBinder) async {
+        self.alert = alert
+    }
+
+    func useSelectedCode(accessCode: String) async throws {
+        try await Task.sleep(seconds: 5)
+        throw "Will be implemented later IOS-8509"
     }
 }
 

--- a/Tangem/Modules/Onboarding/Visa/VisaOnboardingViewModel.swift
+++ b/Tangem/Modules/Onboarding/Visa/VisaOnboardingViewModel.swift
@@ -93,7 +93,7 @@ class VisaOnboardingViewModel: ObservableObject {
         case .welcome, .pushNotifications, .saveUserWallet:
             alert = AlertBuilder.makeExitAlert(okAction: weakify(self, forFunction: VisaOnboardingViewModel.closeOnboarding))
         case .accessCode:
-            guard accessCodeSetupViewModel.canGoBack() else {
+            guard accessCodeSetupViewModel.goBack() else {
                 return
             }
 

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -292,6 +292,7 @@
 		B012A1192AA5CDE00079BAB4 /* NotificationButtonActionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B012A1182AA5CDE00079BAB4 /* NotificationButtonActionType.swift */; };
 		B012A11C2AA617000079BAB4 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B012A11A2AA617000079BAB4 /* NotificationManager.swift */; };
 		B012A11D2AA617000079BAB4 /* UserWalletNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B012A11B2AA617000079BAB4 /* UserWalletNotificationManager.swift */; };
+		B018770F2CEC90BC00794300 /* VisaOnboardingAccessCodeSetupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B018770E2CEC90BC00794300 /* VisaOnboardingAccessCodeSetupViewModel.swift */; };
 		B018F304259204A200D8F89A /* GeneralNotificationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B018F303259204A200D8F89A /* GeneralNotificationEvent.swift */; };
 		B018FE612B0CD33400D8D31E /* ExpressNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B018FE602B0CD33400D8D31E /* ExpressNotificationManager.swift */; };
 		B018FE662B0CE55E00D8D31E /* ExpressNotificationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B018FE652B0CE55E00D8D31E /* ExpressNotificationEvent.swift */; };
@@ -477,6 +478,7 @@
 		B072E12E2B18B26000B0AB27 /* PendingExpressTxStatusBottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B072E12D2B18B26000B0AB27 /* PendingExpressTxStatusBottomSheetView.swift */; };
 		B074AF872B06778800E9CEA3 /* AnalyticsContextDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B074AF862B06778800E9CEA3 /* AnalyticsContextDataProvider.swift */; };
 		B0751ED92C69E3F5009066C8 /* DefaultAmountNotationFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0751ED82C69E3F5009066C8 /* DefaultAmountNotationFormatterTests.swift */; };
+		B0764E482CEB7CBE00361E90 /* VisaOnboardingAccessCodeSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0764E472CEB7CBE00361E90 /* VisaOnboardingAccessCodeSetupView.swift */; };
 		B079DB722AEB937D00D2D0D5 /* Analytics+DebugEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B079DB712AEB937D00D2D0D5 /* Analytics+DebugEvent.swift */; };
 		B07A13822C416B0A00A429C3 /* MarketsTokenDetailsChipsContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B07A13812C416B0A00A429C3 /* MarketsTokenDetailsChipsContainer.swift */; };
 		B07A13842C416B2A00A429C3 /* MarketsTokenDetailsLinkChipsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B07A13832C416B2A00A429C3 /* MarketsTokenDetailsLinkChipsView.swift */; };
@@ -3432,6 +3434,7 @@
 		B012A1182AA5CDE00079BAB4 /* NotificationButtonActionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationButtonActionType.swift; sourceTree = "<group>"; };
 		B012A11A2AA617000079BAB4 /* NotificationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		B012A11B2AA617000079BAB4 /* UserWalletNotificationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserWalletNotificationManager.swift; sourceTree = "<group>"; };
+		B018770E2CEC90BC00794300 /* VisaOnboardingAccessCodeSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisaOnboardingAccessCodeSetupViewModel.swift; sourceTree = "<group>"; };
 		B018F303259204A200D8F89A /* GeneralNotificationEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralNotificationEvent.swift; sourceTree = "<group>"; };
 		B018FE602B0CD33400D8D31E /* ExpressNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressNotificationManager.swift; sourceTree = "<group>"; };
 		B018FE652B0CE55E00D8D31E /* ExpressNotificationEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressNotificationEvent.swift; sourceTree = "<group>"; };
@@ -3623,6 +3626,7 @@
 		B072E12D2B18B26000B0AB27 /* PendingExpressTxStatusBottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingExpressTxStatusBottomSheetView.swift; sourceTree = "<group>"; };
 		B074AF862B06778800E9CEA3 /* AnalyticsContextDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsContextDataProvider.swift; sourceTree = "<group>"; };
 		B0751ED82C69E3F5009066C8 /* DefaultAmountNotationFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAmountNotationFormatterTests.swift; sourceTree = "<group>"; };
+		B0764E472CEB7CBE00361E90 /* VisaOnboardingAccessCodeSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisaOnboardingAccessCodeSetupView.swift; sourceTree = "<group>"; };
 		B079DB712AEB937D00D2D0D5 /* Analytics+DebugEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Analytics+DebugEvent.swift"; sourceTree = "<group>"; };
 		B07A13812C416B0A00A429C3 /* MarketsTokenDetailsChipsContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketsTokenDetailsChipsContainer.swift; sourceTree = "<group>"; };
 		B07A13832C416B2A00A429C3 /* MarketsTokenDetailsLinkChipsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketsTokenDetailsLinkChipsView.swift; sourceTree = "<group>"; };
@@ -7957,6 +7961,15 @@
 			path = AnalyticsContext;
 			sourceTree = "<group>";
 		};
+		B0764E462CEB7CAB00361E90 /* AccessCode */ = {
+			isa = PBXGroup;
+			children = (
+				B0764E472CEB7CBE00361E90 /* VisaOnboardingAccessCodeSetupView.swift */,
+				B018770E2CEC90BC00794300 /* VisaOnboardingAccessCodeSetupViewModel.swift */,
+			);
+			path = AccessCode;
+			sourceTree = "<group>";
+		};
 		B079DB702AEB937000D2D0D5 /* Debug */ = {
 			isa = PBXGroup;
 			children = (
@@ -8020,6 +8033,7 @@
 		B07E07AD2CD8E394007DEDA6 /* Pages */ = {
 			isa = PBXGroup;
 			children = (
+				B0764E462CEB7CAB00361E90 /* AccessCode */,
 				B0063A7C2CDE3A4900EDE943 /* Pin */,
 				B07E07B02CD8E6D7007DEDA6 /* Welcome */,
 			);
@@ -16607,6 +16621,7 @@
 				DCE317B82CC4F7FE0069C641 /* WalletConnectSolanaSignTransactionDTO.swift in Sources */,
 				DA559C532B0265E700F59584 /* SendDestinationTextViewModel.swift in Sources */,
 				B67DC1E62B7C45DD008ACB0E /* UserDefaultsBlockchainDataStorage.swift in Sources */,
+				B0764E482CEB7CBE00361E90 /* VisaOnboardingAccessCodeSetupView.swift in Sources */,
 				B0C171CE264C173400E4BA5C /* CameraAccessDeniedModifier.swift in Sources */,
 				B09446122CAC3EFD008F43D8 /* MarketsDTO+ExchangesList.swift in Sources */,
 				DCEFF6842CC1509A00A49878 /* ScanCardSettingsCoordinator.swift in Sources */,
@@ -17951,6 +17966,7 @@
 				B67688F12B078F71006C94F7 /* MainBottomSheetOverlayView.swift in Sources */,
 				B0D1AC322906719300584E6C /* Analytics+Event.swift in Sources */,
 				DC04693A2B8E6BE400C785D1 /* SellActionURLHelper.swift in Sources */,
+				B018770F2CEC90BC00794300 /* VisaOnboardingAccessCodeSetupViewModel.swift in Sources */,
 				B05A645625E0F57B00F154B7 /* ScanTroubleshootingView.swift in Sources */,
 				EFF763E12C4E38B600E846F4 /* SendStepViewAnimatable.swift in Sources */,
 				EF0295592A9DCDEE000B2142 /* SensitiveText.swift in Sources */,


### PR DESCRIPTION
* Долго пытался отрефачить существующий в онбординге Access Code, чтобы он подошел и для визы, но никак не получается, слишком много логики дополнительной заезжает. Поэтому сделал отдельно
* Пытался сделать 2 раздельных шага, чтобы родительская модель `VisaOnboardingViewModel` ничего не спрашивала у `VisaOnboardingAccessCodeSetupViewModel` и не знала ни про какую `canGoBack()`, но тогда появляется проблема дергающейся клавы, т.к. разные инпуты и видны переходы между экранами + получается заморочистая логика передачи данных между `VisaOnboardingViewModel` и `VisaOnboardingAccessCodeSetupViewModel`, т.к. родительская вьюха должна знать какой именно шаг отправляет команду, что надо удалять из памяти вью модели или же очищать их стейт. Пусть лучше для родительской вью модели будет одна функция, вместо кучи других спагетти
* Написал Лёне, что какая-то странная логика, что на экране создания `Access Code` происходит вся магия активации, посмотрим, может это переделается и чуть упростится логика, не надо будет стартовать таску, блокировать инпут и прочее