### PR TITLE
IOS-4541 [Crash] Update UIApplication+.swift

### DIFF
--- a/Tangem/Common/Extensions/UIKit/UIApplication+.swift
+++ b/Tangem/Common/Extensions/UIKit/UIApplication+.swift
@@ -34,7 +34,7 @@ extension UIApplication {
     static func modalFromTop(_ vc: UIViewController, animated: Bool = true, completion: (() -> Void)? = nil) {
         guard let top = topViewController else { return }
 
-        if top.isBeingDismissed {
+        if top.isBeingDismissed || top.isBeingPresented {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 modalFromTop(vc)
             }


### PR DESCRIPTION
https://tangem.atlassian.net/browse/IOS-4541

```
Application tried to present modally a view controller <SwiftUI.PlatformAlertController: 0x108aba800> that is already being presented by <_TtGC7SwiftUI29PresentationHostingControllerVS_7AnyView_: 0x10b035e00>.
```

Попытка пофиксить это проверкой что бы не было показа view controller, в то время как еще идет анимации предыдущего. Иначе хз. Именно при попытке открытия QRScan, ничего такого не происходит, так что хз вообще почему падает (