### PR TITLE
IOS-8824 Try ios15 crashfix

### DIFF
--- a/Tangem/Modules/App/AppCoordinatorView.swift
+++ b/Tangem/Modules/App/AppCoordinatorView.swift
@@ -21,15 +21,11 @@ struct AppCoordinatorView: CoordinatorView {
         content
             .accentColor(Colors.Text.primary1)
             .overlayContentContainer(item: $coordinator.marketsCoordinator) { coordinator in
-                let viewHierarchySnapshotter = ViewHierarchySnapshottingContainerViewController()
-                viewHierarchySnapshotter.shouldPropagateOverriddenUserInterfaceStyleToChildren = true
-                let adapter = ViewHierarchySnapshottingWeakifyAdapter(adaptee: viewHierarchySnapshotter)
                 let marketsCoordinatorView = MarketsCoordinatorView(coordinator: coordinator)
                     .environment(\.mainWindowSize, mainWindowSize)
-                    .environment(\.viewHierarchySnapshotter, adapter)
 
                 return UIAppearanceBoundaryContainerView(
-                    boundaryMarker: { viewHierarchySnapshotter },
+                    boundaryMarker: { coordinator.viewHierarchySnapshotter },
                     content: { marketsCoordinatorView }
                 )
                 // Ensures that this is a full-screen container and keyboard avoidance is disabled to mitigate IOS-7997

--- a/Tangem/Modules/Markets/Navigation/MarketsCoordinator.swift
+++ b/Tangem/Modules/Markets/Navigation/MarketsCoordinator.swift
@@ -28,11 +28,21 @@ class MarketsCoordinator: CoordinatorObject {
 
     @Published var marketsListOrderBottomSheetViewModel: MarketsListOrderBottomSheetViewModel?
 
+    // MARK: - Helpers
+
+    let viewHierarchySnapshotter: UIViewController
+    private let viewHierarchySnapshottingAdapter: ViewHierarchySnapshotting
+
     // MARK: - Init
 
     required init(dismissAction: @escaping Action<Void>, popToRootAction: @escaping Action<PopToRootOptions>) {
         self.dismissAction = dismissAction
         self.popToRootAction = popToRootAction
+
+        let viewHierarchySnapshotter = ViewHierarchySnapshottingContainerViewController()
+        viewHierarchySnapshotter.shouldPropagateOverriddenUserInterfaceStyleToChildren = true
+        viewHierarchySnapshottingAdapter = ViewHierarchySnapshottingWeakifyAdapter(adaptee: viewHierarchySnapshotter)
+        self.viewHierarchySnapshotter = viewHierarchySnapshotter
     }
 
     // MARK: - Implementation
@@ -40,6 +50,7 @@ class MarketsCoordinator: CoordinatorObject {
     func start(with options: MarketsCoordinator.Options) {
         rootViewModel = .init(
             quotesRepositoryUpdateHelper: CommonMarketsQuotesUpdateHelper(),
+            viewHierarchySnapshotter: viewHierarchySnapshottingAdapter,
             coordinator: self
         )
     }

--- a/Tangem/Modules/Markets/TokenList/MarketsView.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsView.swift
@@ -17,7 +17,6 @@ struct MarketsView: View {
     @StateObject private var navigationControllerConfigurator = MarketsViewNavigationControllerConfigurator()
 
     @Environment(\.overlayContentContainer) private var overlayContentContainer
-    @Environment(\.viewHierarchySnapshotter) private var viewHierarchySnapshotter
     @Environment(\.mainWindowSize) private var mainWindowSize
 
     @State private var headerHeight: CGFloat = .zero
@@ -40,7 +39,6 @@ struct MarketsView: View {
     var body: some View {
         rootView
             .onAppear {
-                viewModel.setViewHierarchySnapshotter(viewHierarchySnapshotter)
                 viewModel.onViewAppear()
             }
             .onDisappear(perform: viewModel.onViewDisappear)

--- a/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
+++ b/Tangem/Modules/Markets/TokenList/MarketsViewModel.swift
@@ -56,7 +56,7 @@ final class MarketsViewModel: MarketsBaseViewModel {
 
     private lazy var listDataController: MarketsListDataController = .init(dataFetcher: self, cellsStateUpdater: self)
 
-    private var viewHierarchySnapshotter: ViewHierarchySnapshotting?
+    private let viewHierarchySnapshotter: ViewHierarchySnapshotting
     private var marketCapFormatter: MarketCapFormatter
     private var bag = Set<AnyCancellable>()
     private var currentSearchValue: String = ""
@@ -72,9 +72,11 @@ final class MarketsViewModel: MarketsBaseViewModel {
 
     init(
         quotesRepositoryUpdateHelper: MarketsQuotesUpdateHelper,
+        viewHierarchySnapshotter: ViewHierarchySnapshotting,
         coordinator: MarketsRoutable
     ) {
         self.quotesRepositoryUpdateHelper = quotesRepositoryUpdateHelper
+        self.viewHierarchySnapshotter = viewHierarchySnapshotter
         self.coordinator = coordinator
 
         marketCapFormatter = .init(
@@ -152,10 +154,6 @@ final class MarketsViewModel: MarketsBaseViewModel {
         tokenListLoadingState = .loading
         resetShowItemsBelowCapFlag()
         fetch(with: currentSearchValue, by: filterProvider.currentFilterValue)
-    }
-
-    func setViewHierarchySnapshotter(_ snapshotter: ViewHierarchySnapshotting?) {
-        viewHierarchySnapshotter = snapshotter
     }
 }
 
@@ -416,14 +414,12 @@ private extension MarketsViewModel {
     }
 
     func updateFooterSnapshot() {
-        assert(viewHierarchySnapshotter != nil, "`viewHierarchySnapshotter` is not injected from the view hierarchy")
-
-        let lightAppearanceSnapshotImage = viewHierarchySnapshotter?.makeSnapshotViewImage(
+        let lightAppearanceSnapshotImage = viewHierarchySnapshotter.makeSnapshotViewImage(
             afterScreenUpdates: true,
             isOpaque: true,
             overrideUserInterfaceStyle: .light
         )
-        let darkAppearanceSnapshotImage = viewHierarchySnapshotter?.makeSnapshotViewImage(
+        let darkAppearanceSnapshotImage = viewHierarchySnapshotter.makeSnapshotViewImage(
             afterScreenUpdates: true,
             isOpaque: true,
             overrideUserInterfaceStyle: .dark


### PR DESCRIPTION
Природа краша до конца не ясна. Падает на iOS15, при попытке сделать снэпшот состояния шторки перед переходом на деталку токена. У меня получалось иногда крашить прилу быстро тапая по токену в момент запуска приложения, но я не уверен что это именно тот краш, а в дебаге я ловил ассерт на отсутствующий снэпшоттер.

Краш исключительно на 15 оси, привнесен в 5.19, по видимому с рефакторингом логина. Поэтому смотрел на связь между снэпшотом и структурой рута. Избавился от прокидывания снэпшоттера через environment, так как помню с ним были проблемы с утечками. 
Предполагаю, что в структуре вьюконтроллеров что-то не успевает произойти, onAppear вызывается позже, во время попытки сделать снэпшот и что-то ломается. 

Фикс по сути вслепую, будем наблюдать