### PR TITLE
IOS-9000 Field "name" now takes coin name instead of network name for saveUserWalletTokens API target.

### DIFF
--- a/Tangem/App/Services/TokenItemsRepository/UserTokenListConverter.swift
+++ b/Tangem/App/Services/TokenItemsRepository/UserTokenListConverter.swift
@@ -26,11 +26,12 @@ struct UserTokenListConverter {
             .compactMap { entry in
                 let network = entry.blockchainNetwork
                 let id = entry.isToken ? entry.id : network.blockchain.coinId
+                let name = entry.isToken ? entry.name : network.blockchain.coinDisplayName
 
                 return UserTokenList.Token(
                     id: id,
                     networkId: network.blockchain.networkId,
-                    name: entry.name,
+                    name: name,
                     symbol: entry.symbol,
                     decimals: entry.decimalCount,
                     derivationPath: network.derivationPath,


### PR DESCRIPTION
Для синхронизации с андроидом, в запрос PUT на /v1/user-tokens/{user-wallet-id} теперь передаем coinDisplayName для блокчейнов.