### PR TITLE
IOS-7610 Don't fail balance loading on token error

### DIFF
--- a/BlockchainSdk/Blockchains/TON/TONWalletInfo.swift
+++ b/BlockchainSdk/Blockchains/TON/TONWalletInfo.swift
@@ -19,7 +19,7 @@ struct TONWalletInfo {
     /// Wallet availability
     let isAvailable: Bool
 
-    let tokensInfo: [Token: TokenInfo]
+    let tokensInfo: [Token: Result<TokenInfo, Error>]
 
     struct TokenInfo {
         let jettonWalletAddress: String

--- a/BlockchainSdk/Blockchains/TON/TONWalletManager.swift
+++ b/BlockchainSdk/Blockchains/TON/TONWalletManager.swift
@@ -160,10 +160,15 @@ private extension TONWalletManager {
         wallet.add(coinValue: info.balance)
 
         for (token, tokenInfo) in info.tokensInfo {
-            wallet.add(tokenValue: tokenInfo.balance, for: token)
-
-            // jetton wallet address is used to calculate fee and build transaction
-            jettonWalletAddressCache[token] = tokenInfo.jettonWalletAddress
+            switch tokenInfo {
+            case .success(let value):
+                wallet.add(tokenValue: value.balance, for: token)
+                // jetton wallet address is used to calculate fee and build transaction
+                jettonWalletAddressCache[token] = value.jettonWalletAddress
+            case .failure:
+                wallet.clearAmount(for: token)
+                jettonWalletAddressCache[token] = nil
+            }
         }
 
         txBuilder.sequenceNumber = info.sequenceNumber


### PR DESCRIPTION
Раньше при ошибке загрузки любого токена фейлилась вся цепочка загрузки балансов для основной сети и токенов. Пофиксил по аналогии с ethereum, в дальнейшем возможно будет иметь смысл сделать generic функцию. Прикладываю скрины до и после
![IMG_7061](https://github.com/user-attachments/assets/48aa6549-02e6-4857-bec0-71bd4811ec97)
![IMG_7062](https://github.com/user-attachments/assets/c73bd766-7d81-4c3d-906a-18cf4f9eb3ad)
