### PR TITLE
IOS-8937 Update EstimationFeeAddress for LTC

### DIFF
--- a/BlockchainSdk/Common/Factories/EstimationFeeAddressFactory.swift
+++ b/BlockchainSdk/Common/Factories/EstimationFeeAddressFactory.swift
@@ -42,7 +42,7 @@ struct EstimationFeeAddressFactory {
         case .bitcoin:
             return "bc1qkrc5kmpq546wr2xk0errg58yw9jjq7thvhdk5k"
         case .litecoin:
-            return "MSqjXH6toL4kHqsRo3mWaWMkhmiH9GQxLR"
+            return "LeAXZ4WKNy8zeybFkD6scFpBSmCPmENUEW"
         case .bitcoinCash:
             return "bitcoincash:qrn96yyxa93t6sqmehvls6746qafkcsuku6zmd9460"
         case .dogecoin:


### PR DESCRIPTION
Было `MSqjXH6toL4kHqsRo3mWaWMkhmiH9GQxLR` - `.p2sh` with size 23
Стало `LeAXZ4WKNy8zeybFkD6scFpBSmCPmENUEW` - `.p2pkh` with size 25