### PR TITLE
IOS-8850 [Onramp] `isTerminated` depends of `ExpressBranch`

### DIFF
--- a/Tangem/App/Models/Express/PendingExpressTransactionStatus.swift
+++ b/Tangem/App/Models/Express/PendingExpressTransactionStatus.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import TangemExpress
 
 enum PendingExpressTransactionStatus: String, Equatable, Codable {
     case created
@@ -75,11 +76,24 @@ enum PendingExpressTransactionStatus: String, Equatable, Codable {
         }
     }
 
-    var isTerminated: Bool {
+    func isTerminated(branch: ExpressBranch) -> Bool {
         switch self {
-        case .done, .refunded, .canceled:
+        case .done,
+             .refunded,
+             .canceled,
+             .failed where branch == .onramp:
             return true
-        case .created, .awaitingDeposit, .confirming, .exchanging, .buying, .sendingToUser, .failed, .verificationRequired, .awaitingHash, .unknown, .paused:
+        case .created,
+             .awaitingDeposit,
+             .confirming,
+             .exchanging,
+             .buying,
+             .sendingToUser,
+             .failed,
+             .verificationRequired,
+             .awaitingHash,
+             .unknown,
+             .paused:
             return false
         }
     }

--- a/Tangem/App/Services/Express/PendingExpressTransactionsManager.swift
+++ b/Tangem/App/Services/Express/PendingExpressTransactionsManager.swift
@@ -116,7 +116,7 @@ class CommonPendingExpressTransactionsManager {
                     let record = pendingTransaction.transactionRecord
 
                     // We have not any sense to update the terminated status
-                    guard !record.transactionStatus.isTerminated else {
+                    guard !record.transactionStatus.isTerminated(branch: .swap) else {
                         transactionsInProgress.append(pendingTransaction)
                         transactionsToSchedule.append(pendingTransaction)
                         continue

--- a/Tangem/App/Services/Onramp/PendingOnrampTransactionManager.swift
+++ b/Tangem/App/Services/Onramp/PendingOnrampTransactionManager.swift
@@ -24,7 +24,7 @@ class CommonPendingOnrampTransactionsManager {
         request: { [weak self] pendingTransaction in
             await self?.request(pendingTransaction: pendingTransaction)
         },
-        shouldStopPolling: { $0.transactionRecord.transactionStatus.isTerminated },
+        shouldStopPolling: { $0.transactionRecord.transactionStatus.isTerminated(branch: .onramp) },
         hasChanges: { $0.transactionRecord.transactionStatus != $1.transactionRecord.transactionStatus },
         pollingInterval: Constants.statusUpdateTimeout
     )

--- a/Tangem/App/Services/PendingTransactionsManager/PendingTransactionsManager.swift
+++ b/Tangem/App/Services/PendingTransactionsManager/PendingTransactionsManager.swift
@@ -12,6 +12,13 @@ import TangemExpress
 enum PendingTransactionType {
     case swap(source: ExpressPendingTransactionRecord.TokenTxInfo, destination: ExpressPendingTransactionRecord.TokenTxInfo)
     case onramp(sourceAmount: Decimal, sourceCurrencySymbol: String, destination: ExpressPendingTransactionRecord.TokenTxInfo)
+
+    var branch: ExpressBranch {
+        switch self {
+        case .swap: .swap
+        case .onramp: .onramp
+        }
+    }
 }
 
 struct PendingTransaction {

--- a/Tangem/App/Utilities/Express/PendingExpressTransactionsConverter.swift
+++ b/Tangem/App/Utilities/Express/PendingExpressTransactionsConverter.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import TangemExpress
 
 struct PendingExpressTransactionsConverter {
     func convertToTokenDetailsPendingTxInfo(_ records: [PendingTransaction], tapAction: @escaping (String) -> Void) -> [PendingExpressTransactionView.Info] {
@@ -68,7 +69,8 @@ struct PendingExpressTransactionsConverter {
                 status: status,
                 currentStatusIndex: currentStatusIndex,
                 currentStatus: pendingTransaction.transactionStatus,
-                lastStatusIndex: statuses.count - 1
+                lastStatusIndex: statuses.count - 1,
+                branch: pendingTransaction.type.branch
             )
         }, currentStatusIndex)
     }
@@ -78,9 +80,10 @@ struct PendingExpressTransactionsConverter {
         status: PendingExpressTransactionStatus,
         currentStatusIndex: Int,
         currentStatus: PendingExpressTransactionStatus,
-        lastStatusIndex: Int
+        lastStatusIndex: Int,
+        branch: ExpressBranch
     ) -> PendingExpressTxStatusRow.StatusRowData {
-        let isFinished = currentStatus.isTerminated
+        let isFinished = currentStatus.isTerminated(branch: branch)
         if isFinished {
             // Always display cross for failed state
             // TODO: Refactor for clarity

--- a/Tangem/Modules/TokenDetails/ExpressBottomSheet/PendingExpressTxStatusBottomSheetViewModel.swift
+++ b/Tangem/Modules/TokenDetails/ExpressBottomSheet/PendingExpressTxStatusBottomSheetViewModel.swift
@@ -219,7 +219,8 @@ class PendingExpressTxStatusBottomSheetViewModel: ObservableObject, Identifiable
                 }
 
                 // We will hide it via separate notification in case of refunded token
-                if pendingTx.transactionStatus.isTerminated, pendingTx.refundedTokenItem == nil {
+                if pendingTx.transactionStatus.isTerminated(branch: pendingTx.type.branch),
+                   pendingTx.refundedTokenItem == nil {
                     viewModel.hidePendingTx(expressTransactionId: pendingTx.expressTransactionId)
                 }
 


### PR DESCRIPTION
в Onramp надо скрывать `.failed`. в Swap по старому