### PR TITLE
IOS-8604 [Onramp] iOS 15 fixes

### DIFF
--- a/Tangem/Modules/OnrampCountryDetection/OnrampCountryDetectionCoordinator.swift
+++ b/Tangem/Modules/OnrampCountryDetection/OnrampCountryDetectionCoordinator.swift
@@ -1,0 +1,76 @@
+//
+//  OnrampCountryDetectionCoordinator.swift
+//  TangemApp
+//
+//  Created by Sergey Balashov on 28.11.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import TangemExpress
+
+class OnrampCountryDetectionCoordinator: CoordinatorObject {
+    let dismissAction: Action<CloseOption?>
+    let popToRootAction: Action<PopToRootOptions>
+
+    // MARK: - Root view model
+
+    @Published private(set) var rootViewModel: OnrampCountryDetectionViewModel?
+
+    // MARK: - Child view models
+
+    @Published var onrampCountrySelectorViewModel: OnrampCountrySelectorViewModel?
+
+    private var options: Options!
+
+    required init(dismissAction: @escaping Action<CloseOption?>, popToRootAction: @escaping Action<PopToRootOptions>) {
+        self.dismissAction = dismissAction
+        self.popToRootAction = popToRootAction
+    }
+
+    func start(with options: Options) {
+        self.options = options
+        rootViewModel = .init(country: options.country, repository: options.repository, coordinator: self)
+    }
+}
+
+// MARK: - Options
+
+extension OnrampCountryDetectionCoordinator {
+    struct Options {
+        let country: OnrampCountry
+        let repository: any OnrampRepository
+        let dataRepository: any OnrampDataRepository
+    }
+
+    enum CloseOption {
+        case closeOnramp
+    }
+}
+
+// MARK: - OnrampCountryDetectionRoutable
+
+extension OnrampCountryDetectionCoordinator: OnrampCountryDetectionRoutable {
+    func openChangeCountry() {
+        onrampCountrySelectorViewModel = OnrampCountrySelectorViewModel(
+            repository: options.repository,
+            dataRepository: options.dataRepository,
+            coordinator: self
+        )
+    }
+
+    func dismissConfirmCountryView() {
+        dismiss(with: nil)
+    }
+
+    func dismissOnramp() {
+        dismiss(with: .closeOnramp)
+    }
+}
+
+// MARK: - OnrampCountrySelectorRoutable
+
+extension OnrampCountryDetectionCoordinator: OnrampCountrySelectorRoutable {
+    func dismissCountrySelector() {
+        onrampCountrySelectorViewModel = nil
+    }
+}

--- a/Tangem/Modules/OnrampCountryDetection/OnrampCountryDetectionCoordinator.swift
+++ b/Tangem/Modules/OnrampCountryDetection/OnrampCountryDetectionCoordinator.swift
@@ -20,7 +20,7 @@ class OnrampCountryDetectionCoordinator: CoordinatorObject {
 
     @Published var onrampCountrySelectorViewModel: OnrampCountrySelectorViewModel?
 
-    private var options: Options!
+    private var options: Options?
 
     required init(dismissAction: @escaping Action<CloseOption?>, popToRootAction: @escaping Action<PopToRootOptions>) {
         self.dismissAction = dismissAction
@@ -51,6 +51,11 @@ extension OnrampCountryDetectionCoordinator {
 
 extension OnrampCountryDetectionCoordinator: OnrampCountryDetectionRoutable {
     func openChangeCountry() {
+        guard let options else {
+            assertionFailure("OnrampCountryDetectionCoordinator.Options not found")
+            return
+        }
+
         onrampCountrySelectorViewModel = OnrampCountrySelectorViewModel(
             repository: options.repository,
             dataRepository: options.dataRepository,

--- a/Tangem/Modules/OnrampCountryDetection/OnrampCountryDetectionCoordinatorView.swift
+++ b/Tangem/Modules/OnrampCountryDetection/OnrampCountryDetectionCoordinatorView.swift
@@ -1,0 +1,29 @@
+//
+//  OnrampCountryDetectionCoordinatorView.swift
+//  TangemApp
+//
+//  Created by Sergey Balashov on 28.11.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import SwiftUI
+
+struct OnrampCountryDetectionCoordinatorView: CoordinatorView {
+    @ObservedObject var coordinator: OnrampCountryDetectionCoordinator
+
+    var body: some View {
+        if let rootViewModel = coordinator.rootViewModel {
+            OnrampCountryDetectionView(viewModel: rootViewModel)
+                // We have to use `overlay` instead of ZStack to save the view size
+                .overlay(content: { sheets })
+        }
+    }
+
+    @ViewBuilder
+    private var sheets: some View {
+        NavHolder()
+            .sheet(item: $coordinator.onrampCountrySelectorViewModel) {
+                OnrampCountrySelectorView(viewModel: $0)
+            }
+    }
+}

--- a/Tangem/Modules/OnrampCountryDetection/OnrampCountryDetectionCoordinatorView.swift
+++ b/Tangem/Modules/OnrampCountryDetection/OnrampCountryDetectionCoordinatorView.swift
@@ -14,7 +14,9 @@ struct OnrampCountryDetectionCoordinatorView: CoordinatorView {
     var body: some View {
         if let rootViewModel = coordinator.rootViewModel {
             OnrampCountryDetectionView(viewModel: rootViewModel)
-                // We have to use `overlay` instead of ZStack to save the view size
+                // We have to save the `OnrampCountryDetectionView` size because it's a bottom sheet
+                // If we will use `ZStack` the `CoordinatorView` will be expand on the whole screen
+                // The `overlay` doesn't impact on `CoordinatorView` size
                 .overlay(content: { sheets })
         }
     }

--- a/Tangem/Modules/OnrampCountryDetection/OnrampCountryDetectionRoutable.swift
+++ b/Tangem/Modules/OnrampCountryDetection/OnrampCountryDetectionRoutable.swift
@@ -9,5 +9,5 @@
 protocol OnrampCountryDetectionRoutable: AnyObject {
     func openChangeCountry()
     func dismissConfirmCountryView()
-    func dismiss()
+    func dismissOnramp()
 }

--- a/Tangem/Modules/OnrampCountryDetection/OnrampCountryDetectionViewModel.swift
+++ b/Tangem/Modules/OnrampCountryDetection/OnrampCountryDetectionViewModel.swift
@@ -54,7 +54,7 @@ final class OnrampCountryDetectionViewModel: ObservableObject, Identifiable {
             repository.updatePreference(country: country, currency: country.currency)
             coordinator?.dismissConfirmCountryView()
         case .notSupport:
-            coordinator?.dismiss()
+            coordinator?.dismissOnramp()
         }
     }
 }
@@ -62,7 +62,18 @@ final class OnrampCountryDetectionViewModel: ObservableObject, Identifiable {
 // MARK: - Private
 
 private extension OnrampCountryDetectionViewModel {
-    func bind() {}
+    func bind() {
+        repository
+            .preferencePublisher
+            // When user selected country we have to close bottom sheet
+            .first { !$0.isEmpty }
+            .withWeakCaptureOf(self)
+            .receive(on: DispatchQueue.main)
+            .sink { viewModel, _ in
+                viewModel.coordinator?.dismissConfirmCountryView()
+            }
+            .store(in: &bag)
+    }
 }
 
 extension OnrampCountryDetectionViewModel {

--- a/Tangem/Modules/OnrampCountrySelector/OnrampCountrySelectorView.swift
+++ b/Tangem/Modules/OnrampCountrySelector/OnrampCountrySelectorView.swift
@@ -29,10 +29,7 @@ struct OnrampCountrySelectorView: View {
 
             contentView
         }
-        .background(
-            Colors.Background.primary
-                .ignoresSafeArea()
-        )
+        .background(Colors.Background.primary.ignoresSafeArea())
     }
 }
 

--- a/Tangem/Modules/OnrampCountrySelector/OnrampCountrySelectorViewModel.swift
+++ b/Tangem/Modules/OnrampCountrySelector/OnrampCountrySelectorViewModel.swift
@@ -51,23 +51,20 @@ final class OnrampCountrySelectorViewModel: Identifiable, ObservableObject {
 
 private extension OnrampCountrySelectorViewModel {
     func bind() {
-        Publishers.CombineLatest(
-            countriesSubject,
-            $searchText
-        )
-        .withWeakCaptureOf(self)
-        .map { viewModel, data in
-            let (countries, searchText) = data
-            return .loaded(
-                viewModel.mapToCountriesViewData(
-                    countries: countries,
-                    searchText: searchText
+        Publishers.CombineLatest(countriesSubject, $searchText)
+            .withWeakCaptureOf(self)
+            .map { viewModel, data in
+                let (countries, searchText) = data
+                return .loaded(
+                    viewModel.mapToCountriesViewData(
+                        countries: countries,
+                        searchText: searchText
+                    )
                 )
-            )
-        }
-        .receive(on: DispatchQueue.main)
-        .assign(to: \.countries, on: self, ownership: .weak)
-        .store(in: &bag)
+            }
+            .receive(on: DispatchQueue.main)
+            .assign(to: \.countries, on: self, ownership: .weak)
+            .store(in: &bag)
     }
 
     func mapToCountriesViewData(countries: [OnrampCountry], searchText: String) -> [OnrampCountryViewData] {
@@ -91,12 +88,6 @@ private extension OnrampCountrySelectorViewModel {
     }
 
     func updatePreference(country: OnrampCountry) {
-        // We have to save the currency in repository
-        // if we don't have one
-        if repository.preferenceCurrency == nil {
-            repository.updatePreference(country: country, currency: country.currency)
-        } else {
-            repository.updatePreference(country: country)
-        }
+        repository.updatePreference(country: country, currency: country.currency)
     }
 }

--- a/Tangem/Modules/Send/Services/SendBaseDataBuilder/CommonOnrampBaseDataBuilder.swift
+++ b/Tangem/Modules/Send/Services/SendBaseDataBuilder/CommonOnrampBaseDataBuilder.swift
@@ -34,12 +34,12 @@ struct CommonOnrampBaseDataBuilder {
 // MARK: - OnrampBaseDataBuilder
 
 extension CommonOnrampBaseDataBuilder: OnrampBaseDataBuilder {
-    func makeDataForOnrampCountryBottomSheet() -> OnrampRepository {
-        onrampRepository
+    func makeDataForOnrampCountryBottomSheet() -> (repository: OnrampRepository, dataRepository: OnrampDataRepository) {
+        (repository: onrampRepository, dataRepository: onrampDataRepository)
     }
 
-    func makeDataForOnrampCountrySelectorView() -> (preferenceRepository: OnrampRepository, dataRepository: OnrampDataRepository) {
-        (preferenceRepository: onrampRepository, dataRepository: onrampDataRepository)
+    func makeDataForOnrampCountrySelectorView() -> (repository: OnrampRepository, dataRepository: OnrampDataRepository) {
+        (repository: onrampRepository, dataRepository: onrampDataRepository)
     }
 
     func makeDataForOnrampProvidersPaymentMethodsView() -> (providersBuilder: OnrampProvidersBuilder, paymentMethodsBuilder: OnrampPaymentMethodsBuilder) {

--- a/Tangem/Modules/Send/Services/SendBaseDataBuilder/SendBaseDataBuilder.swift
+++ b/Tangem/Modules/Send/Services/SendBaseDataBuilder/SendBaseDataBuilder.swift
@@ -21,8 +21,8 @@ protocol StakingBaseDataBuilder: SendGenericBaseDataBuilder {
 }
 
 protocol OnrampBaseDataBuilder: SendGenericBaseDataBuilder {
-    func makeDataForOnrampCountryBottomSheet() -> OnrampRepository
-    func makeDataForOnrampCountrySelectorView() -> (preferenceRepository: OnrampRepository, dataRepository: OnrampDataRepository)
+    func makeDataForOnrampCountryBottomSheet() -> (repository: OnrampRepository, dataRepository: OnrampDataRepository)
+    func makeDataForOnrampCountrySelectorView() -> (repository: OnrampRepository, dataRepository: OnrampDataRepository)
     func makeDataForOnrampProvidersPaymentMethodsView() -> (providersBuilder: OnrampProvidersBuilder, paymentMethodsBuilder: OnrampPaymentMethodsBuilder)
     func makeDataForOnrampRedirecting() -> OnrampRedirectingBuilder
 }

--- a/Tangem/Modules/Send/UI/Base/SendCoordinator.swift
+++ b/Tangem/Modules/Send/UI/Base/SendCoordinator.swift
@@ -28,13 +28,13 @@ class SendCoordinator: CoordinatorObject {
 
     @Published var qrScanViewCoordinator: QRScanViewCoordinator?
     @Published var onrampProvidersCoordinator: OnrampProvidersCoordinator?
+    @Published var onrampCountryDetectionCoordinator: OnrampCountryDetectionCoordinator?
 
     // MARK: - Child view models
 
     @Published var mailViewModel: MailViewModel?
     @Published var expressApproveViewModel: ExpressApproveViewModel?
 
-    @Published var onrampCountryDetectionCoordinator: OnrampCountryDetectionCoordinator?
     @Published var onrampSettingsViewModel: OnrampSettingsViewModel?
     @Published var onrampCountrySelectorViewModel: OnrampCountrySelectorViewModel?
     @Published var onrampCurrencySelectorViewModel: OnrampCurrencySelectorViewModel?

--- a/Tangem/Modules/Send/UI/Base/SendCoordinator.swift
+++ b/Tangem/Modules/Send/UI/Base/SendCoordinator.swift
@@ -34,7 +34,7 @@ class SendCoordinator: CoordinatorObject {
     @Published var mailViewModel: MailViewModel?
     @Published var expressApproveViewModel: ExpressApproveViewModel?
 
-    @Published var onrampCountryDetectionViewModel: OnrampCountryDetectionViewModel?
+    @Published var onrampCountryDetectionCoordinator: OnrampCountryDetectionCoordinator?
     @Published var onrampSettingsViewModel: OnrampSettingsViewModel?
     @Published var onrampCountrySelectorViewModel: OnrampCountrySelectorViewModel?
     @Published var onrampCurrencySelectorViewModel: OnrampCurrencySelectorViewModel?
@@ -141,12 +141,27 @@ extension SendCoordinator: SendRoutable {
 // MARK: - ExpressApproveRoutable
 
 extension SendCoordinator: OnrampRoutable {
-    func openOnrampCountryDetection(country: OnrampCountry, repository: OnrampRepository) {
-        onrampCountryDetectionViewModel = OnrampCountryDetectionViewModel(
-            country: country,
-            repository: repository,
-            coordinator: self
-        )
+    func openOnrampCountryDetection(country: OnrampCountry, repository: OnrampRepository, dataRepository: OnrampDataRepository) {
+        let coordinator = OnrampCountryDetectionCoordinator(dismissAction: { [weak self] option in
+            switch option {
+            case .none:
+                self?.onrampCountryDetectionCoordinator = nil
+            case .closeOnramp:
+                if #available(iOS 16, *) {
+                    self?.dismiss(with: nil)
+                } else {
+                    // On iOS 15 double dismiss doesn't work
+                    self?.onrampCountryDetectionCoordinator = nil
+
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                        self?.dismiss(with: nil)
+                    }
+                }
+            }
+        })
+
+        coordinator.start(with: .init(country: country, repository: repository, dataRepository: dataRepository))
+        onrampCountryDetectionCoordinator = coordinator
     }
 
     func openOnrampCountrySelector(repository: any OnrampRepository, dataRepository: any OnrampDataRepository) {
@@ -208,19 +223,6 @@ extension SendCoordinator: ExpressApproveRoutable {
 
     func userDidCancel() {
         expressApproveViewModel = nil
-    }
-}
-
-// MARK: - OnrampCountryDetectionRoutable
-
-extension SendCoordinator: OnrampCountryDetectionRoutable {
-    func openChangeCountry() {
-        onrampCountryDetectionViewModel = nil
-        rootViewModel?.openOnrampCountrySelectorView()
-    }
-
-    func dismissConfirmCountryView() {
-        onrampCountryDetectionViewModel = nil
     }
 }
 

--- a/Tangem/Modules/Send/UI/Base/SendCoordinatorView.swift
+++ b/Tangem/Modules/Send/UI/Base/SendCoordinatorView.swift
@@ -53,13 +53,13 @@ struct SendCoordinatorView: CoordinatorView {
                 ExpressApproveView(viewModel: $0)
             }
             .bottomSheet(
-                item: $coordinator.onrampCountryDetectionViewModel,
+                item: $coordinator.onrampCountryDetectionCoordinator,
                 settings: .init(
                     backgroundColor: Colors.Background.tertiary,
                     hidingOption: .nonHideable
                 )
             ) {
-                OnrampCountryDetectionView(viewModel: $0)
+                OnrampCountryDetectionCoordinatorView(coordinator: $0)
             }
             .sheet(item: $coordinator.mailViewModel) {
                 MailView(viewModel: $0)

--- a/Tangem/Modules/Send/UI/Base/SendView/SendViewModel.swift
+++ b/Tangem/Modules/Send/UI/Base/SendView/SendViewModel.swift
@@ -333,8 +333,8 @@ extension SendViewModel: OnrampModelRoutable {
     func openOnrampCountryBottomSheet(country: OnrampCountry) {
         do {
             let builder = try dataBuilder.onrampBuilder()
-            let repository = builder.makeDataForOnrampCountryBottomSheet()
-            coordinator?.openOnrampCountryDetection(country: country, repository: repository)
+            let (repository, dataRepository) = builder.makeDataForOnrampCountryBottomSheet()
+            coordinator?.openOnrampCountryDetection(country: country, repository: repository, dataRepository: dataRepository)
         } catch {
             alert = error.alertBinder
         }
@@ -378,7 +378,7 @@ extension SendViewModel: OnrampSummaryRoutable {
     func openOnrampSettingsView() {
         do {
             let builder = try dataBuilder.onrampBuilder()
-            let repository = builder.makeDataForOnrampCountryBottomSheet()
+            let (repository, _) = builder.makeDataForOnrampCountrySelectorView()
             coordinator?.openOnrampSettings(repository: repository)
         } catch {
             alert = error.alertBinder

--- a/Tangem/Modules/Send/UI/Onramp/OnrampView/OnrampRoutable.swift
+++ b/Tangem/Modules/Send/UI/Onramp/OnrampView/OnrampRoutable.swift
@@ -9,7 +9,7 @@
 import TangemExpress
 
 protocol OnrampRoutable {
-    func openOnrampCountryDetection(country: OnrampCountry, repository: OnrampRepository)
+    func openOnrampCountryDetection(country: OnrampCountry, repository: OnrampRepository, dataRepository: OnrampDataRepository)
     func openOnrampCountrySelector(repository: OnrampRepository, dataRepository: OnrampDataRepository)
     func openOnrampSettings(repository: OnrampRepository)
     func openOnrampCurrencySelector(repository: OnrampRepository, dataRepository: OnrampDataRepository)

--- a/Tangem/Modules/Send/UI/OnrampPaymentMethods/OnrampPaymentMethodsView/OnrampPaymentMethodsView.swift
+++ b/Tangem/Modules/Send/UI/OnrampPaymentMethods/OnrampPaymentMethodsView/OnrampPaymentMethodsView.swift
@@ -22,6 +22,7 @@ struct OnrampPaymentMethodsView: View {
         }
         .background(Colors.Background.primary)
         .navigationTitle(Text(Localization.onrampPayWith))
+        .navigationBarTitleDisplayMode(.inline)
         .alert(item: $viewModel.alert, content: { $0.alert })
     }
 }

--- a/Tangem/Modules/Send/UI/OnrampProviders/OnrampProvidersView/OnrampProvidersView.swift
+++ b/Tangem/Modules/Send/UI/OnrampProviders/OnrampProvidersView/OnrampProvidersView.swift
@@ -28,6 +28,7 @@ struct OnrampProvidersView: View {
             }
         }
         .background(Colors.Background.primary)
+        .navigationBarHidden(true)
     }
 
     private var headerView: some View {

--- a/Tangem/Preview Content/Mocks/Send/SendRoutableMock.swift
+++ b/Tangem/Preview Content/Mocks/Send/SendRoutableMock.swift
@@ -19,7 +19,7 @@ class SendRoutableMock: SendRoutable {
     func openQRScanner(with codeBinding: Binding<String>, networkName: String) {}
     func openFeeCurrency(for walletModel: WalletModel, userWalletModel: UserWalletModel) {}
     func openApproveView(settings: ExpressApproveViewModel.Settings, approveViewModelInput: any ApproveViewModelInput) {}
-    func openOnrampCountryDetection(country: OnrampCountry, repository: any OnrampRepository) {}
+    func openOnrampCountryDetection(country: OnrampCountry, repository: any OnrampRepository, dataRepository: any OnrampDataRepository) {}
     func openOnrampCountrySelector(repository: any OnrampRepository, dataRepository: any OnrampDataRepository) {}
     func openOnrampSettings(repository: any OnrampRepository) {}
     func openOnrampCurrencySelector(repository: any OnrampRepository, dataRepository: any OnrampDataRepository) {}

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -2601,6 +2601,8 @@
 		EF68830E2CF8871500658644 /* OnrampPaymentMethodsFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF68830D2CF8871500658644 /* OnrampPaymentMethodsFilter.swift */; };
 		EF6883122CF8B6C400658644 /* OnrampStatusCompactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF6883112CF8B6C200658644 /* OnrampStatusCompactView.swift */; };
 		EF6883142CF8B8EC00658644 /* OnrampStatusCompactViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF6883132CF8B8EC00658644 /* OnrampStatusCompactViewModel.swift */; };
+		EF6883092CF87DA300658644 /* OnrampCountryDetectionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF6883082CF87DA300658644 /* OnrampCountryDetectionCoordinator.swift */; };
+		EF68830B2CF87DC000658644 /* OnrampCountryDetectionCoordinatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF68830A2CF87DC000658644 /* OnrampCountryDetectionCoordinatorView.swift */; };
 		EF692A482951E7C8001F4B8A /* XCAssets+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF692A462951E7C8001F4B8A /* XCAssets+Generated.swift */; };
 		EF692A492951E7C8001F4B8A /* Localizable+Generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF692A472951E7C8001F4B8A /* Localizable+Generated.swift */; };
 		EF6961652CEE0BDD001EC00A /* OnrampNotificationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF6961642CEE0BD9001EC00A /* OnrampNotificationEvent.swift */; };
@@ -5779,6 +5781,8 @@
 		EF68830D2CF8871500658644 /* OnrampPaymentMethodsFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampPaymentMethodsFilter.swift; sourceTree = "<group>"; };
 		EF6883112CF8B6C200658644 /* OnrampStatusCompactView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampStatusCompactView.swift; sourceTree = "<group>"; };
 		EF6883132CF8B8EC00658644 /* OnrampStatusCompactViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampStatusCompactViewModel.swift; sourceTree = "<group>"; };
+		EF6883082CF87DA300658644 /* OnrampCountryDetectionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampCountryDetectionCoordinator.swift; sourceTree = "<group>"; };
+		EF68830A2CF87DC000658644 /* OnrampCountryDetectionCoordinatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampCountryDetectionCoordinatorView.swift; sourceTree = "<group>"; };
 		EF692A462951E7C8001F4B8A /* XCAssets+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCAssets+Generated.swift"; sourceTree = "<group>"; };
 		EF692A472951E7C8001F4B8A /* Localizable+Generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Localizable+Generated.swift"; sourceTree = "<group>"; };
 		EF6961642CEE0BD9001EC00A /* OnrampNotificationEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampNotificationEvent.swift; sourceTree = "<group>"; };
@@ -15677,6 +15681,8 @@
 		EFD68F2E2CC2D01B00693C97 /* OnrampCountryDetection */ = {
 			isa = PBXGroup;
 			children = (
+				EF68830A2CF87DC000658644 /* OnrampCountryDetectionCoordinatorView.swift */,
+				EF6883082CF87DA300658644 /* OnrampCountryDetectionCoordinator.swift */,
 				EFD68F2F2CC2D02300693C97 /* OnrampCountryDetectionView.swift */,
 				EFD68F312CC2D04400693C97 /* OnrampCountryDetectionViewModel.swift */,
 				EFD68F332CC2D29700693C97 /* OnrampCountryDetectionRoutable.swift */,
@@ -16747,6 +16753,7 @@
 				DAA0559928744E2400E4F7B9 /* MercuryoService.swift in Sources */,
 				B0BE7D952AC2EB580012D9EE /* ExpressAvailabilityProvider.swift in Sources */,
 				DAB5E334297E8CBF00A4E9CF /* AmountRoundingType.swift in Sources */,
+				EF68830B2CF87DC000658644 /* OnrampCountryDetectionCoordinatorView.swift in Sources */,
 				B0C4F77F26F0C0BF0086D815 /* TransitionWithoutOpacity.swift in Sources */,
 				B67E4C152CE01A8600983EA1 /* MarketsTokenDetailsSecurityScoreRatingViewData.swift in Sources */,
 				EF0DD7A32B02B5C00099527D /* ExpressFeeRowData.swift in Sources */,
@@ -18280,6 +18287,7 @@
 				B00307042AF0E1BA00C13BCA /* Analytics+WalletConnectDebugEvent.swift in Sources */,
 				B0431B47291A905A00F84DEF /* RoundedBackgroundModifier.swift in Sources */,
 				DC28917D2CD920FB00F57F59 /* BuyTokenSelectorStrings.swift in Sources */,
+				EF6883092CF87DA300658644 /* OnrampCountryDetectionCoordinator.swift in Sources */,
 				DA10101D2CDA4D7F00EE0D05 /* OnrampCountryView.swift in Sources */,
 				B6FB04EB2B1FF022000BB59E /* StatusBarStyleConfigurator+Environment.swift in Sources */,
 				B6E8BBFB2A2F209B0012E7D3 /* InfinityFrameModifier.swift in Sources */,

--- a/TangemExpress/Models/Onramp/OnrampPreference.swift
+++ b/TangemExpress/Models/Onramp/OnrampPreference.swift
@@ -15,3 +15,9 @@ public struct OnrampPreference: Hashable {
         self.currency = currency
     }
 }
+
+public extension OnrampPreference {
+    var isEmpty: Bool {
+        country == nil && currency == nil
+    }
+}


### PR DESCRIPTION
- Переделана логика на отдельный coordinator `OnrampCountryDetectionCoordinator`, так как не получится открыть `.sheet` поверх `.bottomSheet`. на iOS 15 получаем ошибку, на iOS 16+ закрытие `.bottomSheet` и открытие `.sheet`
- Скрыты `NavigationBar` там где они не нужны
- Так же закрыты все кейсы с тем что country cannot be empty.

https://tangem.atlassian.net/browse/IOS-8603
https://tangem.atlassian.net/browse/IOS-8604
https://tangem.atlassian.net/browse/IOS-8605
https://tangem.atlassian.net/browse/IOS-8619
https://tangem.atlassian.net/browse/IOS-8620