### PR TITLE
IOS-8999 BitrockExternalLinkProvider baseExplorerUrl fixed for mainnet

### DIFF
--- a/BlockchainSdk/Blockchains/Ethereum/OtherChains/BitrockExternalLinkProvider.swift
+++ b/BlockchainSdk/Blockchains/Ethereum/OtherChains/BitrockExternalLinkProvider.swift
@@ -14,7 +14,7 @@ struct BitrockExternalLinkProvider: ExternalLinkProvider {
     init(isTestnet: Bool) {
         baseExplorerUrl = isTestnet
             ? "https://testnetscan.bit-rock.io"
-            : "https://scan.bit-rock.io"
+            : "https://explorer.bit-rock.io"
     }
 
     func url(address: String, contractAddress: String?) -> URL? {


### PR DESCRIPTION
В пулл реквесте с добавлением Bitrock'a допустил ошибку в урле эксплорера.