### PR TITLE
IOS-8718 [Crash] Weak capture `CommonTransactionHistoryService`

### DIFF
--- a/Tangem/App/Services/TransactionHistoryRepository/CommonTransactionHistoryService.swift
+++ b/Tangem/App/Services/TransactionHistoryRepository/CommonTransactionHistoryService.swift
@@ -88,7 +88,7 @@ private extension CommonTransactionHistoryService {
 
         cancellable = transactionHistoryProvider
             .loadTransactionHistory(request: request)
-            .handleEvents(receiveCancel: {
+            .handleEvents(receiveCancel: { [weak self] in
                 // Resolves conflicting requests for tracking history from different consumers so as not to lose output from the update process
                 AppLog.shared.debug("\(String(describing: self)) canceled")
                 result(.success(()))


### PR DESCRIPTION
В теории возможно что при `deinit` `CommonTransactionHistoryService`, идет вызов `handleEvents(receiveCancel:)` где пытаемся взять `self` который же умер, и получаем crash