### PR TITLE
IOS-8666 [BalanceCaching] Balance providers

### DIFF
--- a/Tangem/App/Services/BalanceProvider/BalanceProvider.swift
+++ b/Tangem/App/Services/BalanceProvider/BalanceProvider.swift
@@ -1,0 +1,19 @@
+//
+//  TokenBalanceProvider.swift
+//  TangemApp
+//
+//  Created by Sergey Balashov on 24.12.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import Combine
+import TangemFoundation
+
+protocol TokenBalanceProvider {
+    var balanceType: TokenBalanceType { get }
+    var balanceTypePublisher: AnyPublisher<TokenBalanceType, Never> { get }
+
+    var formattedBalanceType: FormattedTokenBalanceType { get }
+    var formattedBalanceTypePublisher: AnyPublisher<FormattedTokenBalanceType, Never> { get }
+}

--- a/Tangem/App/Services/BalanceProvider/FormattedTokenBalanceType.swift
+++ b/Tangem/App/Services/BalanceProvider/FormattedTokenBalanceType.swift
@@ -1,0 +1,80 @@
+//
+//  FormattedTokenBalanceType.swift
+//  TangemApp
+//
+//  Created by Sergey Balashov on 25.12.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - FormattedTokenBalanceType
+
+enum FormattedTokenBalanceType: Hashable {
+    // "Skeleton" or "New animation"
+    case loading(CachedType)
+    // "Cached" or "-"
+    // The date on which the balance would be relevant
+    case failure(CachedType)
+    // All good
+    case loaded(String)
+}
+
+// MARK: - FormattedTokenBalanceType+
+
+extension FormattedTokenBalanceType {
+    var value: String {
+        switch self {
+        case .loading(let cached): cached.value
+        case .failure(let cached): cached.value
+        case .loaded(let value): value
+        }
+    }
+
+    var isLoading: Bool {
+        switch self {
+        case .loading: true
+        default: false
+        }
+    }
+
+    var isFailure: Bool {
+        switch self {
+        case .failure: true
+        default: false
+        }
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension FormattedTokenBalanceType: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .loading(let cached): "Loading cached balance - \(String(describing: cached))"
+        case .failure(let cached): "Failure cached balance - \(String(describing: cached))"
+        case .loaded(let balance): "Loaded balance - \(balance)"
+        }
+    }
+}
+
+// MARK: - Cached
+
+extension FormattedTokenBalanceType {
+    enum CachedType: Hashable {
+        case empty(String)
+        case cache(Cached)
+
+        var value: String {
+            switch self {
+            case .empty(let value): value
+            case .cache(let cached): cached.balance
+            }
+        }
+    }
+
+    struct Cached: Hashable {
+        let balance: String
+        let date: Date
+    }
+}

--- a/Tangem/App/Services/BalanceProvider/FormattedTokenBalanceTypeBuilder.swift
+++ b/Tangem/App/Services/BalanceProvider/FormattedTokenBalanceTypeBuilder.swift
@@ -1,0 +1,34 @@
+//
+//  FormattedTokenBalanceTypeBuilder.swift
+//  TangemApp
+//
+//  Created by Sergey Balashov on 25.12.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+struct FormattedTokenBalanceTypeBuilder {
+    private let format: (Decimal?) -> String
+
+    init(format: @escaping (Decimal?) -> String) {
+        self.format = format
+    }
+
+    func mapToFormattedTokenBalanceType(type: TokenBalanceType) -> FormattedTokenBalanceType {
+        switch type {
+        case .empty:
+            return .loaded(format(.none))
+        case .loading(.some(let cached)):
+            return .loading(.cache(.init(balance: format(cached.balance), date: cached.date)))
+        case .loading(.none):
+            return .loading(.empty(format(.none)))
+        case .failure(.some(let cached)):
+            return .failure(.cache(.init(balance: format(cached.balance), date: cached.date)))
+        case .failure(.none):
+            return .failure(.empty(format(.none)))
+        case .loaded(let balance):
+            return .loaded(format(balance))
+        }
+    }
+}

--- a/Tangem/App/Services/BalanceProvider/Implementation/AvailableBalanceProvider.swift
+++ b/Tangem/App/Services/BalanceProvider/Implementation/AvailableBalanceProvider.swift
@@ -48,14 +48,15 @@ extension AvailableBalanceProvider: TokenBalanceProvider {
 private extension AvailableBalanceProvider {
     func mapToAvailableTokenBalance(state: WalletModel.State) -> TokenBalanceType {
         // The `binance` always has zero balance
-        // TODO: Check it
         if case .binance = walletModel.tokenItem.blockchain {
             return .loaded(0)
         }
 
         switch state {
-        case .created, .noDerivation:
+        case .created:
             return .empty(.noData)
+        case .noDerivation:
+            return .empty(.noDerivation)
         case .loading:
             return .loading(nil)
         case .loaded(let balance):

--- a/Tangem/App/Services/BalanceProvider/Implementation/AvailableBalanceProvider.swift
+++ b/Tangem/App/Services/BalanceProvider/Implementation/AvailableBalanceProvider.swift
@@ -1,0 +1,77 @@
+//
+//  AvailableBalanceProvider.swift
+//  TangemApp
+//
+//  Created by Sergey Balashov on 24.12.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+/// Just simple available to use (e.g. send) balance
+struct AvailableBalanceProvider {
+    private let walletModel: WalletModel
+    private let balanceFormatter = BalanceFormatter()
+
+    init(walletModel: WalletModel) {
+        self.walletModel = walletModel
+    }
+}
+
+// MARK: - TokenBalanceProvider
+
+extension AvailableBalanceProvider: TokenBalanceProvider {
+    var balanceType: TokenBalanceType {
+        mapToAvailableTokenBalance(state: walletModel.state)
+    }
+
+    var balanceTypePublisher: AnyPublisher<TokenBalanceType, Never> {
+        walletModel.statePublisher
+            .map { self.mapToAvailableTokenBalance(state: $0) }
+            .eraseToAnyPublisher()
+    }
+
+    var formattedBalanceType: FormattedTokenBalanceType {
+        mapToFormattedTokenBalanceType(type: balanceType)
+    }
+
+    var formattedBalanceTypePublisher: AnyPublisher<FormattedTokenBalanceType, Never> {
+        balanceTypePublisher
+            .map { self.mapToFormattedTokenBalanceType(type: $0) }
+            .eraseToAnyPublisher()
+    }
+}
+
+// MARK: - Private
+
+private extension AvailableBalanceProvider {
+    func mapToAvailableTokenBalance(state: WalletModel.State) -> TokenBalanceType {
+        // The `binance` always has zero balance
+        // TODO: Check it
+        if case .binance = walletModel.tokenItem.blockchain {
+            return .loaded(0)
+        }
+
+        switch state {
+        case .created, .noDerivation:
+            return .empty(.noData)
+        case .loading:
+            return .loading(nil)
+        case .loaded(let balance):
+            return .loaded(balance)
+        case .noAccount:
+            return .noAccount
+        case .failed:
+            return .failure(nil)
+        }
+    }
+
+    func mapToFormattedTokenBalanceType(type: TokenBalanceType) -> FormattedTokenBalanceType {
+        let builder = FormattedTokenBalanceTypeBuilder(format: { value in
+            balanceFormatter.formatCryptoBalance(value, currencyCode: walletModel.tokenItem.currencySymbol)
+        })
+
+        return builder.mapToFormattedTokenBalanceType(type: type)
+    }
+}

--- a/Tangem/App/Services/BalanceProvider/Implementation/CombineBalanceProvider.swift
+++ b/Tangem/App/Services/BalanceProvider/Implementation/CombineBalanceProvider.swift
@@ -1,0 +1,92 @@
+//
+//  CombineBalanceProvider.swift
+//  TangemApp
+//
+//  Created by Sergey Balashov on 24.12.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Combine
+import TangemFoundation
+import TangemStaking
+
+/// Total crypto balance (available+staking)
+struct CombineBalanceProvider {
+    private let walletModel: WalletModel
+    private let availableBalanceProvider: TokenBalanceProvider
+    private let stakingBalanceProvider: TokenBalanceProvider
+
+    private let balanceFormatter = BalanceFormatter()
+
+    init(walletModel: WalletModel, availableBalanceProvider: TokenBalanceProvider, stakingBalanceProvider: TokenBalanceProvider) {
+        self.walletModel = walletModel
+        self.availableBalanceProvider = availableBalanceProvider
+        self.stakingBalanceProvider = stakingBalanceProvider
+    }
+}
+
+// MARK: - TokenBalanceProvider
+
+extension CombineBalanceProvider: TokenBalanceProvider {
+    var balanceType: TokenBalanceType {
+        mapToAvailableTokenBalance(
+            available: availableBalanceProvider.balanceType,
+            staking: stakingBalanceProvider.balanceType
+        )
+    }
+
+    var balanceTypePublisher: AnyPublisher<TokenBalanceType, Never> {
+        Publishers.CombineLatest(
+            availableBalanceProvider.balanceTypePublisher,
+            stakingBalanceProvider.balanceTypePublisher
+        )
+        .map { self.mapToAvailableTokenBalance(available: $0, staking: $1) }
+        .eraseToAnyPublisher()
+    }
+
+    var formattedBalanceType: FormattedTokenBalanceType {
+        mapToFormattedTokenBalanceType(type: balanceType)
+    }
+
+    var formattedBalanceTypePublisher: AnyPublisher<FormattedTokenBalanceType, Never> {
+        balanceTypePublisher
+            .map { self.mapToFormattedTokenBalanceType(type: $0) }
+            .eraseToAnyPublisher()
+    }
+}
+
+// MARK: - Private
+
+private extension CombineBalanceProvider {
+    func mapToAvailableTokenBalance(available: TokenBalanceType, staking: TokenBalanceType) -> TokenBalanceType {
+        switch (available, staking) {
+        // There is no available balance -> no balance
+        case (.empty, _):
+            return .empty(.noData)
+
+        // There is one of them is loading -> loading
+        case (.loading, _), (_, .loading):
+            return .loading(nil)
+
+        // There is only available -> show only available
+        case (.loaded(let balance), .empty):
+            return .loaded(balance)
+
+        // There is one of them is failure -> show error
+        case (.failure, _), (_, .failure):
+            return .failure(nil)
+
+        // There is both is loaded -> show sum
+        case (.loaded(let available), .loaded(let staking)):
+            return .loaded(available + staking)
+        }
+    }
+
+    func mapToFormattedTokenBalanceType(type: TokenBalanceType) -> FormattedTokenBalanceType {
+        let builder = FormattedTokenBalanceTypeBuilder(format: { value in
+            balanceFormatter.formatCryptoBalance(value, currencyCode: walletModel.tokenItem.currencySymbol)
+        })
+
+        return builder.mapToFormattedTokenBalanceType(type: type)
+    }
+}

--- a/Tangem/App/Services/BalanceProvider/Implementation/FiatBalanceProvider.swift
+++ b/Tangem/App/Services/BalanceProvider/Implementation/FiatBalanceProvider.swift
@@ -1,0 +1,96 @@
+//
+//  FiatBalanceProvider.swift
+//  TangemApp
+//
+//  Created by Sergey Balashov on 24.12.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Combine
+import TangemFoundation
+import TangemStaking
+
+struct FiatBalanceProvider {
+    private let walletModel: WalletModel
+    private let cryptoBalanceProvider: TokenBalanceProvider
+    private let balanceFormatter = BalanceFormatter()
+
+    init(walletModel: WalletModel, cryptoBalanceProvider: TokenBalanceProvider) {
+        self.walletModel = walletModel
+        self.cryptoBalanceProvider = cryptoBalanceProvider
+    }
+}
+
+// MARK: - TokenBalanceProvider
+
+extension FiatBalanceProvider: TokenBalanceProvider {
+    var balanceType: TokenBalanceType {
+        mapToTokenBalance(rate: walletModel.rate, balanceType: cryptoBalanceProvider.balanceType)
+    }
+
+    var balanceTypePublisher: AnyPublisher<TokenBalanceType, Never> {
+        Publishers.CombineLatest(
+            // Listen if rate was loaded after main balance
+            walletModel.ratePublisher.removeDuplicates(),
+            cryptoBalanceProvider.balanceTypePublisher.removeDuplicates()
+        )
+        .map { self.mapToTokenBalance(rate: $0, balanceType: $1) }
+        .eraseToAnyPublisher()
+    }
+
+    var formattedBalanceType: FormattedTokenBalanceType {
+        mapToFormattedTokenBalanceType(type: balanceType)
+    }
+
+    var formattedBalanceTypePublisher: AnyPublisher<FormattedTokenBalanceType, Never> {
+        balanceTypePublisher
+            .map { self.mapToFormattedTokenBalanceType(type: $0) }
+            .eraseToAnyPublisher()
+    }
+}
+
+// MARK: - Private
+
+extension FiatBalanceProvider {
+    func mapToTokenBalance(rate: LoadingResult<Decimal?, Never>, balanceType: TokenBalanceType) -> TokenBalanceType {
+        switch (rate, balanceType) {
+        // There is no rate because it's custom token
+        case (.success(.none), _) where walletModel.isCustom:
+            return .empty(.custom)
+
+        // There is no crypto value to convert
+        case (_, .empty(let reason)):
+            return .empty(reason)
+
+        // There is no rate
+        case (.success(.none), _):
+            return .empty(.noData)
+
+        // There is no crypto value because there was an error
+        case (_, .failure(.none)):
+            return .failure(.none)
+
+        // There is one value is loading
+        case (_, .loading), (.loading, _):
+            return .loading(nil) // TODO: Add cache
+
+        // Has some rate but only cached value
+        case (.success(.some(let rate)), .failure(.some(let cached))):
+            let fiat = cached.balance * rate
+            return .failure(.init(balance: fiat, date: cached.date))
+
+        // Has some rate and some value
+        case (.success(.some(let rate)), .loaded(let value)):
+            let fiat = value * rate
+            return .loaded(fiat)
+        }
+    }
+
+    func mapToFormattedTokenBalanceType(type: TokenBalanceType) -> FormattedTokenBalanceType {
+        let builder = FormattedTokenBalanceTypeBuilder(format: { value in
+            balanceFormatter.formatFiatBalance(value)
+        })
+
+        return builder.mapToFormattedTokenBalanceType(type: type)
+    }
+}

--- a/Tangem/App/Services/BalanceProvider/Implementation/StakingBalanceProvider.swift
+++ b/Tangem/App/Services/BalanceProvider/Implementation/StakingBalanceProvider.swift
@@ -57,7 +57,8 @@ extension StakingBalanceProvider {
         case .availableToStake:
             return .loaded(.zero)
         case .staked(let balances):
-            return .loaded(balances.balances.blocked().sum())
+            let balance = balances.balances.blocked().sum()
+            return .loaded(balance)
         }
     }
 

--- a/Tangem/App/Services/BalanceProvider/Implementation/StakingBalanceProvider.swift
+++ b/Tangem/App/Services/BalanceProvider/Implementation/StakingBalanceProvider.swift
@@ -1,0 +1,71 @@
+//
+//  StakingBalanceProvider.swift
+//  TangemApp
+//
+//  Created by Sergey Balashov on 25.12.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+import Combine
+import TangemStaking
+
+struct StakingBalanceProvider {
+    private let walletModel: WalletModel
+    private let balanceFormatter = BalanceFormatter()
+
+    init(walletModel: WalletModel) {
+        self.walletModel = walletModel
+    }
+}
+
+// MARK: - TokenBalanceProvider
+
+extension StakingBalanceProvider: TokenBalanceProvider {
+    var balanceType: TokenBalanceType {
+        mapToTokenBalance(state: walletModel.stakingManagerState)
+    }
+
+    var balanceTypePublisher: AnyPublisher<TokenBalanceType, Never> {
+        walletModel.stakingManagerStatePublisher
+            .map { self.mapToTokenBalance(state: $0) }
+            .eraseToAnyPublisher()
+    }
+
+    var formattedBalanceType: FormattedTokenBalanceType {
+        mapToFormattedTokenBalanceType(type: balanceType)
+    }
+
+    var formattedBalanceTypePublisher: AnyPublisher<FormattedTokenBalanceType, Never> {
+        balanceTypePublisher
+            .map { self.mapToFormattedTokenBalanceType(type: $0) }
+            .eraseToAnyPublisher()
+    }
+}
+
+// MARK: - Private
+
+extension StakingBalanceProvider {
+    func mapToTokenBalance(state: StakingManagerState) -> TokenBalanceType {
+        switch state {
+        case .loading:
+            return .loading(.none)
+        case .notEnabled, .temporaryUnavailable:
+            return .empty(.noData)
+        case .loadingError:
+            return .failure(.none)
+        case .availableToStake:
+            return .loaded(.zero)
+        case .staked(let balances):
+            return .loaded(balances.balances.blocked().sum())
+        }
+    }
+
+    func mapToFormattedTokenBalanceType(type: TokenBalanceType) -> FormattedTokenBalanceType {
+        let builder = FormattedTokenBalanceTypeBuilder(format: { value in
+            balanceFormatter.formatCryptoBalance(value, currencyCode: walletModel.tokenItem.currencySymbol)
+        })
+
+        return builder.mapToFormattedTokenBalanceType(type: type)
+    }
+}

--- a/Tangem/App/Services/BalanceProvider/TokenBalanceType.swift
+++ b/Tangem/App/Services/BalanceProvider/TokenBalanceType.swift
@@ -57,9 +57,9 @@ extension TokenBalanceType: CustomStringConvertible {
     var description: String {
         switch self {
         case .empty(let reason): "Empty \(reason)"
-        case .loading(let cached): "Loading cached - \(String(describing: cached))"
-        case .failure(let cached): "Failure cached - \(String(describing: cached))"
-        case .loaded(let balance): "Loaded - \(balance)"
+        case .loading(let cached): "Loading cached: \(String(describing: cached))"
+        case .failure(let cached): "Failure cached: \(String(describing: cached))"
+        case .loaded(let balance): "Loaded: \(balance)"
         }
     }
 }
@@ -68,6 +68,7 @@ extension TokenBalanceType: CustomStringConvertible {
 
 extension TokenBalanceType {
     enum EmptyReason: Hashable {
+        case noDerivation
         case noData
         case custom
     }

--- a/Tangem/App/Services/BalanceProvider/TokenBalanceType.swift
+++ b/Tangem/App/Services/BalanceProvider/TokenBalanceType.swift
@@ -1,0 +1,79 @@
+//
+//  TokenBalanceType.swift
+//  TangemApp
+//
+//  Created by Sergey Balashov on 25.12.2024.
+//  Copyright © 2024 Tangem AG. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - TokenBalanceType
+
+enum TokenBalanceType: Hashable {
+    // No derivation / Don't start loading yet
+    case empty(EmptyReason)
+    // "Skeleton" or "New animation"
+    case loading(Cached?)
+    // "Cached" or "-"
+    // The date on which the balance would be relevant
+    case failure(Cached?)
+    // All good
+    case loaded(Decimal)
+}
+
+// MARK: - TokenBalanceType+
+
+extension TokenBalanceType {
+    static let noAccount = TokenBalanceType.loaded(0)
+
+    var value: Decimal? {
+        switch self {
+        case .empty: nil
+        case .loading(let cached): cached?.balance
+        case .failure(let cached): cached?.balance
+        case .loaded(let value): value
+        }
+    }
+
+    var isLoading: Bool {
+        switch self {
+        case .loading: true
+        default: false
+        }
+    }
+
+    var isFailure: Bool {
+        switch self {
+        case .failure: true
+        default: false
+        }
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension TokenBalanceType: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .empty(let reason): "Empty \(reason)"
+        case .loading(let cached): "Loading cached - \(String(describing: cached))"
+        case .failure(let cached): "Failure cached - \(String(describing: cached))"
+        case .loaded(let balance): "Loaded - \(balance)"
+        }
+    }
+}
+
+// MARK: - Models
+
+extension TokenBalanceType {
+    enum EmptyReason: Hashable {
+        case noData
+        case custom
+    }
+
+    struct Cached: Hashable {
+        let balance: Decimal
+        let date: Date
+    }
+}

--- a/Tangem/App/Services/NotificationManagers/SingleTokenNotifications/SingleTokenNotificationManager.swift
+++ b/Tangem/App/Services/NotificationManagers/SingleTokenNotifications/SingleTokenNotificationManager.swift
@@ -56,7 +56,7 @@ final class SingleTokenNotificationManager {
                 self?.setupNoAccountNotification(with: message)
             case .loading, .created:
                 break
-            case .idle, .noDerivation:
+            case .loaded, .noDerivation:
                 guard stakingState != .loading else { return } // fixes issue with staking notification animated re-appear
                 self?.setupLoadedStateNotifications()
             }

--- a/Tangem/App/Services/TotalBalanceProvider/SingleTokenTotalBalanceProvider.swift
+++ b/Tangem/App/Services/TotalBalanceProvider/SingleTokenTotalBalanceProvider.swift
@@ -44,7 +44,7 @@ class SingleTokenTotalBalanceProvider {
                             allTokensBalancesIncluded: true
                         ))
                     )
-                case .idle, .noAccount:
+                case .loaded, .noAccount:
                     balanceProvider.totalBalanceSubject.send(
                         .loaded(.init(
                             balance: balanceProvider.isFiat ? walletModel.fiatValue : walletModel.balanceValue,

--- a/Tangem/App/Services/TotalBalanceProvider/TotalBalanceProvider.swift
+++ b/Tangem/App/Services/TotalBalanceProvider/TotalBalanceProvider.swift
@@ -164,7 +164,7 @@ private extension TotalBalanceProvider {
                 allTokensBalancesIncluded = false
             }
 
-            if token.rateFormatted.isEmpty {
+            if token.rate.value == nil {
                 // Just show warning for custom tokens
                 if token.isCustom {
                     hasError = true

--- a/Tangem/App/Services/UserTokensReordering/UserTokensReorderingLogger.swift
+++ b/Tangem/App/Services/UserTokensReordering/UserTokensReorderingLogger.swift
@@ -67,8 +67,8 @@ struct UserTokensReorderingLogger {
         switch state {
         case .created:
             return "created"
-        case .idle:
-            return "idle"
+        case .loaded:
+            return "loaded"
         case .loading:
             return "loading"
         case .noAccount:

--- a/Tangem/App/ViewModels/WalletModel/WalletModel+Balance.swift
+++ b/Tangem/App/ViewModels/WalletModel/WalletModel+Balance.swift
@@ -172,4 +172,18 @@ extension WalletModel {
     struct BalanceFormatted: Hashable {
         let crypto, fiat: String
     }
+
+    // Don't use yet
+    // TODO: https://tangem.atlassian.net/browse/IOS-8906
+    enum Rate: Hashable {
+        case cached(TokenBalanceType.Cached)
+        case actual(Decimal)
+
+        var value: Decimal {
+            switch self {
+            case .cached(let value): value.balance
+            case .actual(let value): value
+            }
+        }
+    }
 }

--- a/Tangem/App/ViewModels/WalletModel/WalletModel+State.swift
+++ b/Tangem/App/ViewModels/WalletModel/WalletModel+State.swift
@@ -11,7 +11,7 @@ import Foundation
 extension WalletModel {
     enum State: Hashable {
         case created
-        case idle
+        case loaded(Decimal)
         case loading
         case noAccount(message: String, amountToCreate: Decimal)
         case failed(error: String)
@@ -28,7 +28,7 @@ extension WalletModel {
 
         var isSuccessfullyLoaded: Bool {
             switch self {
-            case .idle, .noAccount:
+            case .loaded, .noAccount:
                 return true
             default:
                 return false
@@ -77,7 +77,7 @@ extension WalletModel {
             switch self {
             case .failed, .loading, .created, .noDerivation:
                 return false
-            case .noAccount, .idle:
+            case .noAccount, .loaded:
                 return true
             }
         }

--- a/Tangem/App/ViewModels/WalletModel/WalletModel.swift
+++ b/Tangem/App/ViewModels/WalletModel/WalletModel.swift
@@ -42,14 +42,12 @@ class WalletModel {
         _state.eraseToAnyPublisher()
     }
 
-    var rate: LoadingResult<Decimal?, Never> {
+    var rate: LoadingResult<Rate?, Never> {
         _rate.value
     }
 
-    var ratePublisher: AnyPublisher<LoadingResult<Decimal?, Never>, Never> {
-        _rate
-            .delay(for: .seconds(10), scheduler: DispatchQueue.global())
-            .eraseToAnyPublisher()
+    var ratePublisher: AnyPublisher<LoadingResult<Rate?, Never>, Never> {
+        _rate.eraseToAnyPublisher()
     }
 
     /// Listen tx history changes
@@ -219,7 +217,7 @@ class WalletModel {
     private var updateQueue = DispatchQueue(label: "walletModel_update_queue")
     private var _walletDidChangePublisher: CurrentValueSubject<State, Never> = .init(.created)
     private var _state: CurrentValueSubject<State, Never> = .init(.created)
-    private var _rate: CurrentValueSubject<LoadingResult<Decimal?, Never>, Never> = .init(.loading)
+    private var _rate: CurrentValueSubject<LoadingResult<Rate?, Never>, Never> = .init(.loading)
     private var _localPendingTransactionSubject: PassthroughSubject<Void, Never> = .init()
 
     let converter = BalanceConverter()
@@ -266,7 +264,7 @@ class WalletModel {
             }
             .removeDuplicates()
             .sink { [weak self] rate in
-                self?._rate.send(.success(rate))
+                self?._rate.send(.success(rate.map { .actual($0) }))
             }
             .store(in: &bag)
     }

--- a/Tangem/Common/UI/ExpressCurrencyView/ExpressCurrencyViewModel.swift
+++ b/Tangem/Common/UI/ExpressCurrencyView/ExpressCurrencyViewModel.swift
@@ -62,7 +62,7 @@ final class ExpressCurrencyViewModel: ObservableObject, Identifiable {
                 switch state {
                 case .created, .loading:
                     self?.balanceState = .loading
-                case .idle:
+                case .loaded:
                     let formatted = wallet.balanceValue.map { BalanceFormatter().formatDecimal($0) }
                     self?.balanceState = .formatted(formatted ?? BalanceFormatter.defaultEmptyBalanceString)
                 case .noAccount, .failed, .noDerivation:

--- a/Tangem/Modules/Main/MainHeaderView/MainHeaderSubtitleProvider/SingleWalletMainHeaderSubtitleProvider.swift
+++ b/Tangem/Modules/Main/MainHeaderView/MainHeaderSubtitleProvider/SingleWalletMainHeaderSubtitleProvider.swift
@@ -64,7 +64,7 @@ class SingleWalletMainHeaderSubtitleProvider: MainHeaderSubtitleProvider {
                 switch newState {
                 case .failed:
                     formatErrorMessage()
-                case .idle, .noAccount:
+                case .loaded, .noAccount:
                     formatBalanceMessage()
                 case .created, .loading, .noDerivation:
                     break

--- a/Tangem/Modules/Onboarding/BaseModels/OnboardingTopupViewModel.swift
+++ b/Tangem/Modules/Onboarding/BaseModels/OnboardingTopupViewModel.swift
@@ -65,7 +65,7 @@ class OnboardingTopupViewModel<Step: OnboardingStep, Coordinator: OnboardingTopu
                 case .noAccount(let message, _):
                     AppLog.shared.debug(message)
                     fallthrough
-                case .idle:
+                case .loaded:
                     if shouldGoToNextStep,
                        !walletModel.isEmptyIncludingPendingIncomingTxs,
                        !walletModel.isZeroAmount {

--- a/Tangem/Modules/OrganizeTokens/OrganizeTokensListFactory.swift
+++ b/Tangem/Modules/OrganizeTokens/OrganizeTokensListFactory.swift
@@ -149,7 +149,7 @@ struct OrganizeTokensListFactory {
     }
 
     private func fiatBalance(for walletModel: WalletModel) -> LoadableTextView.State {
-        guard !walletModel.rateFormatted.isEmpty else { return .noData }
+        guard walletModel.rate.value != nil else { return .noData }
 
         let state = TokenItemViewState(walletModel: walletModel)
         switch state {

--- a/Tangem/Modules/StakingDetails/StakingDetailsViewModel.swift
+++ b/Tangem/Modules/StakingDetails/StakingDetailsViewModel.swift
@@ -115,7 +115,7 @@ private extension StakingDetailsViewModel {
         switch state {
         case .created, .loading:
             break
-        case .idle, .failed, .noAccount, .noDerivation:
+        case .loaded, .failed, .noAccount, .noDerivation:
             let hasBalance = (walletModel.availableBalance.crypto ?? 0) > 0
             actionButtonDisabled = !hasBalance
         }

--- a/Tangem/Modules/TokenDetails/TokenDetailsViewModel.swift
+++ b/Tangem/Modules/TokenDetails/TokenDetailsViewModel.swift
@@ -259,7 +259,7 @@ private extension TokenDetailsViewModel {
         switch walletModelState {
         case .created, .loading:
             balances.send(.loading)
-        case .idle, .noAccount:
+        case .loaded, .noAccount:
             balances.send(.loaded(.init(all: walletModel.allBalanceFormatted, available: walletModel.availableBalanceFormatted)))
         case .failed(let message):
             balances.send(.failedToLoad(error: message))

--- a/Tangem/UIComponents/TokenItemView/TokenItemViewState.swift
+++ b/Tangem/UIComponents/TokenItemView/TokenItemViewState.swift
@@ -28,7 +28,7 @@ enum TokenItemViewState {
             self = .noDerivation
         case .loading:
             self = .loading
-        case .idle:
+        case .loaded:
             // respect walletModel.isLoading and walletModel.isSuccessfullyLoaded, just show "–"
             switch walletModel.stakingManagerState {
             case .loadingError, .availableToStake, .staked, .notEnabled, .temporaryUnavailable:

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -14275,9 +14275,9 @@
 			isa = PBXGroup;
 			children = (
 				EF42D77B2D1D65D90065AFD1 /* AvailableBalanceProvider.swift */,
+				EF42D77E2D1D65D90065AFD1 /* StakingBalanceProvider.swift */,
 				EF42D77C2D1D65D90065AFD1 /* CombineBalanceProvider.swift */,
 				EF42D77D2D1D65D90065AFD1 /* FiatBalanceProvider.swift */,
-				EF42D77E2D1D65D90065AFD1 /* StakingBalanceProvider.swift */,
 			);
 			path = Implementation;
 			sourceTree = "<group>";

--- a/TangemApp.xcodeproj/project.pbxproj
+++ b/TangemApp.xcodeproj/project.pbxproj
@@ -2566,6 +2566,14 @@
 		EF40C1112CF5EA2D007EF710 /* ExpressProvidersList.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF40C1102CF5EA2D007EF710 /* ExpressProvidersList.swift */; };
 		EF40C1122CF5EE1A007EF710 /* Sequence+.swift in Sources */ = {isa = PBXBuildFile; fileRef = B674D6D82A96AC8800172491 /* Sequence+.swift */; };
 		EF41937A2C2DE0CB006A30A5 /* SendAmount.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4193792C2DE0CB006A30A5 /* SendAmount.swift */; };
+		EF42D7852D1D65D90065AFD1 /* CombineBalanceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF42D77C2D1D65D90065AFD1 /* CombineBalanceProvider.swift */; };
+		EF42D7862D1D65D90065AFD1 /* FiatBalanceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF42D77D2D1D65D90065AFD1 /* FiatBalanceProvider.swift */; };
+		EF42D7872D1D65D90065AFD1 /* TokenBalanceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF42D7832D1D65D90065AFD1 /* TokenBalanceType.swift */; };
+		EF42D7882D1D65D90065AFD1 /* StakingBalanceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF42D77E2D1D65D90065AFD1 /* StakingBalanceProvider.swift */; };
+		EF42D7892D1D65D90065AFD1 /* AvailableBalanceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF42D77B2D1D65D90065AFD1 /* AvailableBalanceProvider.swift */; };
+		EF42D78A2D1D65D90065AFD1 /* BalanceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF42D7802D1D65D90065AFD1 /* BalanceProvider.swift */; };
+		EF42D78B2D1D65D90065AFD1 /* FormattedTokenBalanceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF42D7812D1D65D90065AFD1 /* FormattedTokenBalanceType.swift */; };
+		EF42D78C2D1D65D90065AFD1 /* FormattedTokenBalanceTypeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF42D7822D1D65D90065AFD1 /* FormattedTokenBalanceTypeBuilder.swift */; };
 		EF435A052C2B124A00B627EB /* SendDestinationInputOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF435A042C2B124A00B627EB /* SendDestinationInputOutput.swift */; };
 		EF435A072C2B1F2300B627EB /* SendDestinationTransactionHistoryProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF435A062C2B1F2300B627EB /* SendDestinationTransactionHistoryProvider.swift */; };
 		EF4535372976C1D80030639A /* FixedSpacer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4535362976C1D80030639A /* FixedSpacer.swift */; };
@@ -5732,6 +5740,14 @@
 		EF407E6D2C04D81100366733 /* Period.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Period.swift; sourceTree = "<group>"; };
 		EF40C1102CF5EA2D007EF710 /* ExpressProvidersList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpressProvidersList.swift; sourceTree = "<group>"; };
 		EF4193792C2DE0CB006A30A5 /* SendAmount.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendAmount.swift; sourceTree = "<group>"; };
+		EF42D77B2D1D65D90065AFD1 /* AvailableBalanceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailableBalanceProvider.swift; sourceTree = "<group>"; };
+		EF42D77C2D1D65D90065AFD1 /* CombineBalanceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineBalanceProvider.swift; sourceTree = "<group>"; };
+		EF42D77D2D1D65D90065AFD1 /* FiatBalanceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FiatBalanceProvider.swift; sourceTree = "<group>"; };
+		EF42D77E2D1D65D90065AFD1 /* StakingBalanceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StakingBalanceProvider.swift; sourceTree = "<group>"; };
+		EF42D7802D1D65D90065AFD1 /* BalanceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceProvider.swift; sourceTree = "<group>"; };
+		EF42D7812D1D65D90065AFD1 /* FormattedTokenBalanceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattedTokenBalanceType.swift; sourceTree = "<group>"; };
+		EF42D7822D1D65D90065AFD1 /* FormattedTokenBalanceTypeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattedTokenBalanceTypeBuilder.swift; sourceTree = "<group>"; };
+		EF42D7832D1D65D90065AFD1 /* TokenBalanceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenBalanceType.swift; sourceTree = "<group>"; };
 		EF435A042C2B124A00B627EB /* SendDestinationInputOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendDestinationInputOutput.swift; sourceTree = "<group>"; };
 		EF435A062C2B1F2300B627EB /* SendDestinationTransactionHistoryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendDestinationTransactionHistoryProvider.swift; sourceTree = "<group>"; };
 		EF4535362976C1D80030639A /* FixedSpacer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedSpacer.swift; sourceTree = "<group>"; };
@@ -12768,6 +12784,7 @@
 		DC0A57DA2822A4DC0031BECC /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				EF42D7842D1D65D90065AFD1 /* BalanceProvider */,
 				DA76BF502CEF966300199317 /* PendingTransactionsManager */,
 				EF2561102CC6A8E000D3C16A /* Onramp */,
 				DA64DAC82C08BE71000CBC1E /* UserWalletNameIndexationHelper */,
@@ -14252,6 +14269,29 @@
 				EF407E612C04D67400366733 /* StakeKitMapper.swift */,
 			);
 			path = StakeKitMapper;
+			sourceTree = "<group>";
+		};
+		EF42D77F2D1D65D90065AFD1 /* Implementation */ = {
+			isa = PBXGroup;
+			children = (
+				EF42D77B2D1D65D90065AFD1 /* AvailableBalanceProvider.swift */,
+				EF42D77C2D1D65D90065AFD1 /* CombineBalanceProvider.swift */,
+				EF42D77D2D1D65D90065AFD1 /* FiatBalanceProvider.swift */,
+				EF42D77E2D1D65D90065AFD1 /* StakingBalanceProvider.swift */,
+			);
+			path = Implementation;
+			sourceTree = "<group>";
+		};
+		EF42D7842D1D65D90065AFD1 /* BalanceProvider */ = {
+			isa = PBXGroup;
+			children = (
+				EF42D7802D1D65D90065AFD1 /* BalanceProvider.swift */,
+				EF42D7812D1D65D90065AFD1 /* FormattedTokenBalanceType.swift */,
+				EF42D7822D1D65D90065AFD1 /* FormattedTokenBalanceTypeBuilder.swift */,
+				EF42D7832D1D65D90065AFD1 /* TokenBalanceType.swift */,
+				EF42D77F2D1D65D90065AFD1 /* Implementation */,
+			);
+			path = BalanceProvider;
 			sourceTree = "<group>";
 		};
 		EF46620F2924DEEE00346B6C /* DefaultListViews */ = {
@@ -18450,6 +18490,14 @@
 				EF48E6C42B02273800FE0072 /* ExpressTokenItemViewModel.swift in Sources */,
 				DC3DCADB2A40AACF00F72554 /* DemoWalletModelsFactory.swift in Sources */,
 				B69E7FC82B220C3400B78D9A /* Dictionary+.swift in Sources */,
+				EF42D7852D1D65D90065AFD1 /* CombineBalanceProvider.swift in Sources */,
+				EF42D7862D1D65D90065AFD1 /* FiatBalanceProvider.swift in Sources */,
+				EF42D7872D1D65D90065AFD1 /* TokenBalanceType.swift in Sources */,
+				EF42D7882D1D65D90065AFD1 /* StakingBalanceProvider.swift in Sources */,
+				EF42D7892D1D65D90065AFD1 /* AvailableBalanceProvider.swift in Sources */,
+				EF42D78A2D1D65D90065AFD1 /* BalanceProvider.swift in Sources */,
+				EF42D78B2D1D65D90065AFD1 /* FormattedTokenBalanceType.swift in Sources */,
+				EF42D78C2D1D65D90065AFD1 /* FormattedTokenBalanceTypeBuilder.swift in Sources */,
 				EFB23F362CBE84F5005A6719 /* OnrampAmountViewModel.swift in Sources */,
 				DC51187C2860B728004FB954 /* AppCoordinatorView.swift in Sources */,
 				B0F62C5025DE4EC9005C8BA0 /* MailView.swift in Sources */,


### PR DESCRIPTION
1 / 3 MR. Пока просто провайдеры, которые будут использовать `Cache` и показывать нужный стейт

В рамках кэширирвоания балансов и желания собрать все логику балансов отдельно и прозрачно, сделал несколько провайдеров
- `AvailableBalanceProvider` баланс BSDK
- `StakingBalanceProvider` баланс стейкинга
- `CombineBalanceProvider`  баланс который объединяет  `Available` и `Staking` и покаывает `Total`
- `FiatBalanceProvider` это обертка над любым `crypto` баланс провайдером что бы использовать `WalletModel.rate` и выдавать нужный state
