### PR TITLE
IOS-8753 Fix tap gesture handling

### DIFF
--- a/Tangem/UIComponents/ReceiveBottomSheetView/ReceiveBottomSheetView.swift
+++ b/Tangem/UIComponents/ReceiveBottomSheetView/ReceiveBottomSheetView.swift
@@ -43,6 +43,7 @@ struct ReceiveBottomSheetView: View {
                     SUILabel(viewModel.stringForAddress(info.address))
                         .padding(.horizontal, 60)
                         .padding(.top, 20)
+                        .contentShape(Rectangle())
                         .onTapGesture {
                             viewModel.copyToClipboard()
                         }


### PR DESCRIPTION
Фиксит область нажатия на iOS 18, без него не срабатывает жест ниже.